### PR TITLE
feat(schema): add plugin registry index JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Schema**: Add plugin registry index JSON Schema (`schemas/plugin_registry.schema.json`)
+  - Validates registry.json files for `pulumicost plugin install` discovery
+  - Aligns with registry.proto definitions (SecurityLevel, capabilities, providers)
+  - Includes `dependentRequired` for deprecation_message when deprecated is true
+  - npm validation scripts: `validate:registry`, `validate:registry-schema`
+  - Example registry with kubecost and aws-public plugins
+  - Closes [#68](https://github.com/rshade/pulumicost-spec/issues/68)
+
 ### Changed
 
 - **Performance**: Optimized registry package enum validation for zero-allocation performance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,6 +522,7 @@ cd schemas && /init            # JSON Schema validation
 
 ## Active Technologies
 
+- JSON Schema draft 2020-12 + AJV (validation), existing `registry.proto` definitions (003-plugin-registry-schema)
 - Go 1.24.10 (toolchain go1.25.4) + Standard library only (no external dependencies for validation) (001-domain-enum-optimization)
 
 ## Recent Changes

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,49 @@
-# PricingSpec Examples
+# PulumiCost Examples
 
-This directory contains comprehensive examples of PricingSpec JSON documents
+This directory contains examples of PulumiCost specification documents including
+PricingSpec JSON documents and plugin registry index files.
+
+## Plugin Registry Index
+
+The **[registry.json](registry.json)** file demonstrates the plugin registry index
+format used by `pulumicost plugin install` to discover and install plugins.
+
+### Registry Format
+
+```json
+{
+  "schema_version": "1.0.0",
+  "plugins": {
+    "plugin-name": {
+      "name": "plugin-name",
+      "description": "Human-readable description (10-500 chars)",
+      "repository": "owner/repo",
+      "author": "Author Name",
+      "supported_providers": ["aws", "azure", "gcp", "kubernetes", "custom"],
+      "min_spec_version": "0.1.0",
+      "capabilities": ["cost_retrieval", "cost_projection"],
+      "security_level": "community",
+      "keywords": ["keyword1", "keyword2"]
+    }
+  }
+}
+```
+
+### Validation
+
+```bash
+# Validate registry against schema
+npm run validate:registry
+```
+
+For detailed contribution guidelines, see
+[specs/001-plugin-registry-schema/quickstart.md](../specs/001-plugin-registry-schema/quickstart.md).
+
+---
+
+## PricingSpec Examples
+
+This section contains comprehensive examples of PricingSpec JSON documents
 demonstrating various cloud provider pricing models and billing patterns.
 
 ## Example Categories

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1.0.0",
+  "plugins": {
+    "kubecost": {
+      "name": "kubecost",
+      "description": "Kubernetes cost analysis via Kubecost API integration",
+      "repository": "rshade/pulumicost-plugin-kubecost",
+      "author": "PulumiCost Team",
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/rshade/pulumicost-plugin-kubecost",
+      "supported_providers": ["kubernetes"],
+      "capabilities": ["cost_retrieval", "cost_projection", "real_time_data"],
+      "security_level": "official",
+      "min_spec_version": "0.1.0",
+      "keywords": ["kubernetes", "kubecost", "k8s", "container"]
+    },
+    "aws-public": {
+      "name": "aws-public",
+      "description": "AWS public pricing data from AWS Price List API",
+      "repository": "rshade/pulumicost-plugin-aws-public",
+      "author": "PulumiCost Team",
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/rshade/pulumicost-plugin-aws-public",
+      "supported_providers": ["aws"],
+      "capabilities": ["cost_projection", "pricing_specs"],
+      "security_level": "official",
+      "min_spec_version": "0.1.0",
+      "keywords": ["aws", "pricing", "ec2", "s3", "rds"]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "ajv-formats": "^3.0.1"
       },
       "devDependencies": {
+        "@commitlint/cli": "^20.1.0",
+        "@commitlint/config-conventional": "^20.0.0",
         "@types/node": "^22.5.4",
         "keep-a-changelog": "^2.5.2",
         "markdownlint-cli2": "^0.15.0",
@@ -24,6 +26,332 @@
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.1.0.tgz",
+      "integrity": "sha512-pW5ujjrOovhq5RcYv5xCpb4GkZxkO2+GtOdBW2/qrr0Ll9tl3PX0aBBobGQl3mdZUbOBgwAexEQLeH6uxL0VYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^20.0.0",
+        "@commitlint/lint": "^20.0.0",
+        "@commitlint/load": "^20.1.0",
+        "@commitlint/read": "^20.0.0",
+        "@commitlint/types": "^20.0.0",
+        "tinyexec": "^1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.0.0.tgz",
+      "integrity": "sha512-q7JroPIkDBtyOkVe9Bca0p7kAUYxZMxkrBArCfuD3yN4KjRAenP9PmYwnn7rsw8Q+hHq1QB2BRmBh0/Z19ZoJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.0.0",
+        "conventional-changelog-conventionalcommits": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.0.0.tgz",
+      "integrity": "sha512-BeyLMaRIJDdroJuYM2EGhDMGwVBMZna9UiIqV9hxj+J551Ctc6yoGuGSmghOy/qPhBSuhA6oMtbEiTmxECafsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.0.0",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.0.0.tgz",
+      "integrity": "sha512-WBV47Fffvabe68n+13HJNFBqiMH5U1Ryls4W3ieGwPC0C7kJqp3OVQQzG2GXqOALmzrgAB+7GXmyy8N9ct8/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
+      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.0.0.tgz",
+      "integrity": "sha512-zrZQXUcSDmQ4eGGrd+gFESiX0Rw+WFJk7nW4VFOmxub4mAATNKBQ4vNw5FgMCVehLUKG2OT2LjOqD0Hk8HvcRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.0.0.tgz",
+      "integrity": "sha512-ayPLicsqqGAphYIQwh9LdAYOVAQ9Oe5QCgTNTj+BfxZb9b/JW222V5taPoIBzYnAP0z9EfUtljgBk+0BN4T4Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.0.0",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.0.0.tgz",
+      "integrity": "sha512-kWrX8SfWk4+4nCexfLaQT3f3EcNjJwJBsSZ5rMBw6JCd6OzXufFHgel2Curos4LKIxwec9WSvs2YUD87rXlxNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^20.0.0",
+        "@commitlint/parse": "^20.0.0",
+        "@commitlint/rules": "^20.0.0",
+        "@commitlint/types": "^20.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.1.0.tgz",
+      "integrity": "sha512-qo9ER0XiAimATQR5QhvvzePfeDfApi/AFlC1G+YN+ZAY8/Ua6IRrDrxRvQAr+YXUKAxUsTDSp9KXeXLBPsNRWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.0.0",
+        "@commitlint/execute-rule": "^20.0.0",
+        "@commitlint/resolve-extends": "^20.1.0",
+        "@commitlint/types": "^20.0.0",
+        "chalk": "^5.3.0",
+        "cosmiconfig": "^9.0.0",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.0.0.tgz",
+      "integrity": "sha512-gLX4YmKnZqSwkmSB9OckQUrI5VyXEYiv3J5JKZRxIp8jOQsWjZgHSG/OgEfMQBK9ibdclEdAyIPYggwXoFGXjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.0.0.tgz",
+      "integrity": "sha512-j/PHCDX2bGM5xGcWObOvpOc54cXjn9g6xScXzAeOLwTsScaL4Y+qd0pFC6HBwTtrH92NvJQc+2Lx9HFkVi48cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.0.0",
+        "conventional-changelog-angular": "^7.0.0",
+        "conventional-commits-parser": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.0.0.tgz",
+      "integrity": "sha512-Ti7Y7aEgxsM1nkwA4ZIJczkTFRX/+USMjNrL9NXwWQHqNqrBX2iMi+zfuzZXqfZ327WXBjdkRaytJ+z5vNqTOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^20.0.0",
+        "@commitlint/types": "^20.0.0",
+        "git-raw-commits": "^4.0.0",
+        "minimist": "^1.2.8",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.1.0.tgz",
+      "integrity": "sha512-cxKXQrqHjZT3o+XPdqDCwOWVFQiae++uwd9dUBC7f2MdV58ons3uUvASdW7m55eat5sRiQ6xUHyMWMRm6atZWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.0.0",
+        "@commitlint/types": "^20.0.0",
+        "global-directory": "^4.0.1",
+        "import-meta-resolve": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.0.0.tgz",
+      "integrity": "sha512-gvg2k10I/RfvHn5I5sxvVZKM1fl72Sqrv2YY/BnM7lMHcYqO0E2jnRWoYguvBfEcZ39t+rbATlciggVe77E4zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^20.0.0",
+        "@commitlint/message": "^20.0.0",
+        "@commitlint/to-lines": "^20.0.0",
+        "@commitlint/types": "^20.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
+      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.0.0.tgz",
+      "integrity": "sha512-drXaPSP2EcopukrUXvUXmsQMu3Ey/FuJDc/5oiW4heoCfoE5BdLQyuc7veGeE3aoQaTVqZnh4D5WTWe2vefYKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.0.0.tgz",
+      "integrity": "sha512-bVUNBqG6aznYcYjTjnc3+Cat/iBgbgpflxbIBTnsHTX0YVpnmINPEkSRWymT2Q8aSH3Y7aKnEbunilkYe8TybA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
       }
     },
     "node_modules/@deno/shim-deno": {
@@ -93,6 +421,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/conventional-commits-parser": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
+      "integrity": "sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
@@ -233,6 +571,13 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -279,6 +624,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -311,6 +679,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -323,6 +702,109 @@
       "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+      "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-text-path": "^2.0.0",
+        "JSONStream": "^1.3.5",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.2.0.tgz",
+      "integrity": "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/dargs": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
+      "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -347,6 +829,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -365,6 +860,26 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/escalade": {
@@ -470,6 +985,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -484,6 +1017,24 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/git-raw-commits": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
+      "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dargs": "^8.0.0",
+        "meow": "^12.0.1",
+        "split2": "^4.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "cli.mjs"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/glob": {
@@ -520,6 +1071,32 @@
         "node": ">= 6"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/globby": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
@@ -551,6 +1128,44 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -577,6 +1192,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -621,6 +1243,29 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-text-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+      "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "text-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isexe": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
@@ -630,6 +1275,23 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -643,6 +1305,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-migrate": {
       "version": "2.0.0",
@@ -678,6 +1347,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      },
+      "bin": {
+        "JSONStream": "bin.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/keep-a-changelog": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/keep-a-changelog/-/keep-a-changelog-2.6.2.tgz",
@@ -691,6 +1387,13 @@
         "changelog": "esm/bin.js"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -700,6 +1403,85 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/markdown-it": {
       "version": "14.1.0",
@@ -793,6 +1575,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -863,6 +1658,80 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -884,6 +1753,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -964,6 +1840,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -1006,6 +1892,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -1017,6 +1916,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -1053,6 +1962,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-extensions": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+      "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1064,6 +2003,21 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {
@@ -1217,6 +2171,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "lint:markdown:fix": "markdownlint-cli2 --fix",
     "lint:yaml": "yamllint .github/",
     "validate:schema": "npx ajv compile --spec=draft2020 --all-errors --strict=false -s schemas/pricing_spec.schema.json",
+    "validate:registry-schema": "npx ajv compile --spec=draft2020 --all-errors --strict=false -s schemas/plugin_registry.schema.json",
     "validate:examples": "node validate_examples.js",
-    "validate": "npm run validate:schema && npm run validate:examples",
+    "validate:registry": "npx ajv validate --spec=draft2020 --all-errors --strict=false -s schemas/plugin_registry.schema.json -d examples/registry.json",
+    "validate": "npm run validate:schema && npm run validate:registry-schema && npm run validate:examples && npm run validate:registry",
     "lint:changelog": "npx keep-a-changelog lint CHANGELOG.md",
     "lint": "npm run lint:markdown && npm run lint:yaml && npm run lint:changelog",
     "test": "npm run validate && npm run lint",
@@ -56,11 +58,13 @@
     "ajv-formats": "^3.0.1"
   },
   "devDependencies": {
-    "markdownlint-cli2": "^0.15.0",
+    "@commitlint/cli": "^20.1.0",
+    "@commitlint/config-conventional": "^20.0.0",
     "@types/node": "^22.5.4",
+    "keep-a-changelog": "^2.5.2",
+    "markdownlint-cli2": "^0.15.0",
     "prettier": "^3.3.3",
-    "yaml-lint": "^1.7.0",
-    "keep-a-changelog": "^2.5.2"
+    "yaml-lint": "^1.7.0"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/schemas/plugin_registry.schema.json
+++ b/schemas/plugin_registry.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spec.pulumicost.dev/schemas/plugin_registry.schema.json",
+  "title": "PulumiCost Plugin Registry Index",
+  "description": "Schema for plugin registry index files containing metadata for discoverable plugins",
+  "type": "object",
+  "required": ["schema_version", "plugins"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Version of this registry schema format",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "examples": ["1.0.0"]
+    },
+    "plugins": {
+      "type": "object",
+      "description": "Map of plugin names to their registry entries",
+      "additionalProperties": {
+        "$ref": "#/$defs/RegistryEntry"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "RegistryEntry": {
+      "type": "object",
+      "description": "Registry entry for a single plugin",
+      "required": [
+        "name",
+        "description",
+        "repository",
+        "author",
+        "supported_providers",
+        "min_spec_version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique plugin identifier (must match registry key)",
+          "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$",
+          "minLength": 1,
+          "maxLength": 50,
+          "examples": ["kubecost", "aws-public"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the plugin",
+          "minLength": 10,
+          "maxLength": 500
+        },
+        "repository": {
+          "type": "string",
+          "description": "GitHub repository in owner/repo format",
+          "pattern": "^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$",
+          "examples": ["rshade/pulumicost-plugin-kubecost"]
+        },
+        "author": {
+          "type": "string",
+          "description": "Plugin author or organization name",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "license": {
+          "type": "string",
+          "description": "SPDX license identifier",
+          "examples": ["Apache-2.0", "MIT", "GPL-3.0-only"]
+        },
+        "homepage": {
+          "type": "string",
+          "description": "Plugin homepage URL",
+          "format": "uri"
+        },
+        "supported_providers": {
+          "type": "array",
+          "description": "Cloud providers supported by this plugin",
+          "items": {
+            "type": "string",
+            "enum": ["aws", "azure", "gcp", "kubernetes", "custom"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "capabilities": {
+          "type": "array",
+          "description": "Plugin capabilities from registry.proto",
+          "items": {
+            "type": "string",
+            "enum": [
+              "cost_retrieval",
+              "cost_projection",
+              "pricing_specs",
+              "real_time_data",
+              "historical_data",
+              "filtering",
+              "aggregation",
+              "tagging",
+              "recommendations",
+              "anomaly_detection",
+              "forecasting",
+              "budgets",
+              "alerts",
+              "custom"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "security_level": {
+          "type": "string",
+          "description": "Plugin security trust level",
+          "enum": ["untrusted", "community", "verified", "official"],
+          "default": "community"
+        },
+        "min_spec_version": {
+          "type": "string",
+          "description": "Minimum PulumiCost spec version required",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "examples": ["0.1.0"]
+        },
+        "max_spec_version": {
+          "type": "string",
+          "description": "Maximum PulumiCost spec version supported",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "keywords": {
+          "type": "array",
+          "description": "Searchable keywords",
+          "items": {
+            "type": "string",
+            "maxLength": 30
+          },
+          "maxItems": 10,
+          "uniqueItems": true
+        },
+        "deprecated": {
+          "type": "boolean",
+          "description": "Whether this plugin is deprecated",
+          "default": false
+        },
+        "deprecation_message": {
+          "type": "string",
+          "description": "Message explaining deprecation and migration path"
+        }
+      },
+      "dependentRequired": {
+        "deprecated": ["deprecation_message"]
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/specs/003-plugin-registry-schema/checklists/requirements.md
+++ b/specs/003-plugin-registry-schema/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Plugin Registry Index JSON Schema
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is complete and ready for `/speckit.clarify` or `/speckit.plan`
+- All requirements derived from GitHub Issue #68 technical specification
+- Enums verified against registry.proto definitions
+- No clarifications needed - issue provides complete technical specification

--- a/specs/003-plugin-registry-schema/data-model.md
+++ b/specs/003-plugin-registry-schema/data-model.md
@@ -1,0 +1,132 @@
+# Data Model: Plugin Registry Index
+
+**Date**: 2025-11-23
+**Feature**: 003-plugin-registry-schema
+
+## Entity Definitions
+
+### RegistryIndex (Root)
+
+Top-level container for the plugin registry index.
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| schema_version | string | Yes | Pattern: `^\d+\.\d+\.\d+$` | Version of registry schema format |
+| plugins | object | Yes | Map of RegistryEntry | Plugin name → metadata map |
+
+**Constraints**:
+
+- `additionalProperties: false` - No extra fields allowed
+- `plugins` values must conform to RegistryEntry schema
+
+### RegistryEntry
+
+Metadata for a single plugin in the registry.
+
+| Field | Type | Required | Validation | Description |
+|-------|------|----------|------------|-------------|
+| name | string | Yes | Pattern: `^[a-z0-9][a-z0-9-]*[a-z0-9]$\|^[a-z0-9]$`, 1-50 chars | Unique plugin identifier |
+| description | string | Yes | 10-500 chars | Human-readable description |
+| repository | string | Yes | Pattern: `^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$` | GitHub owner/repo |
+| author | string | Yes | 1-100 chars | Plugin author/organization |
+| supported_providers | array | Yes | Enum items, min 1, unique | Cloud providers supported |
+| min_spec_version | string | Yes | Pattern: `^\d+\.\d+\.\d+$` | Minimum spec version required |
+| license | string | No | - | SPDX license identifier |
+| homepage | string | No | URI format | Plugin homepage URL |
+| capabilities | array | No | Enum items, unique | Plugin capabilities |
+| security_level | string | No | Enum, default: "community" | Trust level |
+| max_spec_version | string | No | Pattern: `^\d+\.\d+\.\d+$` | Maximum spec version supported |
+| keywords | array | No | Max 10 items, each max 30 chars, unique | Searchable keywords |
+| deprecated | boolean | No | Default: false | Deprecation status |
+| deprecation_message | string | No | - | Migration guidance |
+
+**Constraints**:
+
+- `additionalProperties: false` - No extra fields allowed
+- `dependentRequired`: When `deprecated` is true, `deprecation_message` is required
+
+## Enumerations
+
+### supported_providers
+
+Cloud platforms the plugin supports.
+
+| Value | Description | Proto Reference |
+|-------|-------------|-----------------|
+| `aws` | Amazon Web Services | PluginSpecification.supported_providers |
+| `azure` | Microsoft Azure | PluginSpecification.supported_providers |
+| `gcp` | Google Cloud Platform | PluginSpecification.supported_providers |
+| `kubernetes` | Kubernetes clusters | PluginSpecification.supported_providers |
+| `custom` | Custom/other sources | PluginSpecification.supported_providers |
+
+### capabilities
+
+Plugin features aligned with gRPC service capabilities.
+
+| Value | Description | Proto Reference |
+|-------|-------------|-----------------|
+| `cost_retrieval` | Retrieve actual cost data | PluginInfo.capabilities |
+| `cost_projection` | Project future costs | PluginInfo.capabilities |
+| `pricing_specs` | Provide pricing specifications | PluginInfo.capabilities |
+| `real_time_data` | Real-time cost updates | PluginInfo.capabilities |
+| `historical_data` | Historical cost queries | PluginInfo.capabilities |
+| `filtering` | Filter cost data | PluginInfo.capabilities |
+| `aggregation` | Aggregate cost data | PluginInfo.capabilities |
+| `tagging` | Tag-based cost allocation | PluginInfo.capabilities |
+| `recommendations` | Cost optimization recommendations | PluginInfo.capabilities |
+| `anomaly_detection` | Detect cost anomalies | PluginInfo.capabilities |
+| `forecasting` | Cost forecasting | PluginInfo.capabilities |
+| `budgets` | Budget tracking | PluginInfo.capabilities |
+| `alerts` | Cost alerts | PluginInfo.capabilities |
+| `custom` | Custom capabilities | PluginInfo.capabilities |
+
+### security_level
+
+Plugin security trust levels.
+
+| Value | Description | Proto Reference |
+|-------|-------------|-----------------|
+| `untrusted` | Untrusted, requires explicit approval | SECURITY_LEVEL_UNTRUSTED |
+| `community` | Community verified (default) | SECURITY_LEVEL_COMMUNITY |
+| `verified` | Officially verified | SECURITY_LEVEL_VERIFIED |
+| `official` | Official PulumiCost plugin | SECURITY_LEVEL_OFFICIAL |
+
+## Relationships
+
+```text
+RegistryIndex
+    │
+    └── plugins (map)
+            │
+            └── RegistryEntry
+                    ├── supported_providers[] ──► Provider enum
+                    ├── capabilities[] ──────────► Capability enum
+                    └── security_level ─────────► SecurityLevel enum
+```
+
+## State Transitions
+
+### Plugin Lifecycle in Registry
+
+```text
+[Not Listed] ──► [Active] ──► [Deprecated] ──► [Removed]
+                    │              │
+                    └──────────────┘
+                    (can revert deprecation)
+```
+
+**State Indicators**:
+
+- **Active**: `deprecated: false` or field absent
+- **Deprecated**: `deprecated: true` with `deprecation_message`
+- **Removed**: Entry deleted from registry (not represented in schema)
+
+## Validation Rules (Consumer Responsibility)
+
+These validations cannot be enforced by JSON Schema and must be validated by consuming
+applications (e.g., pulumicost-core):
+
+1. **Name/key match**: Plugin `name` must match its key in the `plugins` map
+2. **Version ordering**: `max_spec_version` >= `min_spec_version` when both specified
+3. **Repository existence**: Repository URL resolves to valid GitHub repo
+4. **License validity**: License string is valid SPDX identifier

--- a/specs/003-plugin-registry-schema/plan.md
+++ b/specs/003-plugin-registry-schema/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Plugin Registry Index JSON Schema
+
+**Branch**: `003-plugin-registry-schema` | **Date**: 2025-11-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/003-plugin-registry-schema/spec.md`
+
+## Summary
+
+Add a JSON Schema (`schemas/plugin_registry.schema.json`) for validating plugin registry
+index files (`registry.json`). The schema defines the contract for well-known plugin
+registries used by `pulumicost plugin install`, aligning field patterns and enums with
+`registry.proto` definitions.
+
+## Technical Context
+
+**Language/Version**: JSON Schema draft 2020-12
+**Primary Dependencies**: AJV (validation), existing `registry.proto` definitions
+**Storage**: N/A (schema file in repository)
+**Testing**: npm validate scripts (AJV), example registry.json validation
+**Target Platform**: Any JSON Schema validator
+**Project Type**: single (schema + examples)
+**Performance Goals**: N/A (schema validation is inherently fast)
+**Constraints**: Must align with registry.proto enums (SecurityLevel, capabilities)
+**Scale/Scope**: Single schema file, 2 example plugins, npm validation integration
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Proto Specification-First | **PASS** | Schema aligns with existing registry.proto |
+| II. Multi-Provider Consistency | **PASS** | Examples include AWS, Kubernetes plugins |
+| III. Test-First Protocol | **PASS** | Schema validation tests before implementation |
+| IV. Protobuf Backward Compatibility | **N/A** | No proto changes (schema only) |
+| V. Comprehensive Documentation | **PASS** | Schema has descriptions, examples provided |
+| VI. Performance as gRPC Requirement | **N/A** | Not a gRPC feature |
+| VII. Validation at Multiple Levels | **PASS** | JSON Schema validates registry entries |
+
+**Gate Result**: PASS - All applicable principles satisfied
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-plugin-registry-schema/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # N/A (not an API feature)
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+schemas/
+├── plugin_registry.schema.json    # NEW: Main schema file
+├── plugin_manifest.schema.json    # Existing
+└── pricing_spec.schema.json       # Existing
+
+examples/
+├── registry.json                  # NEW: Example registry index
+├── specs/                         # Existing pricing spec examples
+└── README.md                      # Update with registry info
+
+scripts/
+└── validate_examples.js           # Update to validate registry
+```
+
+**Structure Decision**: Schema added to existing `schemas/` directory following established
+patterns. Example registry placed in `examples/` at root level (not in `specs/` subdirectory)
+since it represents the registry index format, not a pricing spec.
+
+## Complexity Tracking
+
+> No violations - schema feature follows existing patterns

--- a/specs/003-plugin-registry-schema/quickstart.md
+++ b/specs/003-plugin-registry-schema/quickstart.md
@@ -1,0 +1,155 @@
+# Quickstart: Plugin Registry Index Schema
+
+**Date**: 2025-11-23
+**Feature**: 003-plugin-registry-schema
+
+## Overview
+
+This guide shows how to create a valid plugin registry entry and validate it against the
+schema.
+
+## Creating a Registry Entry
+
+### Minimal Example
+
+```json
+{
+  "schema_version": "1.0.0",
+  "plugins": {
+    "my-plugin": {
+      "name": "my-plugin",
+      "description": "A cost data plugin for my custom cost source",
+      "repository": "myorg/pulumicost-plugin-custom",
+      "author": "My Organization",
+      "supported_providers": ["custom"],
+      "min_spec_version": "0.1.0"
+    }
+  }
+}
+```
+
+### Full Example
+
+```json
+{
+  "schema_version": "1.0.0",
+  "plugins": {
+    "kubecost": {
+      "name": "kubecost",
+      "description": "Kubernetes cost analysis via Kubecost API integration",
+      "repository": "rshade/pulumicost-plugin-kubecost",
+      "author": "PulumiCost Team",
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/rshade/pulumicost-plugin-kubecost",
+      "supported_providers": ["kubernetes"],
+      "capabilities": ["cost_retrieval", "cost_projection", "real_time_data"],
+      "security_level": "official",
+      "min_spec_version": "0.1.0",
+      "keywords": ["kubernetes", "kubecost", "k8s", "container"]
+    }
+  }
+}
+```
+
+## Field Requirements
+
+### Required Fields
+
+| Field | Format | Example |
+|-------|--------|---------|
+| name | Lowercase alphanumeric with hyphens | `my-plugin` |
+| description | 10-500 characters | `A cost data plugin...` |
+| repository | owner/repo format | `myorg/my-plugin` |
+| author | 1-100 characters | `My Organization` |
+| supported_providers | Array of valid providers | `["aws", "azure"]` |
+| min_spec_version | Semantic version | `0.1.0` |
+
+### Optional Fields
+
+| Field | Format | Default | Example |
+|-------|--------|---------|---------|
+| license | SPDX identifier | - | `Apache-2.0` |
+| homepage | Valid URI | - | `https://example.com` |
+| capabilities | Array of valid capabilities | - | `["cost_retrieval"]` |
+| security_level | Valid level | `community` | `verified` |
+| max_spec_version | Semantic version | - | `1.0.0` |
+| keywords | Array (max 10, each max 30 chars) | - | `["aws", "ec2"]` |
+| deprecated | Boolean | `false` | `true` |
+| deprecation_message | String (required if deprecated) | - | `Use aws-v2 instead` |
+
+## Validation
+
+### Using npm Scripts
+
+```bash
+# Validate registry against schema
+npm run validate:registry
+
+# Validate all examples (including registry)
+npm run validate
+```
+
+### Using AJV Directly
+
+```bash
+npx ajv validate -s schemas/plugin_registry.schema.json \
+  -d examples/registry.json --strict=false
+```
+
+### Common Validation Errors
+
+**Missing required field**:
+
+```text
+Error: must have required property 'min_spec_version'
+```
+
+**Invalid name pattern**:
+
+```text
+Error: must match pattern "^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$"
+```
+
+**Description too short**:
+
+```text
+Error: must NOT have fewer than 10 characters
+```
+
+**Invalid provider**:
+
+```text
+Error: must be equal to one of the allowed values
+Allowed: aws, azure, gcp, kubernetes, custom
+```
+
+**Deprecated without message**:
+
+```text
+Error: must have required property 'deprecation_message'
+```
+
+## Adding Your Plugin to the Registry
+
+1. **Create your entry**: Follow the format above with all required fields
+2. **Validate locally**: Run `npm run validate:registry`
+3. **Submit PR**: Add your entry to `examples/registry.json`
+4. **Ensure name matches key**: The plugin `name` field must match its key in `plugins`
+
+## Consumer Validation
+
+The schema validates structure and patterns. Consuming applications (pulumicost-core)
+additionally validate:
+
+- Plugin name matches registry key
+- Version ordering (`max_spec_version >= min_spec_version`)
+- Repository URL is accessible
+
+## Version Compatibility
+
+- **schema_version**: Format version of the registry file
+- **min_spec_version**: Minimum PulumiCost spec version required by plugin
+- **max_spec_version**: Maximum PulumiCost spec version supported (optional)
+
+When installing a plugin, pulumicost-core checks that the current spec version falls
+within the plugin's supported range.

--- a/specs/003-plugin-registry-schema/research.md
+++ b/specs/003-plugin-registry-schema/research.md
@@ -1,0 +1,115 @@
+# Research: Plugin Registry Index JSON Schema
+
+**Date**: 2025-11-23
+**Feature**: 003-plugin-registry-schema
+
+## Research Topics
+
+### 1. JSON Schema draft 2020-12 Features for Conditional Validation
+
+**Decision**: Use `dependentRequired` for deprecation_message requirement
+
+**Rationale**: JSON Schema draft 2020-12 provides `dependentRequired` as the cleaner syntax
+for conditional field requirements (when field A exists, field B is required). This is
+simpler than `if/then/else` for this use case.
+
+**Alternatives considered**:
+
+- `if/then/else` construct - More verbose, harder to read for simple conditional
+- Custom validation in consumer - Defeats purpose of schema validation
+
+**Implementation**:
+
+```json
+"dependentRequired": {
+  "deprecated": ["deprecation_message"]
+}
+```
+
+### 2. Alignment with registry.proto Enums
+
+**Decision**: Map proto enum values to JSON Schema string enums
+
+**Rationale**: The registry.proto defines several enums that must be represented in the
+JSON Schema. Proto enum values are SCREAMING_SNAKE_CASE but JSON convention is snake_case.
+
+**Mappings**:
+
+| Proto Enum | Proto Values | JSON Schema Values |
+|------------|--------------|-------------------|
+| SecurityLevel | SECURITY_LEVEL_UNTRUSTED, etc. | `untrusted`, `community`, `verified`, `official` |
+| Capabilities | (string array in proto) | `cost_retrieval`, `cost_projection`, etc. |
+
+**Note**: PluginInfo.capabilities is already `repeated string` in proto, so the schema
+uses lowercase snake_case values matching the proto field values.
+
+### 3. Plugin Name Pattern Validation
+
+**Decision**: Use regex pattern `^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$`
+
+**Rationale**: Plugin names must be:
+
+- Lowercase alphanumeric with hyphens
+- Cannot start or end with hyphen
+- Single character names allowed
+
+**Alternatives considered**:
+
+- Simpler `^[a-z0-9-]+$` - Would allow leading/trailing hyphens
+- Require minimum 2 characters - Too restrictive for short names like `k8s`
+
+### 4. Repository Format Validation
+
+**Decision**: Use pattern `^[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+$`
+
+**Rationale**: GitHub repository format is `owner/repo` where both can contain alphanumeric,
+hyphens, underscores, and repo can also contain dots.
+
+**Examples**:
+
+- `rshade/pulumicost-plugin-kubecost` - Valid
+- `my-org/my.repo.name` - Valid
+- `invalid` - Invalid (no slash)
+
+### 5. NPM Validation Script Integration
+
+**Decision**: Add new `validate:registry` npm script
+
+**Rationale**: Existing validation uses `validate_examples.js` with AJV. Registry validation
+follows the same pattern but validates `examples/registry.json` against the registry schema.
+
+**Implementation approach**:
+
+1. Add `validate:registry` script to package.json
+2. Update `validate` script to include registry validation
+3. Follow existing pattern of using `--strict=false` for AJV
+
+### 6. Semantic Version Pattern
+
+**Decision**: Use pattern `^\d+\.\d+\.\d+$`
+
+**Rationale**: Standard semver format without pre-release or build metadata. Keeps pattern
+simple while covering all version fields (schema_version, min_spec_version, max_spec_version).
+
+**Note**: Pre-release versions (e.g., `1.0.0-alpha`) not supported in initial version.
+Can be added later if needed.
+
+## Best Practices Applied
+
+### JSON Schema Best Practices
+
+1. **Use `$defs` for reusable components**: RegistryEntry defined once, referenced in
+   additionalProperties
+2. **Provide examples**: Each field with pattern validation includes examples array
+3. **Set `additionalProperties: false`**: Prevents schema drift and catches typos
+4. **Include descriptions**: All properties have clear descriptions
+
+### Validation Integration Best Practices
+
+1. **CI integration**: Validation runs in existing `make validate` pipeline
+2. **Example-driven testing**: Example registry.json serves as both documentation and test
+3. **Schema versioning**: `schema_version` field allows future schema evolution
+
+## Unresolved Items
+
+None - all technical decisions resolved through research.

--- a/specs/003-plugin-registry-schema/spec.md
+++ b/specs/003-plugin-registry-schema/spec.md
@@ -1,0 +1,207 @@
+# Feature Specification: Plugin Registry Index JSON Schema
+
+**Feature Branch**: `003-plugin-registry-schema`
+**Created**: 2025-11-23
+**Status**: Draft
+**Input**: GitHub Issue #68 - Add plugin registry index JSON Schema
+
+## Clarifications
+
+### Session 2025-11-23
+
+- Q: Should the schema enforce that the plugin `name` field matches its registry key?
+  → A: Schema does NOT enforce match; documented as invalid for consumer validation
+  (pulumicost-core test file)
+- Q: Should a deprecated plugin without a `deprecation_message` be allowed?
+  → A: No, require `deprecation_message` when `deprecated: true` (no existing entries)
+- Q: Should schema validate that `max_spec_version` >= `min_spec_version`?
+  → A: No, document as invalid for consumer validation (JSON Schema limitation)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Validate Registry Index File (Priority: P1)
+
+A registry contributor creates or modifies a registry index file (`registry.json`) and needs
+to validate that it conforms to the schema before submitting changes.
+
+**Why this priority**: This is the core purpose of the schema - enabling validation of
+registry entries to ensure consistency and correctness across the ecosystem.
+
+**Independent Test**: Can be fully tested by validating example registry.json files against
+the schema and verifying that valid entries pass and invalid entries fail with clear error
+messages.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registry.json with all required fields populated correctly,
+   **When** validated against the schema,
+   **Then** validation passes with no errors
+2. **Given** a registry.json with a missing required field (e.g., `min_spec_version`),
+   **When** validated against the schema,
+   **Then** validation fails with a clear error message indicating the missing field
+3. **Given** a registry.json with an invalid field value (e.g., invalid semver pattern),
+   **When** validated against the schema,
+   **Then** validation fails with a clear error message indicating the invalid value
+
+---
+
+### User Story 2 - Discover Plugin Metadata (Priority: P1)
+
+A PulumiCost user runs `pulumicost plugin install kubecost` and the CLI fetches the registry
+index to locate the plugin's repository, supported providers, and minimum spec version.
+
+**Why this priority**: This represents the primary consumer use case that drives the need
+for a formal schema - the plugin installation system in pulumicost-core.
+
+**Independent Test**: Can be tested by verifying that the schema captures all metadata
+fields required by the plugin installation system to discover and install plugins.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registry index with multiple plugins,
+   **When** the user searches for a plugin by name,
+   **Then** the system can retrieve the plugin's repository, description, and supported
+   providers
+2. **Given** a registry entry with `security_level: "official"`,
+   **When** the user views plugin details,
+   **Then** the trust level is clearly communicated
+3. **Given** a plugin with `deprecated: true`,
+   **When** listed in search results,
+   **Then** the deprecation status and migration message are visible
+
+---
+
+### User Story 3 - Contribute Plugin to Registry (Priority: P2)
+
+A third-party plugin developer wants to add their plugin to the official registry and needs
+clear guidance on required fields and format.
+
+**Why this priority**: Enables ecosystem growth by providing a clear specification for
+plugin contributions.
+
+**Independent Test**: Can be tested by providing an example registry entry and validating
+that it can be created from scratch following only the schema documentation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new plugin with valid metadata,
+   **When** the developer creates a registry entry following the schema,
+   **Then** the entry validates successfully
+2. **Given** a plugin name with invalid characters (e.g., uppercase, special chars),
+   **When** validated,
+   **Then** validation fails with pattern error explaining naming requirements
+3. **Given** a description shorter than 10 characters,
+   **When** validated,
+   **Then** validation fails indicating minimum length requirement
+
+---
+
+### User Story 4 - Filter Plugins by Capability (Priority: P3)
+
+A user wants to find plugins that support specific capabilities (e.g., `cost_projection`,
+`real_time_data`) or providers (e.g., `aws`, `kubernetes`).
+
+**Why this priority**: Enhances discoverability but depends on basic search working first.
+
+**Independent Test**: Can be tested by creating registry entries with various capabilities
+and providers and verifying filtering operations work correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** registry entries with various `supported_providers`,
+   **When** filtering by provider,
+   **Then** only matching plugins are returned
+2. **Given** registry entries with various `capabilities`,
+   **When** filtering by capability,
+   **Then** only plugins with that capability are returned
+3. **Given** registry entries with `keywords`,
+   **When** searching by keyword,
+   **Then** matching plugins are discoverable
+
+---
+
+### Edge Cases
+
+- **Name/key mismatch**: When a plugin `name` doesn't match its registry key, the schema
+  does not enforce this constraint (JSON Schema limitation). Consuming applications
+  (e.g., pulumicost-core) MUST validate this match and reject mismatched entries.
+- **Deprecated without message**: Schema requires `deprecation_message` when `deprecated`
+  is `true`; validation fails if message is missing.
+- **Version constraint violation**: When `max_spec_version` < `min_spec_version`, the
+  schema does not enforce this (JSON Schema limitation). Consuming applications MUST
+  validate version ordering and reject invalid entries.
+- **Multiple providers display**: How plugins with multiple `supported_providers` are
+  displayed is a consumer UX concern (CLI formatting); schema validates array correctness.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Schema MUST validate registry index files containing plugin metadata
+- **FR-002**: Schema MUST require `schema_version` and `plugins` at the root level
+- **FR-003**: Schema MUST require `name`, `description`, `repository`, `author`,
+  `supported_providers`, and `min_spec_version` for each registry entry
+- **FR-004**: Schema MUST validate plugin name pattern as lowercase alphanumeric with
+  hyphens (pattern: `^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$`)
+- **FR-005**: Schema MUST validate repository format as `owner/repo` pattern
+- **FR-006**: Schema MUST validate version strings as semantic versioning format
+  (`^\d+\.\d+\.\d+$`)
+- **FR-007**: Schema MUST restrict `supported_providers` to enum values: `aws`, `azure`,
+  `gcp`, `kubernetes`, `custom`
+- **FR-008**: Schema MUST restrict `capabilities` to enum values matching registry.proto:
+  `cost_retrieval`, `cost_projection`, `pricing_specs`, `real_time_data`, `historical_data`,
+  `filtering`, `aggregation`, `tagging`, `recommendations`, `anomaly_detection`,
+  `forecasting`, `budgets`, `alerts`, `custom`
+- **FR-009**: Schema MUST restrict `security_level` to enum values matching registry.proto:
+  `untrusted`, `community`, `verified`, `official`
+- **FR-010**: Schema MUST validate description length between 10 and 500 characters
+- **FR-011**: Schema MUST validate keywords array with max 10 items, each max 30 characters
+- **FR-012**: Schema MUST support optional fields: `license`, `homepage`,
+  `max_spec_version`, `keywords`, `deprecated`, `deprecation_message`
+- **FR-013**: Schema MUST disallow additional properties to prevent schema drift
+- **FR-014**: Schema MUST require `deprecation_message` when `deprecated` is `true`
+  (using `dependentRequired` or `if/then`)
+
+### Key Entities
+
+- **RegistryIndex**: Top-level container with `schema_version` and `plugins` map
+- **RegistryEntry**: Individual plugin metadata including name, description, repository,
+  author, providers, capabilities, security level, and version requirements
+- **Supported Providers**: Enumerated cloud platforms the plugin supports
+- **Capabilities**: Plugin features aligned with gRPC service capabilities
+- **Security Level**: Trust tier indicating verification status
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Valid registry entries pass schema validation with no errors
+- **SC-002**: Invalid registry entries fail validation with clear, actionable error
+  messages identifying the specific field and issue
+- **SC-003**: Schema field patterns and enums match existing registry.proto definitions
+  exactly
+- **SC-004**: Example registry file demonstrates all supported field types and validates
+  successfully
+- **SC-005**: Validation can be performed using standard JSON Schema tools (AJV, etc.)
+  without custom code
+
+## Assumptions
+
+- The registry index is consumed by pulumicost-core's plugin installation system
+  (rshade/pulumicost-core#163)
+- Plugin names must be unique within the registry
+- The schema follows JSON Schema draft 2020-12 specification
+- Third-party registries will use this same schema for compatibility
+- The `capabilities` enum aligns with PluginInfo.capabilities string values in
+  registry.proto
+- SPDX license identifiers are used but not validated by the schema (validation would
+  require external reference)
+- Homepage URLs use URI format validation
+
+## Out of Scope
+
+- Version constraint syntax documentation (separate documentation file)
+- Go SDK validation helpers for the registry schema
+- Automated registry submission workflow
+- Plugin signature verification logic
+- Registry synchronization between instances

--- a/specs/003-plugin-registry-schema/tasks.md
+++ b/specs/003-plugin-registry-schema/tasks.md
@@ -1,0 +1,256 @@
+# Tasks: Plugin Registry Index JSON Schema
+
+**Input**: Design documents from `/specs/003-plugin-registry-schema/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Test tasks included (schema validation is test-driven by nature).
+
+**Organization**: Tasks grouped by user story to enable independent implementation and
+testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Schema files**: `schemas/` at repository root
+- **Examples**: `examples/` at repository root
+- **Scripts**: `scripts/` at repository root (npm validation)
+- **Documentation**: Repository root (README.md, package.json)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and verification of existing infrastructure
+
+- [x] T001 Verify existing schema validation infrastructure in package.json
+- [x] T002 [P] Review existing schemas for pattern consistency in schemas/
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core schema file that all user stories depend on
+
+**⚠️ CRITICAL**: No user story work can begin until the schema is created
+
+- [x] T003 Create plugin_registry.schema.json in schemas/plugin_registry.schema.json
+  - Include `$schema`, `$id`, `title`, `description`
+  - Define root properties: `schema_version`, `plugins`
+  - Define `$defs/RegistryEntry` with all required fields
+  - Add all enums: `supported_providers`, `capabilities`, `security_level`
+  - Add `dependentRequired` for deprecated/deprecation_message
+  - Set `additionalProperties: false` at all levels
+
+**Checkpoint**: Schema created - validation tests can now be written
+
+---
+
+## Phase 3: User Story 1 - Validate Registry Index File (Priority: P1) 🎯 MVP
+
+**Goal**: Enable registry contributors to validate registry.json files against the schema
+
+**Independent Test**: Run `npm run validate:registry` against example file and verify
+valid entries pass, invalid entries fail with clear errors
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before full implementation**
+
+- [x] T004 [US1] Create valid example registry in examples/registry.json
+  - Include 2 plugins: kubecost (kubernetes) and aws-public (aws)
+  - All required fields populated correctly
+  - Optional fields demonstrated (license, homepage, capabilities, keywords)
+
+- [x] T005 [US1] Add validate:registry npm script in package.json
+  - Use AJV with `--strict=false` flag
+  - Validate examples/registry.json against schemas/plugin_registry.schema.json
+
+- [x] T006 [US1] Update validate npm script to include registry validation
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Verify schema validates example correctly by running npm run validate:registry
+- [x] T008 [US1] Test invalid cases manually:
+  - Missing required field (remove min_spec_version)
+  - Invalid name pattern (uppercase letters)
+  - Invalid provider enum (invalid value)
+  - Deprecated without deprecation_message
+
+**Checkpoint**: User Story 1 complete - registry validation works
+
+---
+
+## Phase 4: User Story 2 - Discover Plugin Metadata (Priority: P1)
+
+**Goal**: Schema captures all metadata fields required by plugin installation system
+
+**Independent Test**: Verify schema includes all fields from registry.proto PluginInfo,
+PluginMetadata, and PluginRequirements messages
+
+### Tests for User Story 2
+
+- [x] T009 [US2] Verify proto alignment by comparing schema fields to registry.proto
+  - PluginInfo: name, description, author, capabilities, security_level
+  - PluginRequirements: min_spec_version, max_spec_version
+  - PluginMetadata: homepage, repository, license, keywords
+
+### Implementation for User Story 2
+
+- [x] T010 [US2] Document proto alignment in schema field descriptions
+- [x] T011 [US2] Add examples array to schema fields that have specific formats
+  - repository: `"rshade/pulumicost-plugin-kubecost"`
+  - schema_version: `"1.0.0"`
+  - min_spec_version: `"0.1.0"`
+
+**Checkpoint**: User Story 2 complete - schema aligned with proto
+
+---
+
+## Phase 5: User Story 3 - Contribute Plugin to Registry (Priority: P2)
+
+**Goal**: Clear guidance for third-party plugin developers on registry contribution
+
+**Independent Test**: New developer can create valid registry entry using only schema
+documentation and quickstart guide
+
+### Implementation for User Story 3
+
+- [x] T012 [US3] Verify schema properties have clear descriptions in schemas/plugin_registry.schema.json
+  - All 15+ properties should have description field
+  - Descriptions explain purpose, not just type
+  - Pattern fields include format guidance
+- [x] T013 [US3] Update examples/README.md with registry.json documentation
+  - Explain registry format
+  - Link to quickstart.md for contribution guide
+  - Document validation commands
+
+**Checkpoint**: User Story 3 complete - contribution guidance available
+
+---
+
+## Phase 6: User Story 4 - Filter Plugins by Capability (Priority: P3)
+
+**Goal**: Schema supports discoverability through capabilities, providers, and keywords
+
+**Independent Test**: Schema validates arrays correctly, enforces uniqueItems
+
+### Implementation for User Story 4
+
+- [x] T014 [US4] Verify schema enum arrays support filtering use case
+  - supported_providers: minItems 1, uniqueItems
+  - capabilities: uniqueItems
+  - keywords: maxItems 10, uniqueItems
+
+- [x] T015 [US4] Verify example plugins demonstrate filtering diversity in examples/registry.json
+  - kubecost: kubernetes provider, cost_retrieval/cost_projection/real_time_data
+  - aws-public: aws provider, cost_projection/pricing_specs
+  - Different capabilities enable filtering use case demonstration
+
+**Checkpoint**: User Story 4 complete - filterability supported
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and final validation
+
+- [x] T016 [P] Run markdownlint on all new/modified markdown files
+- [x] T017 [P] Run full validation suite: `make validate`
+- [x] T018 Update CHANGELOG.md with new schema addition
+- [x] T019 Run quickstart.md validation examples to verify documentation accuracy
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - verify infrastructure
+- **Foundational (Phase 2)**: Depends on Setup - creates core schema
+- **User Stories (Phase 3+)**: All depend on Foundational phase completion
+  - US1 and US2 are both P1 but US1 must complete first (validation needed)
+  - US3 and US4 can proceed after foundational
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends only on Foundational - core validation
+- **User Story 2 (P1)**: Depends only on Foundational - proto alignment verification
+- **User Story 3 (P2)**: Depends only on Foundational - documentation
+- **User Story 4 (P3)**: Depends only on Foundational - enum array validation
+
+All user stories are independently testable after Foundational phase.
+
+### Within Each User Story
+
+- Tests/verification before implementation
+- Schema updates before documentation
+- Validation before moving to next story
+
+### Parallel Opportunities
+
+- T001, T002 can run in parallel (Setup phase)
+- T004, T005, T006 can run in parallel (US1 tests)
+- T009 can run in parallel with T010, T011 (US2)
+- T016, T017 can run in parallel (Polish phase)
+- Different user stories can be worked on in parallel by different team members
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all setup tasks together:
+Task: "Create valid example registry in examples/registry.json"
+Task: "Add validate:registry npm script in package.json"
+Task: "Update validate npm script to include registry validation"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (verify infrastructure)
+2. Complete Phase 2: Foundational (create schema)
+3. Complete Phase 3: User Story 1 (validation works)
+4. **STOP and VALIDATE**: Run `npm run validate:registry`
+5. Deploy/merge if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Schema exists
+2. Add User Story 1 → Validation works → MVP!
+3. Add User Story 2 → Proto alignment documented
+4. Add User Story 3 → Contribution docs complete
+5. Add User Story 4 → Filtering support verified
+6. Each story adds value without breaking previous stories
+
+### Single Developer Strategy
+
+Recommended execution order:
+
+1. T001 → T002 (Setup)
+2. T003 (Foundational - main schema)
+3. T004 → T005 → T006 → T007 → T008 (User Story 1)
+4. T009 → T010 → T011 (User Story 2)
+5. T012 → T013 (User Story 3)
+6. T014 → T015 (User Story 4)
+7. T016 → T017 → T018 → T019 (Polish)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- This feature has 19 total tasks across 7 phases


### PR DESCRIPTION
Add JSON Schema for validating plugin registry index files used by `pulumicost plugin install` to discover and install plugins.

## Summary

- Add `schemas/plugin_registry.schema.json` with JSON Schema draft 2020-12
- Align with registry.proto definitions (SecurityLevel, capabilities, providers)
- Include `dependentRequired` for deprecation_message when deprecated is true
- Add npm validation scripts: `validate:registry`, `validate:registry-schema`
- Create example registry with kubecost and aws-public plugins
- Update examples/README.md with registry documentation

## Test plan

- [x] Run `npm run validate:registry` - validates example registry
- [x] Run `npm run validate:registry-schema` - compiles schema
- [x] Run `make validate` - full validation suite passes
- [x] Test invalid cases: missing required fields, invalid patterns, deprecated without message
- [x] Verify quickstart.md examples validate correctly

Closes #68