### PR TITLE
chore: fixing release-please issue with releases failing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@pulumicost/spec",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,6 +29,11 @@
           "type": "json",
           "path": "package-lock.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "package-lock.json",
+          "jsonpath": "$.packages[''].version"
         }
       ]
     }


### PR DESCRIPTION
This pull request updates the release configuration to ensure that version numbers are correctly updated in all relevant fields within the `package-lock.json` file.

Release automation improvements:

* Added a new configuration entry to update the `$.packages[''].version` field in `package-lock.json` during the release process, ensuring all version references are kept in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to improve version extraction processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->