### PR TITLE
ci(workflow): add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request introduces a minor update to the GitHub Actions workflow configuration, allowing the release workflow to be triggered manually in addition to running on pushes to the `main` branch.

- Added support for manual workflow runs using `workflow_dispatch` in `.github/workflows/release-please.yml`.