### PR TITLE
feat(testing): add structured logging example for EstimateCost RPC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,6 +522,9 @@ cd schemas && /init            # JSON Schema validation
 
 ## Active Technologies
 
+- Go 1.24+ (toolchain go1.25.4) + zerolog v1.34.0+, google.golang.org/grpc, sdk/go/testing harness (007-zerolog-logging-example)
+- N/A (example code, no data persistence) (007-zerolog-logging-example)
+
 - Go 1.24+ (matches existing SDK, toolchain go1.25.4), Protocol Buffers v3 (006-estimate-cost)
 - N/A (specification repository - no runtime storage) (006-estimate-cost)
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "go",
       "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "draft": false,
       "prerelease": false,

--- a/sdk/go/testing/CLAUDE.md
+++ b/sdk/go/testing/CLAUDE.md
@@ -63,6 +63,47 @@ testing for CostSource plugins.
 - `TestConcurrentRequests` - Thread safety and race condition testing
 - `TestResponseTimeouts` - Configurable delay and timeout behavior
 - `TestDataConsistency` - Idempotent response validation
+- `TestStructuredLoggingExample` - Canonical reference for zerolog logging patterns
+
+### Structured Logging Example (`TestStructuredLoggingExample`)
+
+**Educational Reference for Plugin Developers**:
+
+This test serves as the canonical reference for implementing structured logging with zerolog in PulumiCost plugins.
+It demonstrates NFR-001 compliance patterns from spec 006-estimate-cost.
+
+**Subtests**:
+
+- `RequestLogging` - Demonstrates logging incoming requests with resource context
+- `SuccessResponseLogging` - Demonstrates logging successful responses with cost details
+- `ErrorLogging` - Demonstrates error logging with error codes and original context
+- `CorrelationIDPropagation` - Demonstrates trace_id propagation across log entries
+- `LogStructureValidation` - Verifies JSON parseable output with standard field names
+
+**Key Patterns Demonstrated**:
+
+- Creating configured loggers with `pluginsdk.NewPluginLogger()`
+- Using standard field constants (FieldTraceID, FieldOperation, FieldResourceType, etc.)
+- Correlation ID propagation with `ContextWithTraceID` and `TraceIDFromContext`
+- Operation timing measurement with `LogOperation` helper
+- Sensitive data protection (log attribute count, never values)
+
+**Helper Functions**:
+
+- `parseMultipleLogEntries(t, logOutput)` - Parse newline-delimited JSON log entries
+- `assertLogContains(t, logOutput, expected, errMsg)` - Verify field presence
+- `assertLogNotContains(t, logOutput, unexpected, errMsg)` - Verify sensitive data exclusion
+
+**Running the Example**:
+
+```bash
+# Run all logging example subtests
+go test -v -run TestStructuredLoggingExample
+
+# Run specific subtest
+go test -v -run TestStructuredLoggingExample/RequestLogging
+go test -v -run TestStructuredLoggingExample/ErrorLogging
+```
 
 ### Conformance Testing (`conformance_test.go`)
 

--- a/specs/007-zerolog-logging-example/checklists/requirements.md
+++ b/specs/007-zerolog-logging-example/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Structured Logging Example for EstimateCost
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- Feature depends on 005-zerolog and 006-estimate-cost specs being implemented

--- a/specs/007-zerolog-logging-example/data-model.md
+++ b/specs/007-zerolog-logging-example/data-model.md
@@ -1,0 +1,128 @@
+# Data Model: Structured Logging Example for EstimateCost
+
+**Feature**: 007-zerolog-logging-example
+**Date**: 2025-11-26
+
+## Overview
+
+This feature is a documentation/example feature. The data model consists of:
+
+1. **Existing entities** from dependencies (used, not created)
+2. **Log entry structure** (output format, not persisted data)
+
+## Existing Entities (Dependencies)
+
+### From 005-zerolog
+
+| Entity | Purpose | Key Fields |
+|--------|---------|------------|
+| `Logger` | Configured zerolog instance | plugin_name, plugin_version, level |
+| `TraceID` | Correlation identifier | string value from context |
+
+### From 006-estimate-cost
+
+| Entity | Purpose | Key Fields |
+|--------|---------|------------|
+| `EstimateCostRequest` | RPC input | resource_type (string), attributes (Struct) |
+| `EstimateCostResponse` | RPC output | currency (string), cost_monthly (double) |
+
+### From sdk/go/testing
+
+| Entity | Purpose | Key Fields |
+|--------|---------|------------|
+| `MockPlugin` | Test plugin implementation | ShouldErrorOnEstimateCost, EstimateCostDelay |
+| `TestHarness` | In-memory gRPC harness | client, server |
+
+## Log Entry Structure
+
+The example demonstrates structured JSON log entries with these field patterns:
+
+### Request Log Entry
+
+```json
+{
+  "level": "info",
+  "time": "2025-11-26T10:30:00Z",
+  "trace_id": "abc123",
+  "operation": "EstimateCost",
+  "resource_type": "aws:ec2/instance:Instance",
+  "attribute_count": 3,
+  "message": "Processing cost estimation request"
+}
+```
+
+### Success Response Log Entry
+
+```json
+{
+  "level": "info",
+  "time": "2025-11-26T10:30:00Z",
+  "trace_id": "abc123",
+  "operation": "EstimateCost",
+  "resource_type": "aws:ec2/instance:Instance",
+  "cost_monthly": 8.76,
+  "currency": "USD",
+  "duration_ms": 45,
+  "message": "Cost estimation completed"
+}
+```
+
+### Error Log Entry
+
+```json
+{
+  "level": "error",
+  "time": "2025-11-26T10:30:00Z",
+  "trace_id": "abc123",
+  "operation": "EstimateCost",
+  "resource_type": "invalid:resource",
+  "error_code": "INVALID_ARGUMENT",
+  "error": "Invalid resource_type format",
+  "duration_ms": 12,
+  "message": "Cost estimation failed"
+}
+```
+
+## Field Constants Mapping
+
+| Constant | JSON Field | Type | Description |
+|----------|------------|------|-------------|
+| `FieldTraceID` | `trace_id` | string | Correlation ID for distributed tracing |
+| `FieldOperation` | `operation` | string | RPC method name ("EstimateCost") |
+| `FieldResourceType` | `resource_type` | string | Pulumi resource type |
+| `FieldCostMonthly` | `cost_monthly` | float64 | Estimated monthly cost |
+| `FieldDurationMs` | `duration_ms` | int64 | Operation duration in milliseconds |
+| `FieldErrorCode` | `error_code` | string | gRPC/custom error code |
+| `FieldPluginName` | `plugin_name` | string | Plugin identifier |
+| `FieldPluginVersion` | `plugin_version` | string | Plugin version |
+
+## Relationships
+
+```text
+TestHarness (1) ----> (1) MockPlugin
+     |
+     v
+CostSourceServiceClient ----> EstimateCost RPC
+     |
+     v
+Logger ----> Log Entries (request, response, error)
+     |
+     +----> TraceID (from context)
+```
+
+## State Transitions
+
+Not applicable - this is a stateless example demonstrating logging patterns.
+
+## Validation Rules
+
+| Field | Rule | Enforced By |
+|-------|------|-------------|
+| trace_id | May be empty (graceful degradation) | Application logic |
+| resource_type | Must be non-empty for logging | Proto validation |
+| cost_monthly | Must be non-negative | Proto field semantics |
+| duration_ms | Auto-calculated by LogOperation | LogOperation helper |
+
+## Data Volume Considerations
+
+Not applicable - example produces minimal log output for demonstration purposes only.

--- a/specs/007-zerolog-logging-example/plan.md
+++ b/specs/007-zerolog-logging-example/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Structured Logging Example for EstimateCost
+
+**Branch**: `007-zerolog-logging-example` | **Date**: 2025-11-26 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/007-zerolog-logging-example/spec.md`
+
+## Summary
+
+Add a structured logging example in `sdk/go/testing/integration_test.go` demonstrating zerolog
+integration for the EstimateCost RPC. The example will serve as the canonical reference for
+NFR-001 compliance, showing request/response/error logging patterns with correlation ID
+propagation and timing measurement.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (toolchain go1.25.4)
+**Primary Dependencies**: zerolog v1.34.0+, google.golang.org/grpc, sdk/go/testing harness
+**Storage**: N/A (example code, no data persistence)
+**Testing**: go test (integration test function added to existing file)
+**Target Platform**: Linux/macOS/Windows (cross-platform Go SDK)
+**Project Type**: Single (SDK addition to existing test file)
+**Performance Goals**: N/A (documentation example, not performance-critical)
+**Constraints**: Must follow existing integration_test.go patterns; must use 005-zerolog utilities
+**Scale/Scope**: Single test function with comprehensive logging examples
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. gRPC Proto Specification-First | PASS | No proto changes required; uses existing EstimateCost RPC |
+| II. Multi-Provider gRPC Consistency | PASS | Example uses mock plugin supporting all providers |
+| III. Test-First Protocol | PASS | Example IS a test function demonstrating logging |
+| IV. Protobuf Backward Compatibility | PASS | No proto changes; documentation only |
+| V. Comprehensive Documentation | PASS | Example serves as documentation with code comments |
+| VI. Performance as gRPC Requirement | PASS | Not applicable; documentation example |
+| VII. Validation at Multiple Levels | PASS | Example validates logging output structure |
+
+**Gate Status**: ALL PASS - No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-zerolog-logging-example/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (minimal for this feature)
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+sdk/go/
+├── testing/
+│   ├── integration_test.go    # Target file - add logging example test
+│   ├── harness.go             # Existing test harness (used by example)
+│   ├── mock_plugin.go         # Existing mock plugin (used by example)
+│   └── CLAUDE.md              # Testing package documentation
+├── logging/                   # From 005-zerolog (dependency)
+│   ├── logger.go              # NewPluginLogger, field constants
+│   ├── tracing.go             # TraceIDFromContext, ContextWithTraceID
+│   └── timing.go              # LogOperation helper
+└── proto/                     # Generated gRPC code (existing)
+```
+
+**Structure Decision**: Single file addition to existing `sdk/go/testing/integration_test.go`.
+No new directories or files required beyond the test function itself. Uses existing testing
+framework infrastructure and depends on 005-zerolog logging utilities.
+
+## Complexity Tracking
+
+No violations to justify - all constitutional gates pass.

--- a/specs/007-zerolog-logging-example/quickstart.md
+++ b/specs/007-zerolog-logging-example/quickstart.md
@@ -1,0 +1,127 @@
+# Quickstart: Structured Logging Example for EstimateCost
+
+**Feature**: 007-zerolog-logging-example
+**Date**: 2025-11-26
+
+## Prerequisites
+
+Before implementing this example:
+
+1. **005-zerolog utilities must be implemented** in `sdk/go/logging/`
+2. **006-estimate-cost RPC** is already available in proto and MockPlugin
+3. Go 1.24+ with zerolog v1.34.0+ dependency
+
+## Quick Implementation Guide
+
+### Step 1: Add Test Function to integration_test.go
+
+Add to `sdk/go/testing/integration_test.go`:
+
+```go
+// TestStructuredLoggingExample demonstrates structured logging patterns
+// for the EstimateCost RPC, per NFR-001 of spec 006-estimate-cost.
+func TestStructuredLoggingExample(t *testing.T) {
+    // Setup - see implementation details in tasks
+}
+```
+
+### Step 2: Demonstrate Request Logging
+
+```go
+// Log incoming request with context fields
+logger.Info().
+    Str(logging.FieldTraceID, traceID).
+    Str(logging.FieldOperation, "EstimateCost").
+    Str(logging.FieldResourceType, req.GetResourceType()).
+    Int("attribute_count", len(req.GetAttributes().GetFields())).
+    Msg("Processing cost estimation request")
+```
+
+### Step 3: Demonstrate Response Logging
+
+```go
+// Log successful response with cost details
+done := logging.LogOperation(logger, "EstimateCost")
+// ... perform RPC ...
+done() // Logs duration_ms automatically
+
+logger.Info().
+    Str(logging.FieldTraceID, traceID).
+    Str(logging.FieldOperation, "EstimateCost").
+    Float64(logging.FieldCostMonthly, resp.GetCostMonthly()).
+    Str("currency", resp.GetCurrency()).
+    Msg("Cost estimation completed")
+```
+
+### Step 4: Demonstrate Error Logging
+
+```go
+// Log errors with error code and context
+logger.Error().
+    Err(err).
+    Str(logging.FieldTraceID, traceID).
+    Str(logging.FieldOperation, "EstimateCost").
+    Str(logging.FieldResourceType, req.GetResourceType()).
+    Str(logging.FieldErrorCode, status.Code(err).String()).
+    Msg("Cost estimation failed")
+```
+
+## Running the Example
+
+```bash
+# Run the example test
+go test -v ./sdk/go/testing/ -run TestStructuredLoggingExample
+
+# Expected output shows structured JSON logs
+```
+
+## Expected Log Output
+
+### Request Log
+
+```json
+{"level":"info","time":"...","trace_id":"abc123","operation":"EstimateCost",
+ "resource_type":"aws:ec2/instance:Instance","attribute_count":2,
+ "message":"Processing cost estimation request"}
+```
+
+### Success Log
+
+```json
+{"level":"info","time":"...","trace_id":"abc123","operation":"EstimateCost",
+ "cost_monthly":8.76,"currency":"USD","duration_ms":45,
+ "message":"Cost estimation completed"}
+```
+
+### Error Log
+
+```json
+{"level":"error","time":"...","trace_id":"abc123","operation":"EstimateCost",
+ "resource_type":"invalid:resource","error_code":"INVALID_ARGUMENT",
+ "error":"invalid resource_type format","duration_ms":12,
+ "message":"Cost estimation failed"}
+```
+
+## Key Patterns to Follow
+
+1. **Always include trace_id** when available (graceful degradation if missing)
+2. **Use standard field constants** from `sdk/go/logging/`
+3. **Never log attribute values** - log count only to prevent credential exposure
+4. **Use LogOperation helper** for automatic timing measurement
+5. **Include operation name** in every log entry for filterability
+6. **Log at appropriate levels**: Info for normal flow, Error for failures
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `sdk/go/testing/integration_test.go` | Add `TestStructuredLoggingExample` function |
+
+## Next Steps
+
+After implementation:
+
+1. Run `go test -v ./sdk/go/testing/ -run TestStructuredLoggingExample`
+2. Verify JSON output contains all required fields
+3. Run `make lint` to ensure code quality
+4. Update `sdk/go/testing/README.md` if needed

--- a/specs/007-zerolog-logging-example/research.md
+++ b/specs/007-zerolog-logging-example/research.md
@@ -1,0 +1,237 @@
+# Research: Structured Logging Example for EstimateCost
+
+**Feature**: 007-zerolog-logging-example
+**Date**: 2025-11-26
+
+## Overview
+
+This research consolidates findings for implementing a structured logging example demonstrating
+zerolog integration for the EstimateCost RPC in the PulumiCost SDK testing package.
+
+## Dependencies Analysis
+
+### 005-zerolog SDK Logging Utilities
+
+**Status**: Specification complete (005-zerolog/spec.md), implementation pending
+
+**Key Functions Required**:
+
+| Function | Purpose | Signature Pattern |
+|----------|---------|-------------------|
+| `NewPluginLogger` | Create configured zerolog.Logger | `(name, version string, level zerolog.Level, w io.Writer) zerolog.Logger` |
+| `TraceIDFromContext` | Extract trace_id from context | `(ctx context.Context) string` |
+| `ContextWithTraceID` | Add trace_id to context | `(ctx context.Context, traceID string) context.Context` |
+| `LogOperation` | Timing helper for operations | `(logger zerolog.Logger, operation string) func()` |
+
+**Field Constants** (from FR-006 of 005-zerolog):
+
+- `FieldTraceID` = "trace_id"
+- `FieldComponent` = "component"
+- `FieldOperation` = "operation"
+- `FieldDurationMs` = "duration_ms"
+- `FieldResourceURN` = "resource_urn"
+- `FieldResourceType` = "resource_type"
+- `FieldPluginName` = "plugin_name"
+- `FieldPluginVersion` = "plugin_version"
+- `FieldCostMonthly` = "cost_monthly"
+- `FieldAdapter` = "adapter"
+- `FieldErrorCode` = "error_code"
+
+**Decision**: Example will use these utilities from `sdk/go/logging/` package when implemented.
+**Rationale**: Spec 005-zerolog defines the standard utilities; using them ensures consistency.
+**Alternatives**: Could inline zerolog usage, but that defeats the purpose of showing SDK patterns.
+
+### 006-estimate-cost EstimateCost RPC
+
+**Status**: Implemented in proto/pulumicost/v1/costsource.proto (lines 29-42, 440-484)
+
+**Key Types**:
+
+- `EstimateCostRequest`: resource_type (string), attributes (google.protobuf.Struct)
+- `EstimateCostResponse`: currency (string), cost_monthly (double)
+
+**Error Cases** (from proto comments):
+
+- `InvalidArgument`: Invalid resource_type format or missing required attributes
+- `NotFound`: Unsupported resource_type for this plugin
+- `Unavailable`: Pricing source temporarily unavailable
+
+**Decision**: Example will use existing MockPlugin which already has EstimateCost support.
+**Rationale**: MockPlugin in mock_plugin.go already implements EstimateCost with configurable behavior.
+**Alternatives**: Create new mock - rejected as existing infrastructure is sufficient.
+
+## Existing Testing Patterns
+
+### Integration Test Patterns (sdk/go/testing/integration_test.go)
+
+#### Pattern 1: Basic Test Structure
+
+```go
+func TestFeatureName(t *testing.T) {
+    plugin := plugintesting.NewMockPlugin()
+    harness := plugintesting.NewTestHarness(plugin)
+    harness.Start(t)
+    defer harness.Stop()
+
+    client := harness.Client()
+    ctx := context.Background()
+
+    // Test logic
+}
+```
+
+#### Pattern 2: Subtests with t.Run
+
+```go
+t.Run("SubtestName", func(t *testing.T) {
+    // Subtest logic
+})
+```
+
+#### Pattern 3: Error Condition Testing
+
+```go
+plugin := plugintesting.ConfigurableErrorMockPlugin()
+plugin.ShouldErrorOnName = true
+// Test error handling
+```
+
+**Decision**: Example will follow existing patterns with subtests for each logging scenario.
+**Rationale**: Consistency with existing tests improves maintainability.
+**Alternatives**: Separate test functions - rejected for cohesion of logging examples.
+
+### Mock Plugin Capabilities (mock_plugin.go)
+
+**EstimateCost Support**:
+
+- `ShouldErrorOnEstimateCost` flag for error injection
+- `EstimateCostDelay` for timeout testing
+- Returns simulated cost based on resource attributes
+
+**Decision**: Use ConfigurableErrorMockPlugin for error logging examples.
+**Rationale**: Built-in error injection makes testing error logging patterns straightforward.
+**Alternatives**: Custom mock - rejected as existing mock is sufficient.
+
+## Logging Best Practices Research
+
+### zerolog Builder Pattern
+
+**Standard Usage**:
+
+```go
+logger.Info().
+    Str(FieldOperation, "EstimateCost").
+    Str(FieldResourceType, resourceType).
+    Msg("Processing request")
+```
+
+**Decision**: Example will use builder pattern with standard field constants.
+**Rationale**: This is idiomatic zerolog usage and matches 005-zerolog spec.
+
+### Correlation ID Propagation
+
+**Pattern**:
+
+1. Extract trace_id from context at request entry
+2. Add trace_id to all log entries for that request
+3. Use logger.With() for persistent fields
+
+**Decision**: Use ContextWithTraceID and TraceIDFromContext from 005-zerolog.
+**Rationale**: Standard SDK utilities ensure consistent tracing across plugins.
+
+### Operation Timing
+
+**Pattern**:
+
+```go
+done := LogOperation(logger, "EstimateCost")
+defer done()
+// Operation logic
+```
+
+**Decision**: Demonstrate LogOperation helper from 005-zerolog.
+**Rationale**: Timing is critical for performance monitoring (NFR-001).
+
+### Sensitive Data Handling
+
+**Best Practice**: Never log attribute values directly - log count and keys only.
+
+**Decision**: Example will demonstrate logging `len(attributes.Fields)` not values.
+**Rationale**: Prevents accidental credential/secret exposure in logs.
+
+## Example Code Structure
+
+### Proposed Test Function Structure
+
+```go
+func TestStructuredLoggingExample(t *testing.T) {
+    // Setup with logging
+
+    t.Run("RequestLogging", func(t *testing.T) {
+        // Demonstrate logging incoming requests
+    })
+
+    t.Run("SuccessResponseLogging", func(t *testing.T) {
+        // Demonstrate logging successful responses
+    })
+
+    t.Run("ErrorLogging", func(t *testing.T) {
+        // Demonstrate error logging with context
+    })
+
+    t.Run("CorrelationIDPropagation", func(t *testing.T) {
+        // Demonstrate trace_id across logs
+    })
+}
+```
+
+**Decision**: Single test function with subtests covering all scenarios.
+**Rationale**: Keeps all logging examples together for easy reference.
+
+## Technical Considerations
+
+### Log Output Capture
+
+**Challenge**: Tests need to verify log output structure.
+
+**Solution**: Use `bytes.Buffer` as output writer for zerolog:
+
+```go
+var buf bytes.Buffer
+logger := zerolog.New(&buf).With().Timestamp().Logger()
+```
+
+**Decision**: Use buffer-based logging for testable output.
+**Rationale**: Allows assertions on JSON log structure without external dependencies.
+
+### JSON Log Parsing
+
+**Approach**: Parse log buffer as JSON and assert on fields:
+
+```go
+var logEntry map[string]interface{}
+json.Unmarshal(buf.Bytes(), &logEntry)
+// Assert on logEntry["operation"], logEntry["trace_id"], etc.
+```
+
+**Decision**: Use standard encoding/json for log verification.
+**Rationale**: Simple, no external dependencies, matches production parsing patterns.
+
+## Resolved Questions
+
+| Topic | Resolution |
+|-------|------------|
+| Which test file? | `sdk/go/testing/integration_test.go` per FR-008 |
+| Which mock to use? | `ConfigurableErrorMockPlugin` for error scenarios |
+| How to capture logs? | `bytes.Buffer` as zerolog output writer |
+| How to verify output? | JSON parsing with standard library |
+| Field naming? | Use constants from 005-zerolog (FieldTraceID, etc.) |
+| Sensitive data? | Log attribute count, never attribute values |
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| 005-zerolog not yet implemented | Blocking | Document expected API; example can be written against interface |
+| Mock plugin behavior changes | Low | Test against stable public API only |
+| Log format changes | Low | Use field constants for forward compatibility |

--- a/specs/007-zerolog-logging-example/spec.md
+++ b/specs/007-zerolog-logging-example/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: Structured Logging Example for EstimateCost
+
+**Feature Branch**: `007-zerolog-logging-example`
+**Created**: 2025-11-26
+**Status**: Draft
+**Input**: GitHub Issue #83 - Add structured logging example for EstimateCost (T040)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Plugin Developer Learns Logging Patterns (Priority: P1)
+
+A plugin developer wants to understand how to properly integrate zerolog structured
+logging with PulumiCost plugin operations, specifically for the EstimateCost RPC.
+
+**Why this priority**: Documentation through working examples is the most effective way
+to ensure consistent logging practices across the plugin ecosystem. This example serves
+as the canonical reference for NFR-001 compliance.
+
+**Independent Test**: Can be tested by running the example code and verifying the
+structured JSON output contains all expected fields (trace_id, operation, resource_type,
+duration_ms, cost details).
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the integration test example, **When** they examine the
+   logging code, **Then** they can understand how to create a configured logger with
+   plugin name and version
+2. **Given** a developer reads the example, **When** they examine the request logging
+   pattern, **Then** they can see how to log incoming requests with relevant context
+   fields (resource_type, attributes count)
+3. **Given** a developer reads the example, **When** they examine the response logging
+   pattern, **Then** they can see how to log successful responses with cost details
+   (estimated_cost, currency)
+
+---
+
+### User Story 2 - Plugin Developer Implements Error Logging (Priority: P1)
+
+A plugin developer needs to understand the proper pattern for logging errors in a way
+that supports debugging and monitoring, including correlation IDs for distributed tracing.
+
+**Why this priority**: Error logging is equally critical to success logging - operators
+need clear error context to diagnose production issues. Correlation ID handling enables
+end-to-end tracing.
+
+**Independent Test**: Can be tested by running the error scenario example and verifying
+the error log contains trace_id, error code, and descriptive message.
+
+**Acceptance Scenarios**:
+
+1. **Given** an EstimateCost call fails with an unsupported resource, **When** the
+   developer logs the error, **Then** the log includes error code, error message,
+   resource_type, and trace_id
+2. **Given** a request arrives with a correlation ID header, **When** the developer
+   logs any operation, **Then** the trace_id appears in all related log entries
+3. **Given** an operation times out or encounters an internal error, **When** the
+   developer logs the failure, **Then** the log includes duration_ms to help identify
+   performance issues
+
+---
+
+### User Story 3 - Operator Monitors EstimateCost Health (Priority: P2)
+
+An operator wants to be able to query logs to understand EstimateCost operation health,
+including latency percentiles and error patterns.
+
+**Why this priority**: Operational monitoring requires consistent log structure. While
+not required for plugin development, this enables ecosystem-wide observability.
+
+**Independent Test**: Can be tested by verifying log output follows the documented field
+naming conventions and can be parsed by standard JSON tools.
+
+**Acceptance Scenarios**:
+
+1. **Given** logs from multiple EstimateCost calls, **When** an operator queries by
+   operation field, **Then** they can filter to only EstimateCost operations
+2. **Given** logs with duration_ms fields, **When** an operator aggregates by
+   resource_type, **Then** they can calculate average latency per resource type
+3. **Given** logs with error_code fields, **When** an operator groups errors, **Then**
+   they can identify the most common failure modes
+
+---
+
+### Edge Cases
+
+- What happens when trace_id is not present in the request context?
+  (Log without trace_id field rather than failing; allows graceful degradation)
+- How should very large attribute maps be logged?
+  (Log attribute count rather than full attributes to avoid log bloat)
+- What happens when the estimated cost is zero?
+  (Log normally with cost=0; this is a valid business case)
+- How should sensitive attribute values be handled?
+  (Do not log attribute values; only log count and keys if needed)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Example MUST demonstrate creating a zerolog.Logger with plugin name and
+  version using the SDK's NewPluginLogger function
+- **FR-002**: Example MUST demonstrate logging a request with resource_type and
+  operation context fields
+- **FR-003**: Example MUST demonstrate logging a successful response with estimated
+  cost, currency, and duration_ms fields
+- **FR-004**: Example MUST demonstrate logging an error with error code, error message,
+  and original request context
+- **FR-005**: Example MUST demonstrate correlation ID (trace_id) propagation through
+  request logging
+- **FR-006**: Example MUST use the standard field name constants (FieldTraceID,
+  FieldOperation, FieldDurationMs, FieldResourceType, etc.)
+- **FR-007**: Example MUST include code comments explaining logging best practices
+- **FR-008**: Example MUST be placed in sdk/go/testing/integration_test.go as a test
+  function that can be run and verified
+- **FR-009**: Example MUST demonstrate the LogOperation timing helper for measuring
+  operation duration
+- **FR-010**: Example MUST follow existing integration test patterns in the file
+
+### Key Entities
+
+- **Logger**: Configured zerolog instance with plugin metadata
+- **TraceID**: Correlation identifier propagated via context for distributed tracing
+- **LogFields**: Standard field constants for consistent naming (from 005-zerolog spec)
+- **Operation**: EstimateCost RPC being logged
+- **CostResult**: The estimated cost value and currency to be logged on success
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Developers can run the example test and see structured JSON log output
+- **SC-002**: Example demonstrates all three logging scenarios (request, success response,
+  error response)
+- **SC-003**: All log output uses standard field names from the zerolog SDK utilities
+- **SC-004**: Example code compiles and passes go test without modification
+- **SC-005**: Code comments provide clear guidance that developers can apply to their
+  own plugins
+
+## Assumptions
+
+- The zerolog SDK logging utilities from spec 005-zerolog are implemented and available
+- EstimateCost RPC from spec 006-estimate-cost is implemented and available
+- Plugin developers are familiar with zerolog's builder pattern API
+- The integration test file already exists and follows established patterns
+- Structured JSON output is the standard format (not console/pretty printing)
+
+## Dependencies
+
+- 005-zerolog: Zerolog SDK Logging Utilities (provides NewPluginLogger, field constants,
+  LogOperation)
+- 006-estimate-cost: EstimateCost RPC (provides the operation being logged)
+- sdk/go/testing package: Existing test infrastructure
+
+## Out of Scope
+
+- Creating new zerolog utilities (use existing from 005-zerolog)
+- Implementing actual EstimateCost functionality (use mock or existing implementation)
+- Log aggregation or centralized logging infrastructure
+- Console/pretty-print formatters
+- Metric emission (covered separately in NFR-002 of 006-estimate-cost)

--- a/specs/007-zerolog-logging-example/tasks.md
+++ b/specs/007-zerolog-logging-example/tasks.md
@@ -1,0 +1,194 @@
+# Tasks: Structured Logging Example for EstimateCost
+
+**Input**: Design documents from `/specs/007-zerolog-logging-example/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: This feature is a documentation example that IS a test. No separate test tasks needed.
+
+**Organization**: Tasks grouped by user story to enable independent verification of each logging pattern.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Target file**: `sdk/go/testing/integration_test.go`
+- **Dependency**: `sdk/go/logging/` (from 005-zerolog)
+
+---
+
+## Phase 1: Setup (Verification)
+
+**Purpose**: Verify prerequisites are met before implementation
+
+- [x] T001 Verify 005-zerolog utilities exist in sdk/go/pluginsdk/ (NewPluginLogger, field constants)
+- [x] T002 Verify EstimateCost RPC is available in MockPlugin in sdk/go/testing/mock_plugin.go
+- [x] T003 Review existing test patterns in sdk/go/testing/integration_test.go
+
+---
+
+## Phase 2: Foundational (Test Function Scaffold)
+
+**Purpose**: Create the test function structure that all user stories will use
+
+**CRITICAL**: This scaffold must be complete before implementing logging examples
+
+- [x] T004 Add TestStructuredLoggingExample function scaffold in sdk/go/testing/integration_test.go
+- [x] T005 Add import statements for zerolog, bytes, encoding/json, sdk/go/pluginsdk in sdk/go/testing/integration_test.go
+- [x] T006 Add bytes.Buffer setup for log capture in TestStructuredLoggingExample
+- [x] T007 Add helper function parseMultipleLogEntries, assertLogContains, assertLogNotContains in sdk/go/testing/integration_test.go
+
+**Checkpoint**: Scaffold ready - logging example subtests can now be added
+
+---
+
+## Phase 3: User Story 1 - Plugin Developer Learns Logging Patterns (Priority: P1)
+
+**Goal**: Demonstrate creating a configured logger and logging request/response patterns
+
+**Independent Test**: Run `go test -v ./sdk/go/testing/ -run TestStructuredLoggingExample/RequestLogging`
+and verify JSON output contains trace_id, operation, resource_type fields
+
+### Implementation for User Story 1
+
+- [x] T008 [US1] Add t.Run("RequestLogging") subtest demonstrating request logging in sdk/go/testing/integration_test.go
+- [x] T009 [US1] Demonstrate NewPluginLogger with plugin name and version in RequestLogging subtest
+- [x] T010 [US1] Demonstrate logging resource_type and attribute_count (not values) in RequestLogging subtest
+- [x] T011 [US1] Add t.Run("SuccessResponseLogging") subtest in sdk/go/testing/integration_test.go
+- [x] T012 [US1] Demonstrate logging cost_monthly, currency, and duration_ms in SuccessResponseLogging subtest
+- [x] T013 [US1] Demonstrate LogOperation timing helper in SuccessResponseLogging subtest
+- [x] T014 [US1] Add code comments explaining logging best practices for FR-007 compliance
+
+**Checkpoint**: User Story 1 complete - developers can see request/response logging patterns
+
+---
+
+## Phase 4: User Story 2 - Plugin Developer Implements Error Logging (Priority: P1)
+
+**Goal**: Demonstrate error logging with correlation IDs and error context
+
+**Independent Test**: Run `go test -v ./sdk/go/testing/ -run TestStructuredLoggingExample/ErrorLogging`
+and verify JSON output contains trace_id, error_code, error message fields
+
+### Implementation for User Story 2
+
+- [x] T015 [US2] Add t.Run("ErrorLogging") subtest using ConfigurableErrorMockPlugin in sdk/go/testing/integration_test.go
+- [x] T016 [US2] Demonstrate error logging with FieldErrorCode and gRPC status code in ErrorLogging subtest
+- [x] T017 [US2] Demonstrate including original request context (resource_type) in error logs
+- [x] T018 [US2] Add t.Run("CorrelationIDPropagation") subtest in sdk/go/testing/integration_test.go
+- [x] T019 [US2] Demonstrate ContextWithTraceID and TraceIDFromContext usage in CorrelationIDPropagation subtest
+- [x] T020 [US2] Add assertions verifying trace_id appears in all log entries
+- [x] T021 [US2] Add code comments explaining correlation ID best practices
+
+**Checkpoint**: User Story 2 complete - developers can see error logging and tracing patterns
+
+---
+
+## Phase 5: User Story 3 - Operator Monitors EstimateCost Health (Priority: P2)
+
+**Goal**: Demonstrate consistent log structure for operational monitoring
+
+**Independent Test**: Verify all log outputs use standard field names parseable by JSON tools
+
+### Implementation for User Story 3
+
+- [x] T022 [US3] Add log structure assertions verifying all entries use FieldTraceID, FieldOperation constants in sdk/go/testing/integration_test.go
+- [x] T023 [US3] Add t.Run("LogStructureValidation") subtest verifying JSON parseable output
+- [x] T024 [US3] Demonstrate filterability by operation field across multiple log entries
+- [x] T025 [US3] Add code comments explaining operational monitoring considerations
+
+**Checkpoint**: User Story 3 complete - operators can understand log query patterns
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and documentation
+
+- [x] T026 Run go test -v ./sdk/go/testing/ -run TestStructuredLoggingExample to verify all subtests pass
+- [x] T027 Run make lint to ensure code quality
+- [x] T028 [P] Update sdk/go/testing/CLAUDE.md with logging example documentation
+- [x] T029 Validate implementation matches quickstart.md patterns
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - verify prerequisites first
+- **Foundational (Phase 2)**: Depends on Setup - creates test scaffold
+- **User Story 1 (Phase 3)**: Depends on Foundational - adds request/response logging
+- **User Story 2 (Phase 4)**: Depends on Foundational - can run parallel to US1 (different subtests)
+- **User Story 3 (Phase 5)**: Depends on US1 and US2 (validates their output)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Phase 2 scaffold - demonstrates normal flow logging
+- **User Story 2 (P1)**: Depends on Phase 2 scaffold - demonstrates error flow logging
+- **User Story 3 (P2)**: Depends on US1 and US2 logs to validate structure
+
+### Within Each User Story
+
+- Subtest creation before implementation details
+- Logging demonstrations before assertions
+- Code comments after implementation
+
+### Parallel Opportunities
+
+- T008, T011 (US1 subtests) can be created in parallel (different subtests)
+- T015, T018 (US2 subtests) can be created in parallel (different subtests)
+- US1 and US2 can be worked on in parallel after Phase 2 (no dependencies between them)
+
+---
+
+## Parallel Example: Phase 2 Setup
+
+```bash
+# Import statements and buffer setup can be done in sequence (same file):
+Task: "Add import statements for zerolog, bytes, encoding/json"
+Task: "Add bytes.Buffer setup for log capture"
+Task: "Add helper function parseLogEntry"
+```
+
+## Parallel Example: User Story 1 + User Story 2
+
+```bash
+# After Phase 2 scaffold is complete, these can run in parallel:
+# Developer A: User Story 1 (RequestLogging, SuccessResponseLogging subtests)
+# Developer B: User Story 2 (ErrorLogging, CorrelationIDPropagation subtests)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup verification
+2. Complete Phase 2: Test scaffold
+3. Complete Phase 3: User Story 1 (request/response logging)
+4. **STOP and VALIDATE**: Run `go test -v ./sdk/go/testing/ -run TestStructuredLoggingExample`
+5. Merge if US1 is sufficient for initial documentation
+
+### Full Implementation
+
+1. Complete Setup + Foundational
+2. Add User Story 1 → Verify independently
+3. Add User Story 2 → Verify independently
+4. Add User Story 3 → Validate log structure
+5. Polish and final validation
+
+---
+
+## Notes
+
+- This feature adds to existing file - no new file creation needed
+- All logging examples use the 005-zerolog SDK utilities
+- Example code serves as documentation (FR-007: code comments required)
+- Focus on demonstrating patterns, not exhaustive test coverage
+- Avoid logging sensitive attribute values - log count only


### PR DESCRIPTION
Adds TestStructuredLoggingExample as the canonical reference for plugin developers to implement zerolog structured logging per NFR-001 of spec 006-estimate-cost.

## Summary

- Add `TestStructuredLoggingExample` test with 5 subtests
- Add helper functions: `parseMultipleLogEntries`, `assertLogContains`
- Update `sdk/go/testing/CLAUDE.md` with logging example documentation

## Subtests

- **RequestLogging** - Log incoming requests with resource context
- **SuccessResponseLogging** - Log responses with cost details and timing
- **ErrorLogging** - Log errors with error codes and original context
- **CorrelationIDPropagation** - Demonstrate trace_id propagation
- **LogStructureValidation** - Verify JSON parseable output

## Key Patterns Demonstrated

- Creating configured loggers with `pluginsdk.NewPluginLogger()`
- Using standard field constants (FieldTraceID, FieldOperation)
- Correlation ID propagation with `ContextWithTraceID`
- Operation timing measurement with `LogOperation` helper
- Sensitive data protection (log attribute count, never values)

## Test Plan

- [x] `go test -v ./sdk/go/testing/ -run TestStructuredLoggingExample`
- [x] `make lint` - 0 issues
- [x] `make test` - all tests pass

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an EstimateCost RPC to provide pre-deployment cost estimates (currency and monthly cost).

* **Documentation**
  * Expanded Active Technologies list and developer guide with guidance and comparisons for the new cost estimation capability.
  * Added structured logging example and integration testing guidance for logging best practices.

* **Tests**
  * Added a comprehensive structured logging test suite with helpers for verifying log contents and correlation ID propagation.

* **Chores**
  * Updated release configuration to refine bump behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->