### PR TITLE
feat(focus): add complete FOCUS 1.2 column coverage with builder API

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
@@ -21,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,20 +522,12 @@ cd schemas && /init            # JSON Schema validation
 
 ## Active Technologies
 
-- Go 1.24+ (toolchain go1.25.4) + google.golang.org/grpc v1.77.0, crypto/rand (stdlib) (008-trace-id-validation)
-- N/A (in-memory context propagation only) (008-trace-id-validation)
-
-- Go 1.24+ (toolchain go1.25.4) + zerolog v1.34.0+, google.golang.org/grpc, sdk/go/testing harness (007-zerolog-logging-example)
+- Go 1.24.10 (toolchain go1.25.4)
+- Protocol Buffers v3 + google.golang.org/protobuf
+- google.golang.org/grpc
+- buf v1.32.1 (010-focus-column-audit)
+- crypto/rand (stdlib) (008-trace-id-validation)
+- zerolog v1.34.0+
+- sdk/go/testing harness (007-zerolog-logging-example)
 - N/A (example code, no data persistence) (007-zerolog-logging-example)
-
-- Go 1.24+ (matches existing SDK, toolchain go1.25.4), Protocol Buffers v3 (006-estimate-cost)
-- N/A (specification repository - no runtime storage) (006-estimate-cost)
-
-- Go 1.24+ (matches existing SDK) + zerolog v1.34.0+, google.golang.org/grpc (005-zerolog)
-- JSON Schema draft 2020-12 + AJV (validation), existing `registry.proto` definitions (004-plugin-registry-schema)
-- Go 1.24.10 (toolchain go1.25.4) + Standard library only (no external dependencies for validation) (001-domain-enum-optimization)
-
-## Recent Changes
-
-- 001-domain-enum-optimization: Added Go 1.24.10 (toolchain go1.25.4) + Standard library only (no external
-  dependencies for validation)
+- JSON Schema draft 2020-12 + AJV (validation)(004-plugin-registry-schema)

--- a/buf.yaml
+++ b/buf.yaml
@@ -9,3 +9,10 @@ lint:
 breaking:
   use:
     - FILE
+  # Ignore FOCUS 1.2 alignment renames introduced in PR #99.
+  # These are intentional breaking changes to align with FinOps FOCUS 1.2 spec:
+  #   - currency → billing_currency (field 18)
+  #   - usage_quantity → consumed_quantity (field 20)
+  #   - usage_unit → consumed_unit (field 21)
+  ignore:
+    - proto/pulumicost/v1/focus.proto

--- a/docs/PLUGIN_MIGRATION_GUIDE.md
+++ b/docs/PLUGIN_MIGRATION_GUIDE.md
@@ -8,6 +8,45 @@ This guide explains how to update existing plugins to support the FinOps FOCUS 1
 - **Builder Pattern**: Direct struct initialization of cost records is discouraged. Use `NewFocusRecordBuilder`.
 - **Strict Enums**: Service, Charge, and Pricing categories are now Enums.
 
+## Breaking Changes (v0.2.0)
+
+The following proto field renames align with FOCUS 1.2 naming conventions:
+
+| Old Field Name | New Field Name | Proto Field # | Notes |
+|----------------|----------------|---------------|-------|
+| `currency` | `billing_currency` | 18 | Aligns with FOCUS BillingCurrency |
+| `usage_quantity` | `consumed_quantity` | 20 | Aligns with FOCUS ConsumedQuantity |
+| `usage_unit` | `consumed_unit` | 21 | Aligns with FOCUS ConsumedUnit |
+
+### Wire Format Impact
+
+- **Binary protobuf**: Field numbers unchanged; binary compatibility preserved.
+- **JSON serialization**: Field names changed (e.g., `currency` → `billingCurrency`).
+- **Go SDK**: Use `FocusRecordBuilder` methods which handle naming automatically.
+
+### Migration Example
+
+**Before (v0.1.x):**
+
+```go
+record.Currency = "USD"
+record.UsageQuantity = 100.0
+record.UsageUnit = "Hours"
+```
+
+**After (v0.2.0):**
+
+```go
+// Option 1: Use the builder (recommended)
+builder.WithFinancials(billed, list, effective, "USD", invoiceID)
+builder.WithUsage(100.0, "Hours")
+
+// Option 2: Direct field access (if needed)
+record.BillingCurrency = "USD"
+record.ConsumedQuantity = 100.0
+record.ConsumedUnit = "Hours"
+```
+
 ## Migration Steps
 
 ### 1. Update Imports

--- a/docs/focus-columns.md
+++ b/docs/focus-columns.md
@@ -1,0 +1,329 @@
+# FOCUS 1.2 Column Reference
+
+This document provides a comprehensive reference for all 57 columns defined in the
+FinOps FOCUS 1.2 (FinOps Open Cost and Usage Specification) as implemented in
+PulumiCost.
+
+Reference: <https://focus.finops.org/focus-specification/v1-2/>
+
+## Column Summary
+
+| Level | Count | Description |
+|-------|-------|-------------|
+| Mandatory | 14 | Required for all cost records |
+| Recommended | 1 | Strongly suggested for completeness |
+| Conditional | 42 | Required when applicable conditions are met |
+| **Total** | **57** | Complete FOCUS 1.2 coverage |
+
+## Mandatory Columns (14)
+
+These columns MUST be present in every FOCUS-compliant cost record.
+
+### Identity & Hierarchy
+
+| Column | Type | Description | Provider Mapping |
+|--------|------|-------------|------------------|
+| **ProviderName** | string | Cloud provider name | AWS, Azure, GCP, Kubernetes |
+| **BillingAccountId** | string | Billing account identifier | AWS: Payer Account ID, Azure: Billing Account ID, GCP: Billing Account ID |
+| **BillingAccountName** | string | Display name for billing account | AWS: Account Alias, Azure: Billing Account Name, GCP: Billing Account Name |
+
+### Billing Period
+
+| Column | Type | Description | Provider Mapping |
+|--------|------|-------------|------------------|
+| **BillingPeriodStart** | DateTime | Start of billing period | First day of billing month |
+| **BillingPeriodEnd** | DateTime | End of billing period | Last day of billing month |
+| **BillingCurrency** | string | ISO 4217 currency code | USD, EUR, GBP, etc. |
+
+### Charge Period
+
+| Column | Type | Description | Provider Mapping |
+|--------|------|-------------|------------------|
+| **ChargePeriodStart** | DateTime | When charge began | Line item start time |
+| **ChargePeriodEnd** | DateTime | When charge ended | Line item end time |
+
+### Charge Details
+
+| Column | Type | Description | Provider Mapping |
+|--------|------|-------------|------------------|
+| **ChargeCategory** | Enum | Nature of charge | Usage, Purchase, Credit, Tax, Refund, Adjustment |
+| **ChargeClass** | Enum | Classification | Regular, Correction |
+| **ChargeDescription** | string | Human-readable description | AWS: lineItem/LineItemDescription |
+
+### Service
+
+| Column | Type | Description | Provider Mapping |
+|--------|------|-------------|------------------|
+| **ServiceName** | string | Name of the service | AWS: EC2, S3; Azure: Virtual Machines; GCP: Compute Engine |
+
+### Financial Amounts
+
+| Column | Type | Description | Provider Mapping |
+|--------|------|-------------|------------------|
+| **BilledCost** | Decimal | Amount billed | AWS: lineItem/BlendedCost, Azure: BilledCost |
+| **ContractedCost** | Decimal | ContractedUnitPrice × PricingQuantity | Calculated from contracted rates |
+
+## Recommended Column (1)
+
+This column is strongly recommended but not mandatory.
+
+| Column | Type | Description | Provider Mapping |
+|--------|------|-------------|------------------|
+| **ChargeFrequency** | Enum | How often charge applies | OneTime, Recurring, UsageBased |
+
+## Conditional Columns (42)
+
+These columns are required when specific conditions apply.
+
+### Identity & Hierarchy - Conditional
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **SubAccountId** | string | When sub-accounts exist | AWS: Account ID, Azure: Subscription ID, GCP: Project ID |
+| **SubAccountName** | string | When sub-accounts exist | Account/Subscription/Project name |
+| **BillingAccountType** | string | When account types vary | Enterprise, PayAsYouGo, etc. |
+| **SubAccountType** | string | When sub-account types vary | LinkedAccount, Subscription, Project |
+
+### Location
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **RegionId** | string | When resource has region | AWS: us-east-1, Azure: eastus, GCP: us-central1 |
+| **RegionName** | string | When resource has region | US East (N. Virginia), East US, etc. |
+| **AvailabilityZone** | string | When AZ is applicable | AWS: us-east-1a, Azure: 1, GCP: us-central1-a |
+
+### Resource Details
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **ResourceId** | string | When resource is identifiable | AWS: ARN, Azure: Resource ID, GCP: Resource ID |
+| **ResourceName** | string | When resource has name | User-assigned resource name |
+| **ResourceType** | string | When resource type is known | m5.large, Standard_D2s_v3, n1-standard-1 |
+
+### SKU Details
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **SkuId** | string | When SKU is known | Provider-specific SKU identifier |
+| **SkuPriceId** | string | When SKU price is known | Specific price list ID |
+| **SkuMeter** | string | When meter exists | AWS: BoxUsage, Azure: Meter Name |
+| **SkuPriceDetails** | string | When additional details exist | Operating system, license type, etc. |
+
+### Pricing Details
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **PricingQuantity** | Decimal | When pricing is quantifiable | Number of units priced |
+| **PricingUnit** | string | When pricing unit exists | Hours, GB, Requests |
+| **ListUnitPrice** | Decimal | When list price is known | Public on-demand rate |
+| **ContractedUnitPrice** | Decimal | When contracted price exists | Reserved/committed rate |
+| **PricingCategory** | Enum | When pricing model varies | Standard, Committed, Dynamic, Other |
+| **PricingCurrency** | string | When different from billing currency | ISO 4217 code |
+| **PricingCurrencyContractedUnitPrice** | Decimal | When pricing currency differs | Contracted price in pricing currency |
+| **PricingCurrencyEffectiveCost** | Decimal | When pricing currency differs | Effective cost in pricing currency |
+| **PricingCurrencyListUnitPrice** | Decimal | When pricing currency differs | List price in pricing currency |
+
+### Financial Amounts - Conditional
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **ListCost** | Decimal | When list price is known | On-demand cost at list price |
+| **EffectiveCost** | Decimal | When discounts apply | Actual cost after all adjustments |
+
+### Consumption/Usage
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **ConsumedQuantity** | Decimal | When usage is measurable | AWS: UsageQuantity, Azure: Quantity |
+| **ConsumedUnit** | string | When usage unit exists | Hours, GB, Requests |
+
+### Service - Conditional
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **ServiceCategory** | Enum | When categorization is possible | Compute, Storage, Network, Database, etc. |
+| **ServiceSubcategory** | string | When granular categorization exists | Virtual Machine, Container, Serverless |
+| **Publisher** | string | When publisher differs from provider | Amazon Web Services, Microsoft, Google, Third-party |
+
+### Commitment Discounts
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **CommitmentDiscountCategory** | Enum | When commitment exists | Spend, Usage |
+| **CommitmentDiscountId** | string | When commitment exists | RI ID, Savings Plan ID |
+| **CommitmentDiscountName** | string | When commitment has name | User-assigned name |
+| **CommitmentDiscountQuantity** | Decimal | When commitment has quantity | Amount purchased/consumed |
+| **CommitmentDiscountStatus** | Enum | When commitment applies | Used, Unused |
+| **CommitmentDiscountType** | string | When type is known | Reserved Instance, Savings Plan |
+| **CommitmentDiscountUnit** | string | When unit exists | Hours, USD/Hour |
+
+### Capacity Reservation
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **CapacityReservationId** | string | When capacity reservation exists | CR ID from provider |
+| **CapacityReservationStatus** | Enum | When CR applies | Used, Unused |
+
+### Invoice Details
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **InvoiceId** | string | When invoice exists | AWS: bill/InvoiceId, Azure: InvoiceId |
+| **InvoiceIssuer** | string | When issuer is identifiable | Legal entity name |
+
+### Metadata
+
+| Column | Type | Condition | Provider Mapping |
+|--------|------|-----------|------------------|
+| **Tags** | map\<string,string\> | When resource has tags | User-defined key-value pairs |
+
+## Provider Mapping Examples
+
+### AWS
+
+```text
+ProviderName:           "AWS"
+BillingAccountId:       "123456789012"
+ServiceName:            "Amazon EC2"
+ResourceId:             "arn:aws:ec2:us-east-1:123456789012:instance/i-0abc123"
+RegionId:               "us-east-1"
+CommitmentDiscountType: "Standard Reserved Instance"
+```
+
+### Azure
+
+```text
+ProviderName:           "Azure"
+BillingAccountId:       "ea12345678"
+SubAccountId:           "00000000-0000-0000-0000-000000000000"
+ServiceName:            "Virtual Machines"
+ResourceId:             "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/virtualMachines/vm-name"
+RegionId:               "eastus"
+CommitmentDiscountType: "Reservation"
+```
+
+### GCP
+
+```text
+ProviderName:           "GCP"
+BillingAccountId:       "012345-ABCDEF-678901"
+SubAccountId:           "my-project-id"
+ServiceName:            "Compute Engine"
+ResourceId:             "projects/my-project/zones/us-central1-a/instances/instance-1"
+RegionId:               "us-central1"
+CommitmentDiscountType: "Committed Use Discount"
+```
+
+### Kubernetes (via Kubecost)
+
+```text
+ProviderName:           "Kubernetes"
+BillingAccountId:       "cluster-name"
+SubAccountId:           "namespace-name"
+ServiceName:            "Kubernetes Workload"
+ResourceId:             "namespace/pod-name"
+ServiceCategory:        FOCUS_SERVICE_CATEGORY_COMPUTE
+```
+
+## Common Use Cases
+
+### Cost Allocation by Team
+
+Use Tags to allocate costs:
+
+```go
+builder.WithTags(map[string]string{
+    "team":        "platform",
+    "cost_center": "CC-1001",
+    "environment": "production",
+})
+```
+
+### Reserved Instance Analysis
+
+Track commitment utilization:
+
+```go
+builder.WithCommitmentDiscount(
+    pbc.FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE,
+    "ri-123456789",
+    "EC2 m5.large RI",
+)
+builder.WithCommitmentDiscountDetails(
+    730.0, // hours
+    pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED,
+    "Standard Reserved Instance",
+    "Hours",
+)
+```
+
+### Multi-Currency Billing
+
+Handle pricing in different currencies:
+
+```go
+builder.WithBillingPeriod(start, end, "EUR")
+builder.WithPricingCurrency("USD")
+builder.WithPricingCurrencyPrices(
+    0.089,  // contracted unit price in USD
+    65.0,   // effective cost in USD
+    0.10,   // list unit price in USD
+)
+```
+
+### Capacity Reservation Tracking
+
+Monitor capacity reservation utilization:
+
+```go
+builder.WithCapacityReservation(
+    "cr-0abc123456789def0",
+    pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED,
+)
+```
+
+## Query Patterns
+
+### Total Cost by Service
+
+```sql
+SELECT ServiceName, SUM(BilledCost) as TotalCost
+FROM focus_records
+GROUP BY ServiceName
+ORDER BY TotalCost DESC
+```
+
+### Reserved Instance Utilization
+
+```sql
+SELECT
+    CommitmentDiscountId,
+    CommitmentDiscountName,
+    SUM(CASE WHEN CommitmentDiscountStatus = 'USED' THEN BilledCost ELSE 0 END) as UsedCost,
+    SUM(CASE WHEN CommitmentDiscountStatus = 'UNUSED' THEN BilledCost ELSE 0 END) as WastedCost
+FROM focus_records
+WHERE CommitmentDiscountId IS NOT NULL
+GROUP BY CommitmentDiscountId, CommitmentDiscountName
+```
+
+### Cost by Tag
+
+```sql
+SELECT
+    Tags['team'] as Team,
+    SUM(BilledCost) as TotalCost
+FROM focus_records
+GROUP BY Tags['team']
+```
+
+### Regional Cost Distribution
+
+```sql
+SELECT
+    ProviderName,
+    RegionId,
+    SUM(BilledCost) as TotalCost
+FROM focus_records
+GROUP BY ProviderName, RegionId
+ORDER BY ProviderName, TotalCost DESC
+```

--- a/examples/plugins/focus_example.go
+++ b/examples/plugins/focus_example.go
@@ -1,3 +1,10 @@
+// focus_example.go demonstrates a comprehensive FOCUS 1.2 cost record
+// using all 57 columns defined in the FinOps FOCUS 1.2 specification.
+//
+// This example shows how to use the FocusRecordBuilder to construct
+// a complete cost record with all mandatory, recommended, and conditional columns.
+//
+// Reference: https://focus.finops.org/focus-specification/v1-2/
 package main
 
 import (
@@ -10,45 +17,160 @@ import (
 )
 
 // Example cost values for demonstration.
+// Note: ContractedCost MUST equal ContractedUnitPrice × PricingQuantity per FOCUS 1.2.
 const (
-	exampleBilledCost    = 0.12
-	exampleListCost      = 0.12
-	exampleEffectiveCost = 0.12
+	exampleBilledCost       = 73.00 // Monthly billed cost
+	exampleListCost         = 80.00 // List price before discounts
+	exampleEffectiveCost    = 70.00 // Effective cost after discounts
+	exampleContractedCost   = 64.97 // Contracted cost (= 0.089 × 730.0)
+	exampleListUnitPrice    = 0.10  // List price per hour
+	exampleContractedPrice  = 0.089 // Contracted unit price
+	examplePricingQuantity  = 730.0 // Hours in a month
+	exampleConsumedQuantity = 720.0 // Actual hours consumed
+	exampleDiscountQuantity = 730.0 // Commitment discount quantity
 )
 
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
-	// Demonstrating full Builder usage
-	builder := pluginsdk.NewFocusRecordBuilder()
-
-	start := time.Now()
-	end := start.Add(1 * time.Hour)
-
-	builder.WithIdentity("aws", "123456789012", "Production")
-	builder.WithChargePeriod(start, end)
-	builder.WithServiceCategory(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE)
-	builder.WithChargeDetails(
-		pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
-		pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
-	)
-	builder.WithFinancials(exampleBilledCost, exampleListCost, exampleEffectiveCost, "USD", "inv-2025-11")
-	builder.WithUsage(1.0, "Hour")
-
-	// Backpack usage (extensions)
-	builder.WithExtension("Environment", "Prod")
-	builder.WithExtension("CostCenter", "CC-999")
-
-	record, err := builder.Build()
+	// Create FOCUS 1.2 compliant cost record using the builder pattern
+	record, err := buildCompleteFocusRecord()
 	if err != nil {
 		logger.Error("Failed to build record", "error", err)
 		os.Exit(1)
 	}
 
-	logger.Info("Generated Record",
+	logger.Info("Generated Complete FOCUS 1.2 Record",
 		"provider", record.GetProviderName(),
-		"cost", record.GetBilledCost(),
-		"currency", record.GetCurrency(),
-		"extensions", record.GetExtendedColumns(),
+		"service", record.GetServiceName(),
+		"resource_id", record.GetResourceId(),
+		"billed_cost", record.GetBilledCost(),
+		"effective_cost", record.GetEffectiveCost(),
+		"contracted_cost", record.GetContractedCost(),
+		"currency", record.GetBillingCurrency(),
+		"charge_category", record.GetChargeCategory().String(),
+		"pricing_category", record.GetPricingCategory().String(),
+		"commitment_discount_status", record.GetCommitmentDiscountStatus().String(),
 	)
+}
+
+// buildCompleteFocusRecord builds a complete FOCUS 1.2 record with all 57 columns.
+func buildCompleteFocusRecord() (*pbc.FocusCostRecord, error) {
+	builder := pluginsdk.NewFocusRecordBuilder()
+
+	// Set mandatory columns (14 columns)
+	setMandatoryColumns(builder)
+
+	// Set conditional columns (42 columns)
+	setConditionalColumns(builder)
+
+	return builder.Build()
+}
+
+// setMandatoryColumns configures all 14 mandatory FOCUS 1.2 columns.
+func setMandatoryColumns(builder *pluginsdk.FocusRecordBuilder) {
+	now := time.Now()
+	chargeStart := now.Add(-24 * time.Hour)
+	chargeEnd := now
+	billingStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	billingEnd := billingStart.AddDate(0, 1, 0)
+
+	// Identity & Hierarchy (FOCUS 1.2 Section 2.1)
+	builder.WithIdentity("AWS", "123456789012", "Production Account")
+
+	// Billing Period (FOCUS 1.2 Section 2.2)
+	builder.WithBillingPeriod(billingStart, billingEnd, "USD")
+
+	// Charge Period (FOCUS 1.2 Section 2.3)
+	builder.WithChargePeriod(chargeStart, chargeEnd)
+
+	// Charge Details (FOCUS 1.2 Section 2.4)
+	builder.WithChargeDetails(
+		pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+		pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_COMMITTED,
+	)
+
+	// ChargeDescription, ChargeClass, ChargeFrequency (Section 2.4)
+	builder.WithChargeClassification(
+		pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+		"Amazon EC2 m5.large instance usage - US East (N. Virginia)",
+		pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+	)
+
+	// Service Details (FOCUS 1.2 Section 2.6)
+	builder.WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE, "Amazon EC2")
+
+	// Financial Amounts (FOCUS 1.2 Section 2.10)
+	builder.WithFinancials(exampleBilledCost, exampleListCost, exampleEffectiveCost, "USD", "INV-2025-11-001")
+	builder.WithContractedCost(exampleContractedCost)
+}
+
+// setConditionalColumns configures all 42 conditional FOCUS 1.2 columns.
+func setConditionalColumns(builder *pluginsdk.FocusRecordBuilder) {
+	// Identity - Conditional Fields
+	builder.WithSubAccount("111122223333", "Development Workloads")
+	builder.WithBillingAccountType("Organization")
+	builder.WithSubAccountType("LinkedAccount")
+
+	// Location (Section 2.9)
+	builder.WithLocation("us-east-1", "US East (N. Virginia)", "us-east-1a")
+
+	// Resource Details (Section 2.7)
+	builder.WithResource("i-0abc123def456789", "web-server-prod-01", "m5.large")
+
+	// SKU Details (Section 2.8)
+	builder.WithSKU("DQ578CGN99KG6ECF", "DQ578CGN99KG6ECF.JRTCKXETXF.6YS6EN2CT7")
+	builder.WithSkuDetails("BoxUsage:m5.large", "Linux/UNIX, US East (N. Virginia), m5.large")
+
+	// Pricing Details (Section 2.5)
+	builder.WithPricing(examplePricingQuantity, "Hours", exampleListUnitPrice)
+	builder.WithContractedUnitPrice(exampleContractedPrice)
+	builder.WithPricingCurrency("USD")
+	builder.WithPricingCurrencyPrices(exampleContractedPrice, exampleEffectiveCost, exampleListUnitPrice)
+
+	// Consumption/Usage (Section 2.11)
+	builder.WithUsage(exampleConsumedQuantity, "Hours")
+
+	// Service - Conditional Fields
+	builder.WithPublisher("Amazon Web Services")
+	builder.WithServiceSubcategory("Virtual Machine")
+
+	// Commitment Discounts (Section 2.12)
+	builder.WithCommitmentDiscount(
+		pbc.FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE,
+		"ri-0abc123456789def0",
+		"EC2 m5.large 1-Year Reserved Instance",
+	)
+	builder.WithCommitmentDiscountDetails(
+		exampleDiscountQuantity,
+		pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED,
+		"Standard Reserved Instance",
+		"Hours",
+	)
+
+	// Capacity Reservation (Sections 3.6, 3.7)
+	builder.WithCapacityReservation(
+		"cr-0abc123456789def0",
+		pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED,
+	)
+
+	// Invoice Details (Section 2.13)
+	builder.WithInvoice("INV-2025-11-001", "Amazon Web Services, Inc.")
+
+	// Metadata & Extension (Section 2.14)
+	builder.WithTags(map[string]string{
+		"Environment": "Production",
+		"CostCenter":  "CC-Engineering-001",
+		"Project":     "WebPlatform",
+		"Owner":       "platform-team@example.com",
+		"Application": "web-server",
+		"ManagedBy":   "Pulumi",
+	})
+
+	// ExtendedColumns (The "Backpack" for provider-specific data)
+	builder.WithExtension("aws:instance_lifecycle", "normal")
+	builder.WithExtension("aws:tenancy", "default")
+	builder.WithExtension("aws:purchase_option", "Reserved")
+	builder.WithExtension("pulumi:stack", "production")
+	builder.WithExtension("pulumi:project", "web-infrastructure")
 }

--- a/proto/pulumicost/v1/enums.proto
+++ b/proto/pulumicost/v1/enums.proto
@@ -32,10 +32,56 @@ enum FocusChargeCategory {
 }
 
 // FocusPricingCategory represents the pricing model applied.
+// FOCUS 1.2 Section 2.4: Pricing Category
 enum FocusPricingCategory {
   FOCUS_PRICING_CATEGORY_UNSPECIFIED = 0;
   FOCUS_PRICING_CATEGORY_STANDARD = 1;
   FOCUS_PRICING_CATEGORY_COMMITTED = 2;
   FOCUS_PRICING_CATEGORY_DYNAMIC = 3;
   FOCUS_PRICING_CATEGORY_OTHER = 4;
+}
+
+// FocusChargeClass represents the classification of charges.
+// FOCUS 1.2 Section 2.4: Charge Class (New in 1.0+)
+enum FocusChargeClass {
+  FOCUS_CHARGE_CLASS_UNSPECIFIED = 0;
+  FOCUS_CHARGE_CLASS_REGULAR = 1;
+  FOCUS_CHARGE_CLASS_CORRECTION = 2;
+}
+
+// FocusChargeFrequency represents how often a charge is applied.
+// FOCUS 1.2 Section 2.4: Charge Frequency
+enum FocusChargeFrequency {
+  FOCUS_CHARGE_FREQUENCY_UNSPECIFIED = 0;
+  FOCUS_CHARGE_FREQUENCY_ONE_TIME = 1;
+  FOCUS_CHARGE_FREQUENCY_RECURRING = 2;
+  FOCUS_CHARGE_FREQUENCY_USAGE_BASED = 3;
+}
+
+// FocusCommitmentDiscountCategory represents the type of commitment discount.
+// FOCUS 1.2 Section 2.6: Commitment Discounts
+enum FocusCommitmentDiscountCategory {
+  FOCUS_COMMITMENT_DISCOUNT_CATEGORY_UNSPECIFIED = 0;
+  FOCUS_COMMITMENT_DISCOUNT_CATEGORY_SPEND = 1;
+  FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE = 2;
+}
+
+// FocusCommitmentDiscountStatus represents the utilization status of a
+// commitment discount. FOCUS 1.2 Section 3.17: Commitment Discount Status
+enum FocusCommitmentDiscountStatus {
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED = 0;
+  // Used: Charges utilizing a specific commitment discount amount.
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_USED = 1;
+  // Unused: Charges representing the unused portion of a commitment discount.
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED = 2;
+}
+
+// FocusCapacityReservationStatus represents the utilization status of a
+// capacity reservation. FOCUS 1.2 Section 3.7: Capacity Reservation Status
+enum FocusCapacityReservationStatus {
+  FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED = 0;
+  // Used: Charges utilizing a specific capacity reservation amount.
+  FOCUS_CAPACITY_RESERVATION_STATUS_USED = 1;
+  // Unused: Charges representing the unused portion of a capacity reservation.
+  FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED = 2;
 }

--- a/proto/pulumicost/v1/focus.proto
+++ b/proto/pulumicost/v1/focus.proto
@@ -8,45 +8,266 @@ import "pulumicost/v1/enums.proto";
 option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto;pbc";
 
 // FocusCostRecord represents a single cost line item normalized to the
-// FinOps FOCUS 1.2 specification.
+// FinOps FOCUS 1.2 specification. All field names follow FOCUS naming conventions.
+// Reference: https://focus.finops.org
 message FocusCostRecord {
-  // --- Identity & Hierarchy ---
+  // ==========================================================================
+  // Identity & Hierarchy (FOCUS 1.2 Section 2.1)
+  // ==========================================================================
+
+  // ProviderName: The name of the cloud provider (e.g., "AWS", "Azure", "GCP").
   string provider_name = 1;
+
+  // BillingAccountId: The identifier for the billing account.
   string billing_account_id = 2;
+
+  // BillingAccountName: The display name for the billing account.
   string billing_account_name = 3;
-  
-  // --- Time ---
+
+  // SubAccountId: The identifier for the sub-account (e.g., AWS Account ID,
+  // Azure Subscription ID, GCP Project ID).
+  string sub_account_id = 24;
+
+  // SubAccountName: The display name for the sub-account.
+  string sub_account_name = 25;
+
+  // BillingAccountType: Provider-assigned name to identify the type of billing
+  // account. FOCUS 1.2 Section 3.3: Billing Account Type (CONDITIONAL).
+  string billing_account_type = 42;
+
+  // SubAccountType: Provider-assigned identifier for sub-account classification.
+  // FOCUS 1.2 Section 3.45: Sub Account Type (CONDITIONAL).
+  string sub_account_type = 43;
+
+  // ==========================================================================
+  // Billing Period (FOCUS 1.2 Section 2.2)
+  // ==========================================================================
+
+  // BillingPeriodStart: The start date/time of the billing period.
+  google.protobuf.Timestamp billing_period_start = 26;
+
+  // BillingPeriodEnd: The end date/time of the billing period.
+  google.protobuf.Timestamp billing_period_end = 27;
+
+  // BillingCurrency: The currency used for billing (ISO 4217 code).
+  string billing_currency = 18;
+
+  // ==========================================================================
+  // Charge Period (FOCUS 1.2 Section 2.3)
+  // ==========================================================================
+
+  // ChargePeriodStart: The start date/time when the charge was incurred.
   google.protobuf.Timestamp charge_period_start = 4;
+
+  // ChargePeriodEnd: The end date/time when the charge was incurred.
   google.protobuf.Timestamp charge_period_end = 5;
 
-  // --- Service & Product ---
-  FocusServiceCategory service_category = 6;
-  string service_name = 7;
-  string resource_id = 12;
-  string resource_name = 13;
-  string sku_id = 14;
-  string region_id = 10;
-  string region_name = 11;
+  // ==========================================================================
+  // Charge Details (FOCUS 1.2 Section 2.4)
+  // ==========================================================================
 
-  // --- Charge Details ---
+  // ChargeCategory: The nature of the charge (Usage, Purchase, Credit, etc.).
   FocusChargeCategory charge_category = 8;
+
+  // ChargeClass: Classification of the charge (Regular, Correction).
+  // New in FOCUS 1.0+.
+  FocusChargeClass charge_class = 28;
+
+  // ChargeDescription: A human-readable description of the charge.
+  string charge_description = 29;
+
+  // ChargeFrequency: How often the charge is applied (OneTime, Recurring, UsageBased).
+  FocusChargeFrequency charge_frequency = 30;
+
+  // ==========================================================================
+  // Pricing Details (FOCUS 1.2 Section 2.5)
+  // ==========================================================================
+
+  // PricingCategory: The pricing model applied (Standard, Committed, Dynamic).
   FocusPricingCategory pricing_category = 9;
 
-  // --- Financials ---
+  // PricingQuantity: The quantity used for pricing calculations.
+  double pricing_quantity = 31;
+
+  // PricingUnit: The unit of measure for pricing (e.g., "Hours", "GB").
+  string pricing_unit = 32;
+
+  // ListUnitPrice: The published unit price before any discounts.
+  double list_unit_price = 33;
+
+  // PricingCurrency: Currency for pricing-related columns when different from
+  // billing currency. FOCUS 1.2 Section 3.34: Pricing Currency (CONDITIONAL).
+  // Format: ISO 4217 currency code.
+  string pricing_currency = 51;
+
+  // PricingCurrencyContractedUnitPrice: Contracted unit price denominated in
+  // pricing currency. FOCUS 1.2 Section 3.35 (CONDITIONAL).
+  double pricing_currency_contracted_unit_price = 52;
+
+  // PricingCurrencyEffectiveCost: Effective cost denominated in pricing
+  // currency. FOCUS 1.2 Section 3.36 (CONDITIONAL).
+  double pricing_currency_effective_cost = 53;
+
+  // PricingCurrencyListUnitPrice: List unit price denominated in pricing
+  // currency. FOCUS 1.2 Section 3.37 (CONDITIONAL).
+  double pricing_currency_list_unit_price = 54;
+
+  // ==========================================================================
+  // Service & Product (FOCUS 1.2 Section 2.6)
+  // ==========================================================================
+
+  // ServiceCategory: The category of the service (Compute, Storage, Network, etc.).
+  FocusServiceCategory service_category = 6;
+
+  // ServiceName: The name of the service (e.g., "Amazon EC2", "Azure VMs").
+  string service_name = 7;
+
+  // ServiceSubcategory: Granular service classification supporting functional
+  // categorization. FOCUS 1.2 Section 3.43: Service Subcategory (CONDITIONAL).
+  string service_subcategory = 56;
+
+  // Publisher: Entity that published the service or product.
+  // FOCUS 1.2 Section 3.39: Publisher (CONDITIONAL).
+  string publisher = 55;
+
+  // ==========================================================================
+  // Resource Details (FOCUS 1.2 Section 2.7)
+  // ==========================================================================
+
+  // ResourceId: The unique identifier for the resource.
+  string resource_id = 12;
+
+  // ResourceName: The display name of the resource.
+  string resource_name = 13;
+
+  // ResourceType: The type of resource (e.g., "m5.large", "Standard_D2s_v3").
+  string resource_type = 34;
+
+  // ==========================================================================
+  // SKU Details (FOCUS 1.2 Section 2.8)
+  // ==========================================================================
+
+  // SkuId: The identifier for the SKU.
+  string sku_id = 14;
+
+  // SkuPriceId: The identifier for the specific SKU price.
+  string sku_price_id = 35;
+
+  // SkuMeter: Provider-assigned meter identifier for the SKU.
+  // FOCUS 1.2 Section 3.46: SKU Meter (CONDITIONAL).
+  string sku_meter = 57;
+
+  // SkuPriceDetails: Additional provider-specific pricing details.
+  // FOCUS 1.2 Section 3.48: SKU Price Details (CONDITIONAL).
+  string sku_price_details = 58;
+
+  // ==========================================================================
+  // Location (FOCUS 1.2 Section 2.9)
+  // ==========================================================================
+
+  // RegionId: The identifier for the region (e.g., "us-east-1", "eastus").
+  string region_id = 10;
+
+  // RegionName: The display name of the region.
+  string region_name = 11;
+
+  // AvailabilityZone: The availability zone within the region (conditional).
+  string availability_zone = 36;
+
+  // ==========================================================================
+  // Financial Amounts (FOCUS 1.2 Section 2.10)
+  // ==========================================================================
+
+  // BilledCost: The amount billed for the charge.
   double billed_cost = 15;
+
+  // ListCost: The cost at list price before any discounts.
   double list_cost = 16;
+
+  // EffectiveCost: The actual cost after all discounts and adjustments.
   double effective_cost = 17;
-  string currency = 18;
+
+  // ContractedCost: Cost calculated by multiplying contracted unit price and
+  // pricing quantity. FOCUS 1.2 Section 3.20: Contracted Cost (MANDATORY).
+  // Constraint: Must equal ContractedUnitPrice × PricingQuantity when both
+  // are present and ChargeClass is not "Correction".
+  double contracted_cost = 41;
+
+  // ContractedUnitPrice: Agreed-upon unit price per pricing unit for the
+  // associated SKU. FOCUS 1.2 Section 3.21: Contracted Unit Price (CONDITIONAL).
+  double contracted_unit_price = 50;
+
+  // ==========================================================================
+  // Consumption/Usage (FOCUS 1.2 Section 2.11)
+  // ==========================================================================
+
+  // ConsumedQuantity: The amount of usage consumed.
+  double consumed_quantity = 20;
+
+  // ConsumedUnit: The unit of measure for consumption (e.g., "Hours", "GB").
+  string consumed_unit = 21;
+
+  // ==========================================================================
+  // Commitment Discounts (FOCUS 1.2 Section 2.12)
+  // ==========================================================================
+
+  // CommitmentDiscountCategory: The type of commitment discount (Spend, Usage).
+  FocusCommitmentDiscountCategory commitment_discount_category = 37;
+
+  // CommitmentDiscountId: The identifier for the commitment discount.
+  string commitment_discount_id = 38;
+
+  // CommitmentDiscountName: The display name of the commitment discount.
+  string commitment_discount_name = 39;
+
+  // CommitmentDiscountQuantity: Amount of commitment discount purchased or
+  // accounted for. FOCUS 1.2 Section 3.14 (CONDITIONAL).
+  double commitment_discount_quantity = 46;
+
+  // CommitmentDiscountStatus: Utilization status of commitment discount.
+  // FOCUS 1.2 Section 3.17 (CONDITIONAL). Required when CommitmentDiscountId
+  // is not null and ChargeCategory is "Usage".
+  FocusCommitmentDiscountStatus commitment_discount_status = 47;
+
+  // CommitmentDiscountType: Provider-assigned identifier for the type of
+  // commitment discount applied. FOCUS 1.2 Section 3.18 (CONDITIONAL).
+  string commitment_discount_type = 48;
+
+  // CommitmentDiscountUnit: Provider-specified measurement unit for commitment
+  // discount quantity. FOCUS 1.2 Section 3.19 (CONDITIONAL).
+  string commitment_discount_unit = 49;
+
+  // ==========================================================================
+  // Capacity Reservation (FOCUS 1.2 Sections 3.6, 3.7)
+  // ==========================================================================
+
+  // CapacityReservationId: Identifier assigned to a capacity reservation by
+  // the provider. FOCUS 1.2 Section 3.6 (CONDITIONAL).
+  string capacity_reservation_id = 44;
+
+  // CapacityReservationStatus: Utilization status of capacity reservation.
+  // FOCUS 1.2 Section 3.7 (CONDITIONAL). Required when CapacityReservationId
+  // is not null and ChargeCategory is "Usage".
+  FocusCapacityReservationStatus capacity_reservation_status = 45;
+
+  // ==========================================================================
+  // Invoice Details (FOCUS 1.2 Section 2.13)
+  // ==========================================================================
+
+  // InvoiceId: The identifier for the invoice. Critical for reconciliation.
   string invoice_id = 19;
 
-  // --- Usage ---
-  double usage_quantity = 20;
-  string usage_unit = 21;
+  // InvoiceIssuer: The entity that issued the invoice.
+  string invoice_issuer = 40;
 
-  // --- Metadata & Extension ---
+  // ==========================================================================
+  // Metadata & Extension (FOCUS 1.2 Section 2.14)
+  // ==========================================================================
+
+  // Tags: User-defined key-value pairs for resource tagging.
   map<string, string> tags = 22;
-  
-  // The "Backpack": Supports future FOCUS columns or provider-specific
-  // extensions without requiring a schema update.
+
+  // ExtendedColumns: The "Backpack" - supports future FOCUS columns or
+  // provider-specific extensions without requiring a schema update.
   map<string, string> extended_columns = 23;
 }

--- a/renovate.json
+++ b/renovate.json
@@ -81,16 +81,6 @@
   "automergeStrategy": "auto",
   "platformAutomerge": false,
   "hostRules": [],
-  "onboarding": true,
-  "requireConfig": "optional",
-  "onboardingConfig": {
-    "extends": [
-      "config:recommended"
-    ]
-  },
   "configMigration": true,
-  "binarySource": "global",
-  "cacheDir": "/tmp/renovate/cache",
-  "baseDir": "/tmp/renovate/repos",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>"
 }

--- a/scripts/audit_focus_columns.go
+++ b/scripts/audit_focus_columns.go
@@ -1,0 +1,182 @@
+//go:build ignore
+
+// audit_focus_columns.go verifies that all 57 FOCUS 1.2 columns are implemented
+// in the FocusCostRecord proto message.
+//
+// Usage: go run scripts/audit_focus_columns.go
+//
+// Reference: https://focus.finops.org/focus-specification/v1-2/
+package main
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// Column represents a FOCUS 1.2 column specification.
+type Column struct {
+	Name       string // FOCUS column name (PascalCase)
+	ProtoField string // Expected proto field name (snake_case)
+	Level      string // Mandatory, Recommended, or Conditional
+	Category   string // Column category for grouping
+}
+
+// FOCUS 1.2 columns: 14 mandatory, 1 recommended, 42 conditional = 57 total
+var focus12Columns = []Column{
+	// MANDATORY (14)
+	{"BilledCost", "billed_cost", "Mandatory", "Financial"},
+	{"BillingAccountId", "billing_account_id", "Mandatory", "Identity"},
+	{"BillingAccountName", "billing_account_name", "Mandatory", "Identity"},
+	{"BillingCurrency", "billing_currency", "Mandatory", "Financial"},
+	{"BillingPeriodEnd", "billing_period_end", "Mandatory", "Billing Period"},
+	{"BillingPeriodStart", "billing_period_start", "Mandatory", "Billing Period"},
+	{"ChargeCategory", "charge_category", "Mandatory", "Charge"},
+	{"ChargeClass", "charge_class", "Mandatory", "Charge"},
+	{"ChargeDescription", "charge_description", "Mandatory", "Charge"},
+	{"ChargePeriodEnd", "charge_period_end", "Mandatory", "Charge Period"},
+	{"ChargePeriodStart", "charge_period_start", "Mandatory", "Charge Period"},
+	{"ContractedCost", "contracted_cost", "Mandatory", "Financial"},
+	{"ProviderName", "provider_name", "Mandatory", "Identity"},
+	{"ServiceName", "service_name", "Mandatory", "Service"},
+
+	// RECOMMENDED (1)
+	{"ChargeFrequency", "charge_frequency", "Recommended", "Charge"},
+
+	// CONDITIONAL (42)
+	{"AvailabilityZone", "availability_zone", "Conditional", "Location"},
+	{"BillingAccountType", "billing_account_type", "Conditional", "Identity"},
+	{"CapacityReservationId", "capacity_reservation_id", "Conditional", "Capacity Reservation"},
+	{"CapacityReservationStatus", "capacity_reservation_status", "Conditional", "Capacity Reservation"},
+	{"CommitmentDiscountCategory", "commitment_discount_category", "Conditional", "Commitment Discount"},
+	{"CommitmentDiscountId", "commitment_discount_id", "Conditional", "Commitment Discount"},
+	{"CommitmentDiscountName", "commitment_discount_name", "Conditional", "Commitment Discount"},
+	{"CommitmentDiscountQuantity", "commitment_discount_quantity", "Conditional", "Commitment Discount"},
+	{"CommitmentDiscountStatus", "commitment_discount_status", "Conditional", "Commitment Discount"},
+	{"CommitmentDiscountType", "commitment_discount_type", "Conditional", "Commitment Discount"},
+	{"CommitmentDiscountUnit", "commitment_discount_unit", "Conditional", "Commitment Discount"},
+	{"ConsumedQuantity", "consumed_quantity", "Conditional", "Usage"},
+	{"ConsumedUnit", "consumed_unit", "Conditional", "Usage"},
+	{"ContractedUnitPrice", "contracted_unit_price", "Conditional", "Financial"},
+	{"EffectiveCost", "effective_cost", "Conditional", "Financial"},
+	{"InvoiceId", "invoice_id", "Conditional", "Invoice"},
+	{"InvoiceIssuer", "invoice_issuer", "Conditional", "Invoice"},
+	{"ListCost", "list_cost", "Conditional", "Financial"},
+	{"ListUnitPrice", "list_unit_price", "Conditional", "Pricing"},
+	{"PricingCategory", "pricing_category", "Conditional", "Pricing"},
+	{"PricingCurrency", "pricing_currency", "Conditional", "Pricing"},
+	{"PricingCurrencyContractedUnitPrice", "pricing_currency_contracted_unit_price", "Conditional", "Pricing"},
+	{"PricingCurrencyEffectiveCost", "pricing_currency_effective_cost", "Conditional", "Pricing"},
+	{"PricingCurrencyListUnitPrice", "pricing_currency_list_unit_price", "Conditional", "Pricing"},
+	{"PricingQuantity", "pricing_quantity", "Conditional", "Pricing"},
+	{"PricingUnit", "pricing_unit", "Conditional", "Pricing"},
+	{"Publisher", "publisher", "Conditional", "Service"},
+	{"RegionId", "region_id", "Conditional", "Location"},
+	{"RegionName", "region_name", "Conditional", "Location"},
+	{"ResourceId", "resource_id", "Conditional", "Resource"},
+	{"ResourceName", "resource_name", "Conditional", "Resource"},
+	{"ResourceType", "resource_type", "Conditional", "Resource"},
+	{"ServiceCategory", "service_category", "Conditional", "Service"},
+	{"ServiceSubcategory", "service_subcategory", "Conditional", "Service"},
+	{"SkuId", "sku_id", "Conditional", "SKU"},
+	{"SkuMeter", "sku_meter", "Conditional", "SKU"},
+	{"SkuPriceDetails", "sku_price_details", "Conditional", "SKU"},
+	{"SkuPriceId", "sku_price_id", "Conditional", "SKU"},
+	{"SubAccountId", "sub_account_id", "Conditional", "Identity"},
+	{"SubAccountName", "sub_account_name", "Conditional", "Identity"},
+	{"SubAccountType", "sub_account_type", "Conditional", "Identity"},
+	{"Tags", "tags", "Conditional", "Metadata"},
+}
+
+func main() {
+	fmt.Println("FOCUS 1.2 Column Audit")
+	fmt.Println("======================")
+	fmt.Println()
+
+	recordType := reflect.TypeOf(pbc.FocusCostRecord{})
+
+	var missing []Column
+	var present []Column
+	mandatoryMissing := 0
+
+	for _, col := range focus12Columns {
+		goFieldName := snakeToPascal(col.ProtoField)
+		if _, found := recordType.FieldByName(goFieldName); found {
+			present = append(present, col)
+		} else {
+			missing = append(missing, col)
+			if col.Level == "Mandatory" {
+				mandatoryMissing++
+			}
+		}
+	}
+
+	// Summary
+	fmt.Printf("Total columns: %d\n", len(focus12Columns))
+	fmt.Printf("Implemented: %d\n", len(present))
+	fmt.Printf("Missing: %d\n", len(missing))
+	fmt.Println()
+
+	// Breakdown by level
+	mandatoryCount := 0
+	recommendedCount := 0
+	conditionalCount := 0
+	for _, col := range focus12Columns {
+		switch col.Level {
+		case "Mandatory":
+			mandatoryCount++
+		case "Recommended":
+			recommendedCount++
+		case "Conditional":
+			conditionalCount++
+		}
+	}
+
+	mandatoryPresent := 0
+	recommendedPresent := 0
+	for _, col := range present {
+		switch col.Level {
+		case "Mandatory":
+			mandatoryPresent++
+		case "Recommended":
+			recommendedPresent++
+		}
+	}
+
+	conditionalPresent := len(present) - mandatoryPresent - recommendedPresent
+	fmt.Printf("Mandatory: %d/%d\n", mandatoryPresent, mandatoryCount)
+	fmt.Printf("Recommended: %d/%d\n", recommendedPresent, recommendedCount)
+	fmt.Printf("Conditional: %d/%d\n", conditionalPresent, conditionalCount)
+	fmt.Println()
+
+	if len(missing) > 0 {
+		fmt.Println("❌ Missing columns:")
+		for _, col := range missing {
+			fmt.Printf("  - %s (%s) [%s]\n", col.Name, col.ProtoField, col.Level)
+		}
+		fmt.Println()
+
+		if mandatoryMissing > 0 {
+			fmt.Printf("⚠️  %d MANDATORY column(s) missing!\n", mandatoryMissing)
+		}
+
+		os.Exit(1)
+	}
+
+	fmt.Println("✅ All FOCUS 1.2 columns are implemented")
+	os.Exit(0)
+}
+
+// snakeToPascal converts snake_case to PascalCase for Go struct field lookup.
+func snakeToPascal(s string) string {
+	parts := strings.Split(s, "_")
+	for i, part := range parts {
+		if len(part) > 0 {
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	return strings.Join(parts, "")
+}

--- a/sdk/go/pluginsdk/focus_builder.go
+++ b/sdk/go/pluginsdk/focus_builder.go
@@ -22,7 +22,7 @@ func NewFocusRecordBuilder() *FocusRecordBuilder {
 	}
 }
 
-// WithIdentity sets the identity and hierarchy fields.
+// WithIdentity sets the identity and hierarchy fields per FOCUS 1.2 Section 2.1.
 func (b *FocusRecordBuilder) WithIdentity(
 	providerName, billingAccountID, billingAccountName string,
 ) *FocusRecordBuilder {
@@ -32,20 +32,35 @@ func (b *FocusRecordBuilder) WithIdentity(
 	return b
 }
 
-// WithChargePeriod sets the start and end time of the charge.
+// WithSubAccount sets the sub-account fields (e.g., AWS Account, Azure Subscription, GCP Project) per FOCUS 1.2 Section 2.1.
+func (b *FocusRecordBuilder) WithSubAccount(subAccountID, subAccountName string) *FocusRecordBuilder {
+	b.record.SubAccountId = subAccountID
+	b.record.SubAccountName = subAccountName
+	return b
+}
+
+// WithBillingPeriod sets the billing period start/end and currency per FOCUS 1.2 Section 2.2.
+func (b *FocusRecordBuilder) WithBillingPeriod(start, end time.Time, currency string) *FocusRecordBuilder {
+	b.record.BillingPeriodStart = timestamppb.New(start)
+	b.record.BillingPeriodEnd = timestamppb.New(end)
+	b.record.BillingCurrency = currency
+	return b
+}
+
+// WithChargePeriod sets the start and end time of the charge per FOCUS 1.2 Section 2.3.
 func (b *FocusRecordBuilder) WithChargePeriod(start, end time.Time) *FocusRecordBuilder {
 	b.record.ChargePeriodStart = timestamppb.New(start)
 	b.record.ChargePeriodEnd = timestamppb.New(end)
 	return b
 }
 
-// WithServiceCategory sets the service category.
+// WithServiceCategory sets the service category per FOCUS 1.2 Section 2.6.
 func (b *FocusRecordBuilder) WithServiceCategory(category pbc.FocusServiceCategory) *FocusRecordBuilder {
 	b.record.ServiceCategory = category
 	return b
 }
 
-// WithChargeDetails sets the charge and pricing categories.
+// WithChargeDetails sets the charge category and pricing category per FOCUS 1.2 Section 2.4.
 func (b *FocusRecordBuilder) WithChargeDetails(
 	chargeCat pbc.FocusChargeCategory,
 	pricingCat pbc.FocusPricingCategory,
@@ -55,7 +70,27 @@ func (b *FocusRecordBuilder) WithChargeDetails(
 	return b
 }
 
-// WithFinancials sets the cost amounts and currency.
+// WithChargeClassification sets the charge class, description, and frequency per FOCUS 1.2 Section 2.4.
+func (b *FocusRecordBuilder) WithChargeClassification(
+	chargeClass pbc.FocusChargeClass,
+	description string,
+	frequency pbc.FocusChargeFrequency,
+) *FocusRecordBuilder {
+	b.record.ChargeClass = chargeClass
+	b.record.ChargeDescription = description
+	b.record.ChargeFrequency = frequency
+	return b
+}
+
+// WithPricing sets the pricing quantity, unit, and list unit price per FOCUS 1.2 Section 2.5.
+func (b *FocusRecordBuilder) WithPricing(quantity float64, unit string, listUnitPrice float64) *FocusRecordBuilder {
+	b.record.PricingQuantity = quantity
+	b.record.PricingUnit = unit
+	b.record.ListUnitPrice = listUnitPrice
+	return b
+}
+
+// WithFinancials sets the cost amounts and currency per FOCUS 1.2 Section 2.10.
 func (b *FocusRecordBuilder) WithFinancials(
 	billed, list, effective float64,
 	currency, invoiceID string,
@@ -63,21 +98,197 @@ func (b *FocusRecordBuilder) WithFinancials(
 	b.record.BilledCost = billed
 	b.record.ListCost = list
 	b.record.EffectiveCost = effective
-	b.record.Currency = currency
+	b.record.BillingCurrency = currency
 	b.record.InvoiceId = invoiceID
 	return b
 }
 
-// WithUsage sets the usage quantity and unit.
+// WithUsage sets the consumed quantity and unit per FOCUS 1.2 Section 2.11.
 func (b *FocusRecordBuilder) WithUsage(quantity float64, unit string) *FocusRecordBuilder {
-	b.record.UsageQuantity = quantity
-	b.record.UsageUnit = unit
+	b.record.ConsumedQuantity = quantity
+	b.record.ConsumedUnit = unit
 	return b
 }
 
-// WithExtension adds a key-value pair to the extended columns (Backpack).
+// WithResource sets the resource details per FOCUS 1.2 Section 2.7.
+func (b *FocusRecordBuilder) WithResource(resourceID, resourceName, resourceType string) *FocusRecordBuilder {
+	b.record.ResourceId = resourceID
+	b.record.ResourceName = resourceName
+	b.record.ResourceType = resourceType
+	return b
+}
+
+// WithService sets the service details per FOCUS 1.2 Section 2.6.
+func (b *FocusRecordBuilder) WithService(
+	category pbc.FocusServiceCategory,
+	serviceName string,
+) *FocusRecordBuilder {
+	b.record.ServiceCategory = category
+	b.record.ServiceName = serviceName
+	return b
+}
+
+// WithSKU sets the SKU details per FOCUS 1.2 Section 2.8.
+func (b *FocusRecordBuilder) WithSKU(skuID, skuPriceID string) *FocusRecordBuilder {
+	b.record.SkuId = skuID
+	b.record.SkuPriceId = skuPriceID
+	return b
+}
+
+// WithLocation sets the region and availability zone per FOCUS 1.2 Section 2.9.
+func (b *FocusRecordBuilder) WithLocation(regionID, regionName, availabilityZone string) *FocusRecordBuilder {
+	b.record.RegionId = regionID
+	b.record.RegionName = regionName
+	b.record.AvailabilityZone = availabilityZone
+	return b
+}
+
+// WithCommitmentDiscount sets the commitment discount details per FOCUS 1.2 Section 2.12.
+func (b *FocusRecordBuilder) WithCommitmentDiscount(
+	category pbc.FocusCommitmentDiscountCategory,
+	discountID, discountName string,
+) *FocusRecordBuilder {
+	b.record.CommitmentDiscountCategory = category
+	b.record.CommitmentDiscountId = discountID
+	b.record.CommitmentDiscountName = discountName
+	return b
+}
+
+// WithInvoice sets the invoice details per FOCUS 1.2 Section 2.13.
+func (b *FocusRecordBuilder) WithInvoice(invoiceID, invoiceIssuer string) *FocusRecordBuilder {
+	b.record.InvoiceId = invoiceID
+	b.record.InvoiceIssuer = invoiceIssuer
+	return b
+}
+
+// WithTag adds a single tag key-value pair per FOCUS 1.2 Section 2.14.
+func (b *FocusRecordBuilder) WithTag(key, value string) *FocusRecordBuilder {
+	b.record.Tags[key] = value
+	return b
+}
+
+// WithTags sets multiple tags at once per FOCUS 1.2 Section 2.14.
+func (b *FocusRecordBuilder) WithTags(tags map[string]string) *FocusRecordBuilder {
+	for k, v := range tags {
+		b.record.Tags[k] = v
+	}
+	return b
+}
+
+// WithExtension adds a key-value pair to the extended columns (Backpack) per FOCUS 1.2 Section 2.14.
 func (b *FocusRecordBuilder) WithExtension(key, value string) *FocusRecordBuilder {
 	b.record.ExtendedColumns[key] = value
+	return b
+}
+
+// =============================================================================
+// FOCUS 1.2 New Column Builder Methods (19 new columns)
+// =============================================================================
+
+// WithContractedCost sets the contracted cost per FOCUS 1.2 Section 3.20.
+// This is a MANDATORY field representing the cost calculated by multiplying
+// contracted unit price and pricing quantity.
+func (b *FocusRecordBuilder) WithContractedCost(cost float64) *FocusRecordBuilder {
+	b.record.ContractedCost = cost
+	return b
+}
+
+// WithBillingAccountType sets the billing account type per FOCUS 1.2 Section 3.3.
+// This is a CONDITIONAL field representing the provider-assigned name to identify
+// the type of billing account.
+func (b *FocusRecordBuilder) WithBillingAccountType(accountType string) *FocusRecordBuilder {
+	b.record.BillingAccountType = accountType
+	return b
+}
+
+// WithSubAccountType sets the sub-account type per FOCUS 1.2 Section 3.45.
+// This is a CONDITIONAL field representing the provider-assigned identifier
+// for sub-account classification.
+func (b *FocusRecordBuilder) WithSubAccountType(accountType string) *FocusRecordBuilder {
+	b.record.SubAccountType = accountType
+	return b
+}
+
+// WithCapacityReservation sets the capacity reservation details per FOCUS 1.2 Sections 3.6, 3.7.
+// This includes the capacity reservation ID and its utilization status.
+// Both fields are CONDITIONAL.
+func (b *FocusRecordBuilder) WithCapacityReservation(
+	reservationID string,
+	status pbc.FocusCapacityReservationStatus,
+) *FocusRecordBuilder {
+	b.record.CapacityReservationId = reservationID
+	b.record.CapacityReservationStatus = status
+	return b
+}
+
+// WithCommitmentDiscountDetails sets extended commitment discount details per FOCUS 1.2.
+// Includes quantity (Section 3.14), status (Section 3.17), type (Section 3.18),
+// and unit (Section 3.19). All fields are CONDITIONAL.
+func (b *FocusRecordBuilder) WithCommitmentDiscountDetails(
+	quantity float64,
+	status pbc.FocusCommitmentDiscountStatus,
+	discountType string,
+	unit string,
+) *FocusRecordBuilder {
+	b.record.CommitmentDiscountQuantity = quantity
+	b.record.CommitmentDiscountStatus = status
+	b.record.CommitmentDiscountType = discountType
+	b.record.CommitmentDiscountUnit = unit
+	return b
+}
+
+// WithContractedUnitPrice sets the contracted unit price per FOCUS 1.2 Section 3.21.
+// This is a CONDITIONAL field representing the agreed-upon unit price per
+// pricing unit for the associated SKU.
+func (b *FocusRecordBuilder) WithContractedUnitPrice(price float64) *FocusRecordBuilder {
+	b.record.ContractedUnitPrice = price
+	return b
+}
+
+// WithPricingCurrency sets the pricing currency per FOCUS 1.2 Section 3.34.
+// This is a CONDITIONAL field used when pricing is in a different currency
+// than billing. Format: ISO 4217 currency code.
+func (b *FocusRecordBuilder) WithPricingCurrency(currency string) *FocusRecordBuilder {
+	b.record.PricingCurrency = currency
+	return b
+}
+
+// WithPricingCurrencyPrices sets pricing currency amounts per FOCUS 1.2.
+// Includes contracted unit price (Section 3.35), effective cost (Section 3.36),
+// and list unit price (Section 3.37). All fields are CONDITIONAL.
+func (b *FocusRecordBuilder) WithPricingCurrencyPrices(
+	contractedUnitPrice float64,
+	effectiveCost float64,
+	listUnitPrice float64,
+) *FocusRecordBuilder {
+	b.record.PricingCurrencyContractedUnitPrice = contractedUnitPrice
+	b.record.PricingCurrencyEffectiveCost = effectiveCost
+	b.record.PricingCurrencyListUnitPrice = listUnitPrice
+	return b
+}
+
+// WithPublisher sets the publisher per FOCUS 1.2 Section 3.39.
+// This is a CONDITIONAL field representing the entity that published the
+// service or product.
+func (b *FocusRecordBuilder) WithPublisher(publisher string) *FocusRecordBuilder {
+	b.record.Publisher = publisher
+	return b
+}
+
+// WithServiceSubcategory sets the service subcategory per FOCUS 1.2 Section 3.43.
+// This is a CONDITIONAL field providing granular service classification
+// supporting functional categorization.
+func (b *FocusRecordBuilder) WithServiceSubcategory(subcategory string) *FocusRecordBuilder {
+	b.record.ServiceSubcategory = subcategory
+	return b
+}
+
+// WithSkuDetails sets SKU meter and price details per FOCUS 1.2 Sections 3.46, 3.48.
+// SkuMeter is the provider-assigned meter identifier, and SkuPriceDetails contains
+// additional pricing information. Both fields are CONDITIONAL.
+func (b *FocusRecordBuilder) WithSkuDetails(meter, priceDetails string) *FocusRecordBuilder {
+	b.record.SkuMeter = meter
+	b.record.SkuPriceDetails = priceDetails
 	return b
 }
 

--- a/sdk/go/pluginsdk/focus_builder_test.go
+++ b/sdk/go/pluginsdk/focus_builder_test.go
@@ -9,17 +9,26 @@ import (
 )
 
 func TestFocusRecordBuilder_Build_HappyPath(t *testing.T) {
-	start := time.Now().Add(-24 * time.Hour)
-	end := time.Now()
+	now := time.Now()
+	billingStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	billingEnd := billingStart.AddDate(0, 1, 0)
+	chargeStart := now.Add(-24 * time.Hour)
+	chargeEnd := now
 
 	builder := pluginsdk.NewFocusRecordBuilder()
-	builder.WithIdentity("provider-aws", "acc-123", "My Account")
-	builder.WithChargePeriod(start, end)
-	builder.WithServiceCategory(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE)
+	builder.WithIdentity("AWS", "acc-123", "My Account")
+	builder.WithBillingPeriod(billingStart, billingEnd, "USD")
+	builder.WithChargePeriod(chargeStart, chargeEnd)
 	builder.WithChargeDetails(
 		pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
 		pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
 	)
+	builder.WithChargeClassification(
+		pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+		"EC2 Instance Usage",
+		pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+	)
+	builder.WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE, "Amazon EC2")
 	builder.WithFinancials(10.5, 12.0, 10.0, "USD", "inv-001")
 	builder.WithUsage(1.0, "Hour")
 
@@ -51,17 +60,7 @@ func TestFocusRecordBuilder_Build_MissingFields(t *testing.T) {
 }
 
 func TestFocusRecordBuilder_WithExtension(t *testing.T) {
-	builder := pluginsdk.NewFocusRecordBuilder()
-	// Set mandatory fields
-	builder.WithIdentity("p", "acc", "n")
-	builder.WithChargePeriod(time.Now(), time.Now())
-	builder.WithServiceCategory(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE)
-	builder.WithChargeDetails(
-		pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
-		pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
-	)
-	builder.WithFinancials(1.0, 1.0, 1.0, "USD", "i")
-	builder.WithUsage(1.0, "unit")
+	builder := createValidBuilder()
 
 	builder.WithExtension("MyKey", "MyValue")
 	builder.WithExtension("AnotherKey", "AnotherValue")
@@ -76,5 +75,630 @@ func TestFocusRecordBuilder_WithExtension(t *testing.T) {
 	}
 	if record.GetExtendedColumns()["AnotherKey"] != "AnotherValue" {
 		t.Errorf("Expected AnotherKey=AnotherValue, got %s", record.GetExtendedColumns()["AnotherKey"])
+	}
+}
+
+// =============================================================================
+// FOCUS 1.2 New Column Builder Tests (Phase 5: US3)
+// =============================================================================
+
+// createValidBuilder creates a builder with all mandatory fields set for testing new methods.
+// Updated to include all 14 FOCUS 1.2 mandatory fields.
+func createValidBuilder() *pluginsdk.FocusRecordBuilder {
+	now := time.Now()
+	billingStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	billingEnd := billingStart.AddDate(0, 1, 0)
+
+	builder := pluginsdk.NewFocusRecordBuilder()
+	builder.WithIdentity("AWS", "acc-123", "Account Name")
+	builder.WithBillingPeriod(billingStart, billingEnd, "USD")
+	builder.WithChargePeriod(now.Add(-time.Hour), now)
+	builder.WithChargeDetails(
+		pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+		pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
+	)
+	builder.WithChargeClassification(
+		pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+		"EC2 Instance Usage",
+		pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+	)
+	builder.WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE, "Amazon EC2")
+	builder.WithFinancials(10.0, 12.0, 10.0, "USD", "inv-001")
+	builder.WithUsage(1.0, "Hour")
+	return builder
+}
+
+// TestFocusRecordBuilder_WithContractedCost tests the WithContractedCost builder method.
+func TestFocusRecordBuilder_WithContractedCost(t *testing.T) {
+	tests := []struct {
+		name     string
+		cost     float64
+		expected float64
+	}{
+		{"zero cost", 0.0, 0.0},
+		{"positive cost", 100.50, 100.50},
+		{"large cost", 999999.99, 999999.99},
+		{"small cost", 0.001, 0.001},
+		{"negative cost (credit)", -50.25, -50.25},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithContractedCost(tt.cost)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetContractedCost() != tt.expected {
+				t.Errorf("Expected ContractedCost %f, got %f", tt.expected, record.GetContractedCost())
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithBillingAccountType tests the WithBillingAccountType builder method.
+func TestFocusRecordBuilder_WithBillingAccountType(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType string
+		expected    string
+	}{
+		{"empty type", "", ""},
+		{"enterprise", "Enterprise", "Enterprise"},
+		{"pay as you go", "PayAsYouGo", "PayAsYouGo"},
+		{"linked account", "LinkedAccount", "LinkedAccount"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithBillingAccountType(tt.accountType)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetBillingAccountType() != tt.expected {
+				t.Errorf("Expected BillingAccountType %q, got %q", tt.expected, record.GetBillingAccountType())
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithSubAccountType tests the WithSubAccountType builder method.
+func TestFocusRecordBuilder_WithSubAccountType(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType string
+		expected    string
+	}{
+		{"empty type", "", ""},
+		{"subscription", "Subscription", "Subscription"},
+		{"project", "Project", "Project"},
+		{"account", "Account", "Account"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithSubAccountType(tt.accountType)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetSubAccountType() != tt.expected {
+				t.Errorf("Expected SubAccountType %q, got %q", tt.expected, record.GetSubAccountType())
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithCapacityReservation tests the WithCapacityReservation builder method.
+func TestFocusRecordBuilder_WithCapacityReservation(t *testing.T) {
+	tests := []struct {
+		name           string
+		reservationID  string
+		status         pbc.FocusCapacityReservationStatus
+		expectedID     string
+		expectedStatus pbc.FocusCapacityReservationStatus
+	}{
+		{
+			"empty reservation",
+			"",
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED,
+			"",
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED,
+		},
+		{
+			"used reservation",
+			"cr-12345",
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED,
+			"cr-12345",
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED,
+		},
+		{
+			"unused reservation",
+			"cr-67890",
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED,
+			"cr-67890",
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithCapacityReservation(tt.reservationID, tt.status)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetCapacityReservationId() != tt.expectedID {
+				t.Errorf("Expected CapacityReservationId %q, got %q", tt.expectedID, record.GetCapacityReservationId())
+			}
+			if record.GetCapacityReservationStatus() != tt.expectedStatus {
+				t.Errorf(
+					"Expected CapacityReservationStatus %v, got %v",
+					tt.expectedStatus,
+					record.GetCapacityReservationStatus(),
+				)
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithCommitmentDiscountDetails tests WithCommitmentDiscountDetails.
+func TestFocusRecordBuilder_WithCommitmentDiscountDetails(t *testing.T) {
+	tests := []struct {
+		name             string
+		quantity         float64
+		status           pbc.FocusCommitmentDiscountStatus
+		discountType     string
+		unit             string
+		expectedQuantity float64
+		expectedStatus   pbc.FocusCommitmentDiscountStatus
+		expectedType     string
+		expectedUnit     string
+	}{
+		{
+			"empty details",
+			0.0,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED,
+			"",
+			"",
+			0.0,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED,
+			"",
+			"",
+		},
+		{
+			"used savings plan",
+			100.0,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED,
+			"SavingsPlan",
+			"USD/Hour",
+			100.0,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED,
+			"SavingsPlan",
+			"USD/Hour",
+		},
+		{
+			"unused reserved instance",
+			50.5,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED,
+			"ReservedInstance",
+			"Hours",
+			50.5,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED,
+			"ReservedInstance",
+			"Hours",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithCommitmentDiscountDetails(tt.quantity, tt.status, tt.discountType, tt.unit)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetCommitmentDiscountQuantity() != tt.expectedQuantity {
+				t.Errorf(
+					"Expected CommitmentDiscountQuantity %f, got %f",
+					tt.expectedQuantity,
+					record.GetCommitmentDiscountQuantity(),
+				)
+			}
+			if record.GetCommitmentDiscountStatus() != tt.expectedStatus {
+				t.Errorf(
+					"Expected CommitmentDiscountStatus %v, got %v",
+					tt.expectedStatus,
+					record.GetCommitmentDiscountStatus(),
+				)
+			}
+			if record.GetCommitmentDiscountType() != tt.expectedType {
+				t.Errorf(
+					"Expected CommitmentDiscountType %q, got %q",
+					tt.expectedType,
+					record.GetCommitmentDiscountType(),
+				)
+			}
+			if record.GetCommitmentDiscountUnit() != tt.expectedUnit {
+				t.Errorf(
+					"Expected CommitmentDiscountUnit %q, got %q",
+					tt.expectedUnit,
+					record.GetCommitmentDiscountUnit(),
+				)
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithContractedUnitPrice tests the WithContractedUnitPrice builder method.
+func TestFocusRecordBuilder_WithContractedUnitPrice(t *testing.T) {
+	tests := []struct {
+		name     string
+		price    float64
+		expected float64
+	}{
+		{"zero price", 0.0, 0.0},
+		{"positive price", 0.0023, 0.0023},
+		{"large price", 1500.99, 1500.99},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithContractedUnitPrice(tt.price)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetContractedUnitPrice() != tt.expected {
+				t.Errorf("Expected ContractedUnitPrice %f, got %f", tt.expected, record.GetContractedUnitPrice())
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithPricingCurrency tests the WithPricingCurrency builder method.
+func TestFocusRecordBuilder_WithPricingCurrency(t *testing.T) {
+	tests := []struct {
+		name     string
+		currency string
+		expected string
+	}{
+		{"empty currency", "", ""},
+		{"USD", "USD", "USD"},
+		{"EUR", "EUR", "EUR"},
+		{"GBP", "GBP", "GBP"},
+		{"JPY", "JPY", "JPY"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithPricingCurrency(tt.currency)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetPricingCurrency() != tt.expected {
+				t.Errorf("Expected PricingCurrency %q, got %q", tt.expected, record.GetPricingCurrency())
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithPricingCurrencyPrices tests the WithPricingCurrencyPrices method.
+func TestFocusRecordBuilder_WithPricingCurrencyPrices(t *testing.T) {
+	tests := []struct {
+		name                string
+		contractedUnitPrice float64
+		effectiveCost       float64
+		listUnitPrice       float64
+		expectedContracted  float64
+		expectedEffective   float64
+		expectedList        float64
+	}{
+		{"all zeros", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+		{"all positive", 10.50, 100.00, 12.00, 10.50, 100.00, 12.00},
+		{"mixed values", 0.023, 50.5, 0.025, 0.023, 50.5, 0.025},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithPricingCurrencyPrices(tt.contractedUnitPrice, tt.effectiveCost, tt.listUnitPrice)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetPricingCurrencyContractedUnitPrice() != tt.expectedContracted {
+				t.Errorf(
+					"Expected PricingCurrencyContractedUnitPrice %f, got %f",
+					tt.expectedContracted,
+					record.GetPricingCurrencyContractedUnitPrice(),
+				)
+			}
+			if record.GetPricingCurrencyEffectiveCost() != tt.expectedEffective {
+				t.Errorf(
+					"Expected PricingCurrencyEffectiveCost %f, got %f",
+					tt.expectedEffective,
+					record.GetPricingCurrencyEffectiveCost(),
+				)
+			}
+			if record.GetPricingCurrencyListUnitPrice() != tt.expectedList {
+				t.Errorf(
+					"Expected PricingCurrencyListUnitPrice %f, got %f",
+					tt.expectedList,
+					record.GetPricingCurrencyListUnitPrice(),
+				)
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithPublisher tests the WithPublisher builder method.
+func TestFocusRecordBuilder_WithPublisher(t *testing.T) {
+	tests := []struct {
+		name      string
+		publisher string
+		expected  string
+	}{
+		{"empty publisher", "", ""},
+		{"AWS", "Amazon Web Services", "Amazon Web Services"},
+		{"Azure", "Microsoft", "Microsoft"},
+		{"GCP", "Google", "Google"},
+		{"third party", "Datadog", "Datadog"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithPublisher(tt.publisher)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetPublisher() != tt.expected {
+				t.Errorf("Expected Publisher %q, got %q", tt.expected, record.GetPublisher())
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithServiceSubcategory tests the WithServiceSubcategory builder method.
+func TestFocusRecordBuilder_WithServiceSubcategory(t *testing.T) {
+	tests := []struct {
+		name        string
+		subcategory string
+		expected    string
+	}{
+		{"empty subcategory", "", ""},
+		{"virtual machine", "Virtual Machine", "Virtual Machine"},
+		{"container", "Container", "Container"},
+		{"serverless", "Serverless", "Serverless"},
+		{"kubernetes", "Kubernetes", "Kubernetes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithServiceSubcategory(tt.subcategory)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetServiceSubcategory() != tt.expected {
+				t.Errorf("Expected ServiceSubcategory %q, got %q", tt.expected, record.GetServiceSubcategory())
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_WithSkuDetails tests the WithSkuDetails builder method.
+func TestFocusRecordBuilder_WithSkuDetails(t *testing.T) {
+	tests := []struct {
+		name            string
+		meter           string
+		priceDetails    string
+		expectedMeter   string
+		expectedDetails string
+	}{
+		{"empty details", "", "", "", ""},
+		{"compute meter", "compute-hours", "On-Demand", "compute-hours", "On-Demand"},
+		{"storage meter", "storage-gb-month", "Standard tier", "storage-gb-month", "Standard tier"},
+		{"network meter", "data-transfer-gb", "Outbound", "data-transfer-gb", "Outbound"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidBuilder()
+			builder.WithSkuDetails(tt.meter, tt.priceDetails)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetSkuMeter() != tt.expectedMeter {
+				t.Errorf("Expected SkuMeter %q, got %q", tt.expectedMeter, record.GetSkuMeter())
+			}
+			if record.GetSkuPriceDetails() != tt.expectedDetails {
+				t.Errorf("Expected SkuPriceDetails %q, got %q", tt.expectedDetails, record.GetSkuPriceDetails())
+			}
+		})
+	}
+}
+
+// TestFocusRecordBuilder_ChainNewMethods tests chaining multiple new builder methods.
+func TestFocusRecordBuilder_ChainNewMethods(t *testing.T) {
+	builder := createValidBuilder()
+
+	// Chain all new methods
+	record, err := builder.
+		WithContractedCost(100.50).
+		WithBillingAccountType("Enterprise").
+		WithSubAccountType("Subscription").
+		WithCapacityReservation("cr-123", pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED).
+		WithCommitmentDiscountDetails(50.0, pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED, "SavingsPlan", "USD/Hour").
+		WithContractedUnitPrice(0.05).
+		WithPricingCurrency("EUR").
+		WithPricingCurrencyPrices(0.045, 90.0, 0.055).
+		WithPublisher("Amazon Web Services").
+		WithServiceSubcategory("Virtual Machine").
+		WithSkuDetails("compute-hours", "On-Demand").
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Verify all fields were set
+	if record.GetContractedCost() != 100.50 {
+		t.Errorf("Expected ContractedCost 100.50, got %f", record.GetContractedCost())
+	}
+	if record.GetBillingAccountType() != "Enterprise" {
+		t.Errorf("Expected BillingAccountType 'Enterprise', got %q", record.GetBillingAccountType())
+	}
+	if record.GetSubAccountType() != "Subscription" {
+		t.Errorf("Expected SubAccountType 'Subscription', got %q", record.GetSubAccountType())
+	}
+	if record.GetCapacityReservationId() != "cr-123" {
+		t.Errorf("Expected CapacityReservationId 'cr-123', got %q", record.GetCapacityReservationId())
+	}
+	if record.GetCommitmentDiscountQuantity() != 50.0 {
+		t.Errorf("Expected CommitmentDiscountQuantity 50.0, got %f", record.GetCommitmentDiscountQuantity())
+	}
+	if record.GetContractedUnitPrice() != 0.05 {
+		t.Errorf("Expected ContractedUnitPrice 0.05, got %f", record.GetContractedUnitPrice())
+	}
+	if record.GetPricingCurrency() != "EUR" {
+		t.Errorf("Expected PricingCurrency 'EUR', got %q", record.GetPricingCurrency())
+	}
+	if record.GetPublisher() != "Amazon Web Services" {
+		t.Errorf("Expected Publisher 'Amazon Web Services', got %q", record.GetPublisher())
+	}
+	if record.GetServiceSubcategory() != "Virtual Machine" {
+		t.Errorf("Expected ServiceSubcategory 'Virtual Machine', got %q", record.GetServiceSubcategory())
+	}
+	if record.GetSkuMeter() != "compute-hours" {
+		t.Errorf("Expected SkuMeter 'compute-hours', got %q", record.GetSkuMeter())
+	}
+}
+
+// =============================================================================
+// Benchmarks for Builder Operations
+// =============================================================================
+
+// BenchmarkNewFocusRecordBuilder measures builder creation performance.
+func BenchmarkNewFocusRecordBuilder(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		_ = pluginsdk.NewFocusRecordBuilder()
+	}
+}
+
+// BenchmarkFocusRecordBuilder_Build measures the full build cycle performance.
+func BenchmarkFocusRecordBuilder_Build(b *testing.B) {
+	b.ReportAllocs()
+	for range b.N {
+		builder := createValidBuilder()
+		_, _ = builder.Build()
+	}
+}
+
+// BenchmarkFocusRecordBuilder_ChainedBuild measures chained method performance.
+func BenchmarkFocusRecordBuilder_ChainedBuild(b *testing.B) {
+	now := time.Now()
+	billingStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	billingEnd := billingStart.AddDate(0, 1, 0)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		_, _ = pluginsdk.NewFocusRecordBuilder().
+			WithIdentity("AWS", "acc-123", "Account").
+			WithBillingPeriod(billingStart, billingEnd, "USD").
+			WithChargePeriod(now.Add(-time.Hour), now).
+			WithChargeDetails(
+				pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+				pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
+			).
+			WithChargeClassification(
+				pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+				"Usage",
+				pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+			).
+			WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE, "EC2").
+			WithFinancials(10.0, 12.0, 10.0, "USD", "inv-001").
+			WithUsage(1.0, "Hour").
+			Build()
+	}
+}
+
+// BenchmarkFocusRecordBuilder_FullRecord measures building a complete 57-column record.
+func BenchmarkFocusRecordBuilder_FullRecord(b *testing.B) {
+	now := time.Now()
+	billingStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	billingEnd := billingStart.AddDate(0, 1, 0)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		builder := pluginsdk.NewFocusRecordBuilder()
+
+		// Mandatory columns
+		builder.WithIdentity("AWS", "acc-123", "Account")
+		builder.WithBillingPeriod(billingStart, billingEnd, "USD")
+		builder.WithChargePeriod(now.Add(-time.Hour), now)
+		builder.WithChargeDetails(
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+			pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
+		)
+		builder.WithChargeClassification(
+			pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			"Usage",
+			pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+		)
+		builder.WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE, "EC2")
+		builder.WithFinancials(10.0, 12.0, 10.0, "USD", "inv-001")
+		builder.WithUsage(1.0, "Hour")
+
+		// Conditional columns
+		builder.WithSubAccount("sub-123", "SubAccount")
+		builder.WithBillingAccountType("Enterprise")
+		builder.WithSubAccountType("Subscription")
+		builder.WithLocation("us-east-1", "US East", "us-east-1a")
+		builder.WithResource("i-123", "instance", "m5.large")
+		builder.WithSKU("sku-123", "price-123")
+		builder.WithSkuDetails("meter", "details")
+		builder.WithPricing(100.0, "Hours", 0.10)
+		builder.WithContractedCost(10.0)
+		builder.WithContractedUnitPrice(0.10)
+		builder.WithPricingCurrency("USD")
+		builder.WithPricingCurrencyPrices(0.10, 10.0, 0.12)
+		builder.WithPublisher("AWS")
+		builder.WithServiceSubcategory("VM")
+		builder.WithCommitmentDiscount(
+			pbc.FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE,
+			"ri-123", "Reserved Instance",
+		)
+		builder.WithCommitmentDiscountDetails(
+			100.0,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED,
+			"Standard RI", "Hours",
+		)
+		builder.WithCapacityReservation(
+			"cr-123",
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED,
+		)
+		builder.WithInvoice("inv-001", "AWS Inc")
+		builder.WithTags(map[string]string{"env": "prod", "team": "platform"})
+		builder.WithExtension("custom", "value")
+
+		_, _ = builder.Build()
 	}
 }

--- a/sdk/go/pluginsdk/focus_conformance.go
+++ b/sdk/go/pluginsdk/focus_conformance.go
@@ -2,43 +2,212 @@ package pluginsdk
 
 import (
 	"errors"
+	"fmt"
+	"math"
 
 	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
 )
 
+// iso4217Currencies contains valid ISO 4217 currency codes.
+// This is a comprehensive set of active ISO 4217 currency codes commonly
+// encountered in cloud billing across major providers (AWS, Azure, GCP).
+//
+//nolint:gochecknoglobals // Package-level constant data for currency validation.
+var iso4217Currencies = map[string]bool{
+	"AED": true, "AFN": true, "ALL": true, "AMD": true, "ANG": true,
+	"AOA": true, "ARS": true, "AUD": true, "AWG": true, "AZN": true,
+	"BAM": true, "BBD": true, "BDT": true, "BGN": true, "BHD": true,
+	"BIF": true, "BMD": true, "BND": true, "BOB": true, "BRL": true,
+	"BSD": true, "BTN": true, "BWP": true, "BYN": true, "BZD": true,
+	"CAD": true, "CDF": true, "CHF": true, "CLP": true, "CNY": true,
+	"COP": true, "CRC": true, "CUP": true, "CVE": true, "CZK": true,
+	"DJF": true, "DKK": true, "DOP": true, "DZD": true, "EGP": true,
+	"ERN": true, "ETB": true, "EUR": true, "FJD": true, "FKP": true,
+	"GBP": true, "GEL": true, "GHS": true, "GIP": true, "GMD": true,
+	"GNF": true, "GTQ": true, "GYD": true, "HKD": true, "HNL": true,
+	"HRK": true, "HTG": true, "HUF": true, "IDR": true, "ILS": true,
+	"INR": true, "IQD": true, "IRR": true, "ISK": true, "JMD": true,
+	"JOD": true, "JPY": true, "KES": true, "KGS": true, "KHR": true,
+	"KMF": true, "KPW": true, "KRW": true, "KWD": true, "KYD": true,
+	"KZT": true, "LAK": true, "LBP": true, "LKR": true, "LRD": true,
+	"LSL": true, "LYD": true, "MAD": true, "MDL": true, "MGA": true,
+	"MKD": true, "MMK": true, "MNT": true, "MOP": true, "MRU": true,
+	"MUR": true, "MVR": true, "MWK": true, "MXN": true, "MYR": true,
+	"MZN": true, "NAD": true, "NGN": true, "NIO": true, "NOK": true,
+	"NPR": true, "NZD": true, "OMR": true, "PAB": true, "PEN": true,
+	"PGK": true, "PHP": true, "PKR": true, "PLN": true, "PYG": true,
+	"QAR": true, "RON": true, "RSD": true, "RUB": true, "RWF": true,
+	"SAR": true, "SBD": true, "SCR": true, "SDG": true, "SEK": true,
+	"SGD": true, "SHP": true, "SLE": true, "SOS": true, "SRD": true,
+	"SSP": true, "STN": true, "SVC": true, "SYP": true, "SZL": true,
+	"THB": true, "TJS": true, "TMT": true, "TND": true, "TOP": true,
+	"TRY": true, "TTD": true, "TWD": true, "TZS": true, "UAH": true,
+	"UGX": true, "USD": true, "UYU": true, "UZS": true, "VES": true,
+	"VND": true, "VUV": true, "WST": true, "XAF": true, "XCD": true,
+	"XOF": true, "XPF": true, "YER": true, "ZAR": true, "ZMW": true,
+	"ZWL": true,
+}
+
+// contractedCostTolerance is the relative tolerance for ContractedCost validation.
+// Allows for floating-point precision differences up to 0.01%.
+const contractedCostTolerance = 0.0001
+
 // ValidateFocusRecord checks if a record complies with FOCUS 1.2 mandatory fields and business rules.
+// Reference: https://focus.finops.org
 func ValidateFocusRecord(r *pbc.FocusCostRecord) error {
 	if r == nil {
 		return errors.New("record is nil")
 	}
 
-	// Mandatory fields
-	if r.GetBillingAccountId() == "" {
-		return errors.New("billing_account_id is required")
-	}
-	if r.GetChargePeriodStart() == nil || r.GetChargePeriodEnd() == nil {
-		return errors.New("charge_period (start/end) is required")
-	}
-	if r.GetServiceCategory() == pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_UNSPECIFIED {
-		return errors.New("service_category is required")
-	}
-	if r.GetChargeCategory() == pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_UNSPECIFIED {
-		return errors.New("charge_category is required")
-	}
-	if r.GetCurrency() == "" {
-		return errors.New("currency is required")
+	// Validate mandatory fields (FOCUS 1.2).
+	if err := validateMandatoryFields(r); err != nil {
+		return err
 	}
 
-	// Business Rules
-	//
-	// Rule: Usage records should have usage quantity (unless it's a fixed fee, but usually usage implies quantity)
-	// The spec example said "if ChargeCategory=Usage, UsageQuantity must be > 0".
-	if r.GetChargeCategory() == pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE {
-		if r.GetUsageQuantity() == 0 {
-			// 0 usage for usage charge seems wrong.
-			return errors.New("usage_quantity must be non-zero for usage charge category")
-		}
+	// Validate currency codes (ISO 4217).
+	if err := validateCurrencyFields(r); err != nil {
+		return err
+	}
+
+	// Validate business rules.
+	if err := validateBusinessRules(r); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+// validateMandatoryFields checks all 14 mandatory FOCUS 1.2 fields.
+func validateMandatoryFields(r *pbc.FocusCostRecord) error {
+	// Identity fields (FOCUS 1.2 Section 2.1).
+	if r.GetProviderName() == "" {
+		return errors.New("provider_name is required")
+	}
+	if r.GetBillingAccountId() == "" {
+		return errors.New("billing_account_id is required")
+	}
+
+	// Billing period (FOCUS 1.2 Section 2.2).
+	if r.GetBillingPeriodStart() == nil || r.GetBillingPeriodEnd() == nil {
+		return errors.New("billing_period (start/end) is required")
+	}
+	if r.GetBillingCurrency() == "" {
+		return errors.New("billing_currency is required")
+	}
+
+	// Charge period (FOCUS 1.2 Section 2.3).
+	if r.GetChargePeriodStart() == nil || r.GetChargePeriodEnd() == nil {
+		return errors.New("charge_period (start/end) is required")
+	}
+
+	// Charge details (FOCUS 1.2 Section 2.4).
+	if r.GetChargeCategory() == pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_UNSPECIFIED {
+		return errors.New("charge_category is required")
+	}
+	if r.GetChargeClass() == pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_UNSPECIFIED {
+		return errors.New("charge_class is required")
+	}
+	if r.GetChargeDescription() == "" {
+		return errors.New("charge_description is required")
+	}
+
+	// Service details (FOCUS 1.2 Section 2.6).
+	if r.GetServiceCategory() == pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_UNSPECIFIED {
+		return errors.New("service_category is required")
+	}
+	if r.GetServiceName() == "" {
+		return errors.New("service_name is required")
+	}
+
+	// Note: BilledCost and ContractedCost are mandatory but can be zero or negative
+	// (e.g., credits, refunds per FOCUS 1.2 spec).
+	//
+	// Note: BillingAccountName is mandatory per FOCUS 1.2 but validation is intentionally
+	// relaxed to accommodate cloud providers that may not include account names in all
+	// billing data exports. Plugins should populate this field when available.
+	return nil
+}
+
+// validateCurrencyFields validates ISO 4217 currency codes.
+func validateCurrencyFields(r *pbc.FocusCostRecord) error {
+	if err := validateCurrency(r.GetBillingCurrency(), "billing_currency"); err != nil {
+		return err
+	}
+
+	// PricingCurrency is optional, but if present, must be valid ISO 4217.
+	if r.GetPricingCurrency() != "" {
+		if err := validateCurrency(r.GetPricingCurrency(), "pricing_currency"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateBusinessRules validates FOCUS 1.2 business rules.
+func validateBusinessRules(r *pbc.FocusCostRecord) error {
+	// Rule: Usage records must have positive consumed quantity.
+	// FOCUS 1.2: If ChargeCategory=Usage, ConsumedQuantity must be > 0.
+	if r.GetChargeCategory() == pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE {
+		if r.GetConsumedQuantity() <= 0 {
+			return errors.New("consumed_quantity must be positive for usage charge category")
+		}
+	}
+
+	// Rule: ContractedCost must equal ContractedUnitPrice × PricingQuantity.
+	// FOCUS 1.2 Section 3.20: When ContractedUnitPrice and PricingQuantity are present
+	// and ChargeClass is not "Correction", this relationship must hold.
+	if err := validateContractedCostRule(r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateCurrency checks if a currency code is a valid ISO 4217 code.
+func validateCurrency(code string, fieldName string) error {
+	if !iso4217Currencies[code] {
+		return fmt.Errorf("%s must be a valid ISO 4217 currency code, got %q", fieldName, code)
+	}
+	return nil
+}
+
+// validateContractedCostRule verifies ContractedCost = ContractedUnitPrice × PricingQuantity.
+// This rule applies when both ContractedUnitPrice and PricingQuantity are present (non-zero)
+// and ChargeClass is not Correction.
+func validateContractedCostRule(r *pbc.FocusCostRecord) error {
+	// Skip validation for correction charges.
+	if r.GetChargeClass() == pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_CORRECTION {
+		return nil
+	}
+
+	contractedUnitPrice := r.GetContractedUnitPrice()
+	pricingQuantity := r.GetPricingQuantity()
+
+	// Only validate when both values are present (non-zero).
+	if contractedUnitPrice == 0 || pricingQuantity == 0 {
+		return nil
+	}
+
+	contractedCost := r.GetContractedCost()
+	expectedCost := contractedUnitPrice * pricingQuantity
+
+	// Use relative tolerance for floating-point comparison.
+	if !floatEquals(contractedCost, expectedCost, contractedCostTolerance) {
+		return fmt.Errorf(
+			"contracted_cost (%f) must equal contracted_unit_price (%f) × pricing_quantity (%f) = %f",
+			contractedCost, contractedUnitPrice, pricingQuantity, expectedCost,
+		)
+	}
+
+	return nil
+}
+
+// floatEquals compares two floats with relative tolerance.
+func floatEquals(a, b, tolerance float64) bool {
+	if a == b {
+		return true
+	}
+	diff := math.Abs(a - b)
+	largest := math.Max(math.Abs(a), math.Abs(b))
+	return diff <= largest*tolerance
 }

--- a/sdk/go/pluginsdk/focus_conformance_test.go
+++ b/sdk/go/pluginsdk/focus_conformance_test.go
@@ -1,0 +1,760 @@
+package pluginsdk_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// FOCUS 1.2 Column Definitions for schema completeness verification.
+// Reference: https://focus.finops.org/focus-specification/v1-2/.
+// Total: 57 columns (14 mandatory, 1 recommended, 42 conditional).
+//
+//nolint:gochecknoglobals // Test data for FOCUS column validation.
+var focus12Columns = map[string]struct {
+	ProtoField string // Expected proto field name (snake_case)
+	ProtoType  string // Expected Go type after generation
+	Level      string // Mandatory, Recommended, or Conditional
+}{
+	// ==========================================================================
+	// MANDATORY COLUMNS (14 total)
+	// ==========================================================================
+	"BilledCost":         {"billed_cost", "float64", "Mandatory"},
+	"BillingAccountId":   {"billing_account_id", "string", "Mandatory"},
+	"BillingAccountName": {"billing_account_name", "string", "Mandatory"},
+	"BillingCurrency":    {"billing_currency", "string", "Mandatory"},
+	"BillingPeriodEnd":   {"billing_period_end", "*timestamppb.Timestamp", "Mandatory"},
+	"BillingPeriodStart": {"billing_period_start", "*timestamppb.Timestamp", "Mandatory"},
+	"ChargeCategory":     {"charge_category", "FocusChargeCategory", "Mandatory"},
+	"ChargeClass":        {"charge_class", "FocusChargeClass", "Mandatory"},
+	"ChargeDescription":  {"charge_description", "string", "Mandatory"},
+	"ChargePeriodEnd":    {"charge_period_end", "*timestamppb.Timestamp", "Mandatory"},
+	"ChargePeriodStart":  {"charge_period_start", "*timestamppb.Timestamp", "Mandatory"},
+	"ContractedCost":     {"contracted_cost", "float64", "Mandatory"},
+	"ProviderName":       {"provider_name", "string", "Mandatory"},
+	"ServiceName":        {"service_name", "string", "Mandatory"},
+
+	// ==========================================================================
+	// RECOMMENDED COLUMNS (1 total)
+	// ==========================================================================
+	"ChargeFrequency": {"charge_frequency", "FocusChargeFrequency", "Recommended"},
+
+	// ==========================================================================
+	// CONDITIONAL COLUMNS (42 total)
+	// ==========================================================================
+
+	// Account Types
+	"BillingAccountType": {"billing_account_type", "string", "Conditional"},
+	"SubAccountId":       {"sub_account_id", "string", "Conditional"},
+	"SubAccountName":     {"sub_account_name", "string", "Conditional"},
+	"SubAccountType":     {"sub_account_type", "string", "Conditional"},
+
+	// Capacity Reservation
+	"CapacityReservationId":     {"capacity_reservation_id", "string", "Conditional"},
+	"CapacityReservationStatus": {"capacity_reservation_status", "FocusCapacityReservationStatus", "Conditional"},
+
+	// Commitment Discounts
+	"CommitmentDiscountCategory": {"commitment_discount_category", "FocusCommitmentDiscountCategory", "Conditional"},
+	"CommitmentDiscountId":       {"commitment_discount_id", "string", "Conditional"},
+	"CommitmentDiscountName":     {"commitment_discount_name", "string", "Conditional"},
+	"CommitmentDiscountQuantity": {"commitment_discount_quantity", "float64", "Conditional"},
+	"CommitmentDiscountStatus":   {"commitment_discount_status", "FocusCommitmentDiscountStatus", "Conditional"},
+	"CommitmentDiscountType":     {"commitment_discount_type", "string", "Conditional"},
+	"CommitmentDiscountUnit":     {"commitment_discount_unit", "string", "Conditional"},
+
+	// Consumption/Usage
+	"ConsumedQuantity": {"consumed_quantity", "float64", "Conditional"},
+	"ConsumedUnit":     {"consumed_unit", "string", "Conditional"},
+
+	// Financial
+	"ContractedUnitPrice": {"contracted_unit_price", "float64", "Conditional"},
+	"EffectiveCost":       {"effective_cost", "float64", "Conditional"},
+	"ListCost":            {"list_cost", "float64", "Conditional"},
+
+	// Invoice
+	"InvoiceId":     {"invoice_id", "string", "Conditional"},
+	"InvoiceIssuer": {"invoice_issuer", "string", "Conditional"},
+
+	// Location
+	"AvailabilityZone": {"availability_zone", "string", "Conditional"},
+	"RegionId":         {"region_id", "string", "Conditional"},
+	"RegionName":       {"region_name", "string", "Conditional"},
+
+	// Metadata
+	"Tags": {"tags", "map[string]string", "Conditional"},
+
+	// Pricing
+	"ListUnitPrice":                      {"list_unit_price", "float64", "Conditional"},
+	"PricingCategory":                    {"pricing_category", "FocusPricingCategory", "Conditional"},
+	"PricingCurrency":                    {"pricing_currency", "string", "Conditional"},
+	"PricingCurrencyContractedUnitPrice": {"pricing_currency_contracted_unit_price", "float64", "Conditional"},
+	"PricingCurrencyEffectiveCost":       {"pricing_currency_effective_cost", "float64", "Conditional"},
+	"PricingCurrencyListUnitPrice":       {"pricing_currency_list_unit_price", "float64", "Conditional"},
+	"PricingQuantity":                    {"pricing_quantity", "float64", "Conditional"},
+	"PricingUnit":                        {"pricing_unit", "string", "Conditional"},
+
+	// Resource
+	"ResourceId":   {"resource_id", "string", "Conditional"},
+	"ResourceName": {"resource_name", "string", "Conditional"},
+	"ResourceType": {"resource_type", "string", "Conditional"},
+
+	// Service
+	"Publisher":          {"publisher", "string", "Conditional"},
+	"ServiceCategory":    {"service_category", "FocusServiceCategory", "Conditional"},
+	"ServiceSubcategory": {"service_subcategory", "string", "Conditional"},
+
+	// SKU
+	"SkuId":           {"sku_id", "string", "Conditional"},
+	"SkuMeter":        {"sku_meter", "string", "Conditional"},
+	"SkuPriceDetails": {"sku_price_details", "string", "Conditional"},
+	"SkuPriceId":      {"sku_price_id", "string", "Conditional"},
+}
+
+// TestFOCUS12ColumnCompleteness verifies all 57 FOCUS 1.2 columns are present
+// in the FocusCostRecord proto message.
+func TestFOCUS12ColumnCompleteness(t *testing.T) {
+	// Get the type of FocusCostRecord
+	recordType := reflect.TypeOf(pbc.FocusCostRecord{})
+
+	missingColumns := []string{}
+	presentColumns := []string{}
+
+	for focusColumn, spec := range focus12Columns {
+		// Convert proto field name to Go struct field name (PascalCase)
+		goFieldName := snakeToPascal(spec.ProtoField)
+
+		// Check if the field exists in the struct
+		_, found := recordType.FieldByName(goFieldName)
+		if !found {
+			missingColumns = append(missingColumns, focusColumn)
+		} else {
+			presentColumns = append(presentColumns, focusColumn)
+		}
+	}
+
+	// Report results
+	t.Logf("FOCUS 1.2 Column Audit Results:")
+	t.Logf("  Total columns defined: %d", len(focus12Columns))
+	t.Logf("  Present in proto: %d", len(presentColumns))
+	t.Logf("  Missing from proto: %d", len(missingColumns))
+
+	if len(missingColumns) > 0 {
+		t.Errorf("Missing FOCUS 1.2 columns: %v", missingColumns)
+	}
+
+	// Verify we have exactly 57 columns (FOCUS 1.2 specification)
+	if len(focus12Columns) != 57 {
+		t.Errorf("Expected 57 FOCUS 1.2 columns, but test defines %d", len(focus12Columns))
+	}
+}
+
+// TestFOCUS12MandatoryColumns verifies all mandatory columns are present.
+func TestFOCUS12MandatoryColumns(t *testing.T) {
+	recordType := reflect.TypeOf(pbc.FocusCostRecord{})
+
+	mandatoryColumns := []string{}
+	for focusColumn, spec := range focus12Columns {
+		if spec.Level == "Mandatory" {
+			mandatoryColumns = append(mandatoryColumns, focusColumn)
+		}
+	}
+
+	missingMandatory := []string{}
+	for _, col := range mandatoryColumns {
+		spec := focus12Columns[col]
+		goFieldName := snakeToPascal(spec.ProtoField)
+		if _, found := recordType.FieldByName(goFieldName); !found {
+			missingMandatory = append(missingMandatory, col)
+		}
+	}
+
+	t.Logf("Mandatory columns: %d", len(mandatoryColumns))
+
+	if len(missingMandatory) > 0 {
+		t.Errorf("Missing MANDATORY FOCUS 1.2 columns: %v", missingMandatory)
+	}
+
+	// FOCUS 1.2 has 14 mandatory columns
+	if len(mandatoryColumns) != 14 {
+		t.Errorf("Expected 14 mandatory columns, got %d", len(mandatoryColumns))
+	}
+}
+
+// TestFOCUS12NewEnumTypes verifies the new enum types are properly defined.
+func TestFOCUS12NewEnumTypes(t *testing.T) {
+	// Test FocusCommitmentDiscountStatus enum
+	t.Run("FocusCommitmentDiscountStatus", func(t *testing.T) {
+		// Verify enum values exist
+		if pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED != 0 {
+			t.Error("UNSPECIFIED should be 0")
+		}
+		if pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED != 1 {
+			t.Error("USED should be 1")
+		}
+		if pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED != 2 {
+			t.Error("UNUSED should be 2")
+		}
+	})
+
+	// Test FocusCapacityReservationStatus enum
+	t.Run("FocusCapacityReservationStatus", func(t *testing.T) {
+		// Verify enum values exist
+		if pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED != 0 {
+			t.Error("UNSPECIFIED should be 0")
+		}
+		if pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED != 1 {
+			t.Error("USED should be 1")
+		}
+		if pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED != 2 {
+			t.Error("UNUSED should be 2")
+		}
+	})
+}
+
+// TestFOCUS12NewFieldsAccessible verifies all 19 new fields can be accessed.
+func TestFOCUS12NewFieldsAccessible(t *testing.T) {
+	record := &pbc.FocusCostRecord{}
+
+	// Test all 19 new fields are accessible (fields 41-58 + enums)
+	newFields := map[string]interface{}{
+		"ContractedCost":                     record.GetContractedCost(),
+		"BillingAccountType":                 record.GetBillingAccountType(),
+		"SubAccountType":                     record.GetSubAccountType(),
+		"CapacityReservationId":              record.GetCapacityReservationId(),
+		"CapacityReservationStatus":          record.GetCapacityReservationStatus(),
+		"CommitmentDiscountQuantity":         record.GetCommitmentDiscountQuantity(),
+		"CommitmentDiscountStatus":           record.GetCommitmentDiscountStatus(),
+		"CommitmentDiscountType":             record.GetCommitmentDiscountType(),
+		"CommitmentDiscountUnit":             record.GetCommitmentDiscountUnit(),
+		"ContractedUnitPrice":                record.GetContractedUnitPrice(),
+		"PricingCurrency":                    record.GetPricingCurrency(),
+		"PricingCurrencyContractedUnitPrice": record.GetPricingCurrencyContractedUnitPrice(),
+		"PricingCurrencyEffectiveCost":       record.GetPricingCurrencyEffectiveCost(),
+		"PricingCurrencyListUnitPrice":       record.GetPricingCurrencyListUnitPrice(),
+		"Publisher":                          record.GetPublisher(),
+		"ServiceSubcategory":                 record.GetServiceSubcategory(),
+		"SkuMeter":                           record.GetSkuMeter(),
+		"SkuPriceDetails":                    record.GetSkuPriceDetails(),
+	}
+
+	t.Logf("Verified %d new FOCUS 1.2 fields are accessible", len(newFields))
+
+	// All should return zero values without panicking
+	for name, value := range newFields {
+		if value == nil {
+			t.Logf("  %s: nil (pointer type)", name)
+		} else {
+			t.Logf("  %s: %v (zero value)", name, value)
+		}
+	}
+}
+
+// snakeToPascal converts snake_case to PascalCase for Go struct field lookup.
+func snakeToPascal(s string) string {
+	parts := strings.Split(s, "_")
+	for i, part := range parts {
+		if len(part) > 0 {
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+// TestFOCUS12TypeMappings verifies proto types match FOCUS data type requirements.
+// FOCUS types: String -> string, Decimal -> float64, DateTime -> *timestamppb.Timestamp.
+func TestFOCUS12TypeMappings(t *testing.T) {
+	recordType := reflect.TypeOf(pbc.FocusCostRecord{})
+
+	// Define expected type mappings based on FOCUS specification
+	typeMappings := map[string]string{
+		// Decimal fields -> float64
+		"BilledCost":                         "float64",
+		"ContractedCost":                     "float64",
+		"ContractedUnitPrice":                "float64",
+		"EffectiveCost":                      "float64",
+		"ListCost":                           "float64",
+		"ListUnitPrice":                      "float64",
+		"PricingQuantity":                    "float64",
+		"ConsumedQuantity":                   "float64",
+		"CommitmentDiscountQuantity":         "float64",
+		"PricingCurrencyContractedUnitPrice": "float64",
+		"PricingCurrencyEffectiveCost":       "float64",
+		"PricingCurrencyListUnitPrice":       "float64",
+
+		// DateTime fields -> *timestamppb.Timestamp
+		"BillingPeriodStart": "*timestamppb.Timestamp",
+		"BillingPeriodEnd":   "*timestamppb.Timestamp",
+		"ChargePeriodStart":  "*timestamppb.Timestamp",
+		"ChargePeriodEnd":    "*timestamppb.Timestamp",
+
+		// String fields -> string
+		"ProviderName":       "string",
+		"BillingAccountId":   "string",
+		"BillingAccountName": "string",
+		"BillingCurrency":    "string",
+		"ChargeDescription":  "string",
+		"ServiceName":        "string",
+	}
+
+	errors := []string{}
+	for fieldName, expectedType := range typeMappings {
+		field, found := recordType.FieldByName(fieldName)
+		if !found {
+			errors = append(errors, fmt.Sprintf("%s: field not found", fieldName))
+			continue
+		}
+
+		actualType := field.Type.String()
+		// Normalize type names for comparison
+		if strings.Contains(actualType, "timestamp") {
+			actualType = "*timestamppb.Timestamp"
+		}
+
+		if actualType != expectedType {
+			errors = append(errors, fmt.Sprintf("%s: expected %s, got %s", fieldName, expectedType, actualType))
+		}
+	}
+
+	if len(errors) > 0 {
+		for _, err := range errors {
+			t.Errorf("Type mismatch: %s", err)
+		}
+	}
+
+	t.Logf("Verified %d type mappings", len(typeMappings))
+}
+
+// =============================================================================
+// Validation Enhancement Tests
+// =============================================================================
+
+// TestValidateFocusRecord_MandatoryFields tests that all 14 mandatory fields are validated.
+func TestValidateFocusRecord_MandatoryFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		modifyFunc  func(*pbc.FocusCostRecord)
+		expectedErr string
+	}{
+		{
+			name:        "missing provider_name",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.ProviderName = "" },
+			expectedErr: "provider_name is required",
+		},
+		{
+			name:        "missing billing_account_id",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.BillingAccountId = "" },
+			expectedErr: "billing_account_id is required",
+		},
+		{
+			name:        "missing billing_period_start",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.BillingPeriodStart = nil },
+			expectedErr: "billing_period (start/end) is required",
+		},
+		{
+			name:        "missing billing_period_end",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.BillingPeriodEnd = nil },
+			expectedErr: "billing_period (start/end) is required",
+		},
+		{
+			name:        "missing charge_period_start",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.ChargePeriodStart = nil },
+			expectedErr: "charge_period (start/end) is required",
+		},
+		{
+			name:        "missing charge_period_end",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.ChargePeriodEnd = nil },
+			expectedErr: "charge_period (start/end) is required",
+		},
+		{
+			name: "missing charge_category",
+			modifyFunc: func(r *pbc.FocusCostRecord) {
+				r.ChargeCategory = pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_UNSPECIFIED
+			},
+			expectedErr: "charge_category is required",
+		},
+		{
+			name: "missing charge_class",
+			modifyFunc: func(r *pbc.FocusCostRecord) {
+				r.ChargeClass = pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_UNSPECIFIED
+			},
+			expectedErr: "charge_class is required",
+		},
+		{
+			name:        "missing charge_description",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.ChargeDescription = "" },
+			expectedErr: "charge_description is required",
+		},
+		{
+			name: "missing service_category",
+			modifyFunc: func(r *pbc.FocusCostRecord) {
+				r.ServiceCategory = pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_UNSPECIFIED
+			},
+			expectedErr: "service_category is required",
+		},
+		{
+			name:        "missing service_name",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.ServiceName = "" },
+			expectedErr: "service_name is required",
+		},
+		{
+			name:        "missing billing_currency",
+			modifyFunc:  func(r *pbc.FocusCostRecord) { r.BillingCurrency = "" },
+			expectedErr: "billing_currency is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := createValidFocusRecord()
+			tt.modifyFunc(record)
+
+			err := pluginsdk.ValidateFocusRecord(record)
+			if err == nil {
+				t.Errorf("Expected error %q, got nil", tt.expectedErr)
+				return
+			}
+			if err.Error() != tt.expectedErr {
+				t.Errorf("Expected error %q, got %q", tt.expectedErr, err.Error())
+			}
+		})
+	}
+}
+
+// TestValidateFocusRecord_ISO4217Currency tests ISO 4217 currency validation.
+func TestValidateFocusRecord_ISO4217Currency(t *testing.T) {
+	tests := []struct {
+		name          string
+		billingCurr   string
+		pricingCurr   string
+		expectError   bool
+		errorContains string
+	}{
+		{"valid USD", "USD", "", false, ""},
+		{"valid EUR", "EUR", "", false, ""},
+		{"valid GBP", "GBP", "", false, ""},
+		{"valid JPY", "JPY", "", false, ""},
+		{"valid CNY", "CNY", "", false, ""},
+		{"valid CAD", "CAD", "", false, ""},
+		{"valid AUD", "AUD", "", false, ""},
+		{"invalid billing currency", "XXX", "", true, "billing_currency must be a valid ISO 4217"},
+		{"invalid lowercase", "usd", "", true, "billing_currency must be a valid ISO 4217"},
+		{"empty pricing currency ok", "USD", "", false, ""},
+		{"valid pricing currency", "USD", "EUR", false, ""},
+		{"invalid pricing currency", "USD", "ZZZ", true, "pricing_currency must be a valid ISO 4217"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := createValidFocusRecord()
+			record.BillingCurrency = tt.billingCurr
+			record.PricingCurrency = tt.pricingCurr
+
+			err := pluginsdk.ValidateFocusRecord(record)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error containing %q, got nil", tt.errorContains)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error containing %q, got %q", tt.errorContains, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateFocusRecord_ContractedCostRule tests the ContractedCost business rule.
+func TestValidateFocusRecord_ContractedCostRule(t *testing.T) {
+	tests := []struct {
+		name                string
+		contractedCost      float64
+		contractedUnitPrice float64
+		pricingQuantity     float64
+		chargeClass         pbc.FocusChargeClass
+		expectError         bool
+		errorContains       string
+	}{
+		{
+			name:                "valid calculation",
+			contractedCost:      100.0,
+			contractedUnitPrice: 10.0,
+			pricingQuantity:     10.0,
+			chargeClass:         pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			expectError:         false,
+		},
+		{
+			name:                "valid with decimals",
+			contractedCost:      73.0,
+			contractedUnitPrice: 0.10,
+			pricingQuantity:     730.0,
+			chargeClass:         pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			expectError:         false,
+		},
+		{
+			name:                "skip when unit price is zero",
+			contractedCost:      100.0,
+			contractedUnitPrice: 0.0,
+			pricingQuantity:     10.0,
+			chargeClass:         pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			expectError:         false,
+		},
+		{
+			name:                "skip when quantity is zero",
+			contractedCost:      100.0,
+			contractedUnitPrice: 10.0,
+			pricingQuantity:     0.0,
+			chargeClass:         pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			expectError:         false,
+		},
+		{
+			name:                "skip for correction charges",
+			contractedCost:      999.0, // Doesn't match calculation
+			contractedUnitPrice: 10.0,
+			pricingQuantity:     10.0,
+			chargeClass:         pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_CORRECTION,
+			expectError:         false,
+		},
+		{
+			name:                "invalid mismatch",
+			contractedCost:      50.0, // Should be 100.0
+			contractedUnitPrice: 10.0,
+			pricingQuantity:     10.0,
+			chargeClass:         pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			expectError:         true,
+			errorContains:       "contracted_cost",
+		},
+		{
+			name:                "within tolerance",
+			contractedCost:      100.001, // Slightly off but within 0.01% tolerance
+			contractedUnitPrice: 10.0,
+			pricingQuantity:     10.0,
+			chargeClass:         pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			expectError:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := createValidFocusRecord()
+			record.ContractedCost = tt.contractedCost
+			record.ContractedUnitPrice = tt.contractedUnitPrice
+			record.PricingQuantity = tt.pricingQuantity
+			record.ChargeClass = tt.chargeClass
+
+			err := pluginsdk.ValidateFocusRecord(record)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error containing %q, got nil", tt.errorContains)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("Expected error containing %q, got %q", tt.errorContains, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateFocusRecord_UsageQuantityRule tests consumed quantity validation for usage charges.
+func TestValidateFocusRecord_UsageQuantityRule(t *testing.T) {
+	tests := []struct {
+		name             string
+		chargeCategory   pbc.FocusChargeCategory
+		consumedQuantity float64
+		expectError      bool
+	}{
+		{"usage with quantity", pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE, 1.0, false},
+		{"usage without quantity", pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE, 0.0, true},
+		{"usage with negative quantity", pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE, -1.0, true},
+		{"purchase without quantity ok", pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_PURCHASE, 0.0, false},
+		{"credit without quantity ok", pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_CREDIT, 0.0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := createValidFocusRecord()
+			record.ChargeCategory = tt.chargeCategory
+			record.ConsumedQuantity = tt.consumedQuantity
+
+			err := pluginsdk.ValidateFocusRecord(record)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+					return
+				}
+				if !strings.Contains(err.Error(), "consumed_quantity") {
+					t.Errorf("Expected consumed_quantity error, got %q", err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// createValidFocusRecord creates a valid FocusCostRecord for testing validation.
+// Uses realistic distinct timestamps for billing and charge periods.
+func createValidFocusRecord() *pbc.FocusCostRecord {
+	now := time.Now()
+	// Billing period: first of current month to first of next month
+	billingStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	billingEnd := billingStart.AddDate(0, 1, 0)
+	// Charge period: 24 hours ending now
+	chargeStart := now.Add(-24 * time.Hour)
+	chargeEnd := now
+
+	return &pbc.FocusCostRecord{
+		ProviderName:       "AWS",
+		BillingAccountId:   "123456789012",
+		BillingAccountName: "Production Account",
+		BillingCurrency:    "USD",
+		BillingPeriodStart: timestamppb.New(billingStart),
+		BillingPeriodEnd:   timestamppb.New(billingEnd),
+		ChargePeriodStart:  timestamppb.New(chargeStart),
+		ChargePeriodEnd:    timestamppb.New(chargeEnd),
+		ChargeCategory:     pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+		ChargeClass:        pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+		ChargeDescription:  "EC2 Instance Usage",
+		ServiceCategory:    pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE,
+		ServiceName:        "Amazon EC2",
+		BilledCost:         10.0,
+		ContractedCost:     10.0,
+		ConsumedQuantity:   1.0,
+		ConsumedUnit:       "Hours",
+	}
+}
+
+// TestFOCUS12EnumCompleteness verifies all enum types have expected values.
+func TestFOCUS12EnumCompleteness(t *testing.T) {
+	// FocusChargeCategory - FOCUS 1.2 charge categories
+	t.Run("FocusChargeCategory", func(t *testing.T) {
+		expectedValues := []pbc.FocusChargeCategory{
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_UNSPECIFIED,
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_PURCHASE,
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_CREDIT,
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_TAX,
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_REFUND,
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_ADJUSTMENT,
+		}
+		if len(pbc.FocusChargeCategory_name) < len(expectedValues) {
+			t.Errorf("FocusChargeCategory missing values: expected %d, got %d",
+				len(expectedValues), len(pbc.FocusChargeCategory_name))
+		}
+	})
+
+	// FocusChargeClass - FOCUS 1.2 charge classes
+	t.Run("FocusChargeClass", func(t *testing.T) {
+		expectedValues := []pbc.FocusChargeClass{
+			pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_UNSPECIFIED,
+			pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_CORRECTION,
+		}
+		if len(pbc.FocusChargeClass_name) < len(expectedValues) {
+			t.Errorf("FocusChargeClass missing values: expected %d, got %d",
+				len(expectedValues), len(pbc.FocusChargeClass_name))
+		}
+	})
+
+	// FocusChargeFrequency - FOCUS 1.2 charge frequencies
+	t.Run("FocusChargeFrequency", func(t *testing.T) {
+		expectedValues := []pbc.FocusChargeFrequency{
+			pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_UNSPECIFIED,
+			pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_ONE_TIME,
+			pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_RECURRING,
+			pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+		}
+		if len(pbc.FocusChargeFrequency_name) < len(expectedValues) {
+			t.Errorf("FocusChargeFrequency missing values: expected %d, got %d",
+				len(expectedValues), len(pbc.FocusChargeFrequency_name))
+		}
+	})
+
+	// FocusPricingCategory - FOCUS 1.2 pricing categories
+	t.Run("FocusPricingCategory", func(t *testing.T) {
+		expectedValues := []pbc.FocusPricingCategory{
+			pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_UNSPECIFIED,
+			pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
+			pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_COMMITTED,
+			pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_DYNAMIC,
+			pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_OTHER,
+		}
+		if len(pbc.FocusPricingCategory_name) < len(expectedValues) {
+			t.Errorf("FocusPricingCategory missing values: expected %d, got %d",
+				len(expectedValues), len(pbc.FocusPricingCategory_name))
+		}
+	})
+
+	// FocusServiceCategory - FOCUS 1.2 service categories
+	t.Run("FocusServiceCategory", func(t *testing.T) {
+		expectedValues := []pbc.FocusServiceCategory{
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_UNSPECIFIED,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_STORAGE,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_NETWORK,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_DATABASE,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_ANALYTICS,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_MACHINE_LEARNING,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_MANAGEMENT,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_SECURITY,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_DEVELOPER_TOOLS,
+			pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_OTHER,
+		}
+		if len(pbc.FocusServiceCategory_name) < len(expectedValues) {
+			t.Errorf("FocusServiceCategory missing values: expected %d, got %d",
+				len(expectedValues), len(pbc.FocusServiceCategory_name))
+		}
+	})
+
+	// FocusCommitmentDiscountCategory - FOCUS 1.2 commitment discount categories
+	t.Run("FocusCommitmentDiscountCategory", func(t *testing.T) {
+		expectedValues := []pbc.FocusCommitmentDiscountCategory{
+			pbc.FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_UNSPECIFIED,
+			pbc.FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_SPEND,
+			pbc.FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE,
+		}
+		if len(pbc.FocusCommitmentDiscountCategory_name) < len(expectedValues) {
+			t.Errorf("FocusCommitmentDiscountCategory missing values: expected %d, got %d",
+				len(expectedValues), len(pbc.FocusCommitmentDiscountCategory_name))
+		}
+	})
+
+	// FocusCommitmentDiscountStatus - NEW in this feature
+	t.Run("FocusCommitmentDiscountStatus", func(t *testing.T) {
+		expectedValues := []pbc.FocusCommitmentDiscountStatus{
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED,
+			pbc.FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED,
+		}
+		if len(pbc.FocusCommitmentDiscountStatus_name) != len(expectedValues) {
+			t.Errorf("FocusCommitmentDiscountStatus: expected %d values, got %d",
+				len(expectedValues), len(pbc.FocusCommitmentDiscountStatus_name))
+		}
+	})
+
+	// FocusCapacityReservationStatus - NEW in this feature
+	t.Run("FocusCapacityReservationStatus", func(t *testing.T) {
+		expectedValues := []pbc.FocusCapacityReservationStatus{
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED,
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED,
+			pbc.FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED,
+		}
+		if len(pbc.FocusCapacityReservationStatus_name) != len(expectedValues) {
+			t.Errorf("FocusCapacityReservationStatus: expected %d values, got %d",
+				len(expectedValues), len(pbc.FocusCapacityReservationStatus_name))
+		}
+	})
+}

--- a/sdk/go/proto/pulumicost/v1/enums.pb.go
+++ b/sdk/go/proto/pulumicost/v1/enums.pb.go
@@ -159,6 +159,7 @@ func (FocusChargeCategory) EnumDescriptor() ([]byte, []int) {
 }
 
 // FocusPricingCategory represents the pricing model applied.
+// FOCUS 1.2 Section 2.4: Pricing Category
 type FocusPricingCategory int32
 
 const (
@@ -214,6 +215,268 @@ func (FocusPricingCategory) EnumDescriptor() ([]byte, []int) {
 	return file_pulumicost_v1_enums_proto_rawDescGZIP(), []int{2}
 }
 
+// FocusChargeClass represents the classification of charges.
+// FOCUS 1.2 Section 2.4: Charge Class (New in 1.0+)
+type FocusChargeClass int32
+
+const (
+	FocusChargeClass_FOCUS_CHARGE_CLASS_UNSPECIFIED FocusChargeClass = 0
+	FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR     FocusChargeClass = 1
+	FocusChargeClass_FOCUS_CHARGE_CLASS_CORRECTION  FocusChargeClass = 2
+)
+
+// Enum value maps for FocusChargeClass.
+var (
+	FocusChargeClass_name = map[int32]string{
+		0: "FOCUS_CHARGE_CLASS_UNSPECIFIED",
+		1: "FOCUS_CHARGE_CLASS_REGULAR",
+		2: "FOCUS_CHARGE_CLASS_CORRECTION",
+	}
+	FocusChargeClass_value = map[string]int32{
+		"FOCUS_CHARGE_CLASS_UNSPECIFIED": 0,
+		"FOCUS_CHARGE_CLASS_REGULAR":     1,
+		"FOCUS_CHARGE_CLASS_CORRECTION":  2,
+	}
+)
+
+func (x FocusChargeClass) Enum() *FocusChargeClass {
+	p := new(FocusChargeClass)
+	*p = x
+	return p
+}
+
+func (x FocusChargeClass) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (FocusChargeClass) Descriptor() protoreflect.EnumDescriptor {
+	return file_pulumicost_v1_enums_proto_enumTypes[3].Descriptor()
+}
+
+func (FocusChargeClass) Type() protoreflect.EnumType {
+	return &file_pulumicost_v1_enums_proto_enumTypes[3]
+}
+
+func (x FocusChargeClass) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use FocusChargeClass.Descriptor instead.
+func (FocusChargeClass) EnumDescriptor() ([]byte, []int) {
+	return file_pulumicost_v1_enums_proto_rawDescGZIP(), []int{3}
+}
+
+// FocusChargeFrequency represents how often a charge is applied.
+// FOCUS 1.2 Section 2.4: Charge Frequency
+type FocusChargeFrequency int32
+
+const (
+	FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_UNSPECIFIED FocusChargeFrequency = 0
+	FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_ONE_TIME    FocusChargeFrequency = 1
+	FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_RECURRING   FocusChargeFrequency = 2
+	FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED FocusChargeFrequency = 3
+)
+
+// Enum value maps for FocusChargeFrequency.
+var (
+	FocusChargeFrequency_name = map[int32]string{
+		0: "FOCUS_CHARGE_FREQUENCY_UNSPECIFIED",
+		1: "FOCUS_CHARGE_FREQUENCY_ONE_TIME",
+		2: "FOCUS_CHARGE_FREQUENCY_RECURRING",
+		3: "FOCUS_CHARGE_FREQUENCY_USAGE_BASED",
+	}
+	FocusChargeFrequency_value = map[string]int32{
+		"FOCUS_CHARGE_FREQUENCY_UNSPECIFIED": 0,
+		"FOCUS_CHARGE_FREQUENCY_ONE_TIME":    1,
+		"FOCUS_CHARGE_FREQUENCY_RECURRING":   2,
+		"FOCUS_CHARGE_FREQUENCY_USAGE_BASED": 3,
+	}
+)
+
+func (x FocusChargeFrequency) Enum() *FocusChargeFrequency {
+	p := new(FocusChargeFrequency)
+	*p = x
+	return p
+}
+
+func (x FocusChargeFrequency) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (FocusChargeFrequency) Descriptor() protoreflect.EnumDescriptor {
+	return file_pulumicost_v1_enums_proto_enumTypes[4].Descriptor()
+}
+
+func (FocusChargeFrequency) Type() protoreflect.EnumType {
+	return &file_pulumicost_v1_enums_proto_enumTypes[4]
+}
+
+func (x FocusChargeFrequency) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use FocusChargeFrequency.Descriptor instead.
+func (FocusChargeFrequency) EnumDescriptor() ([]byte, []int) {
+	return file_pulumicost_v1_enums_proto_rawDescGZIP(), []int{4}
+}
+
+// FocusCommitmentDiscountCategory represents the type of commitment discount.
+// FOCUS 1.2 Section 2.6: Commitment Discounts
+type FocusCommitmentDiscountCategory int32
+
+const (
+	FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_UNSPECIFIED FocusCommitmentDiscountCategory = 0
+	FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_SPEND       FocusCommitmentDiscountCategory = 1
+	FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE       FocusCommitmentDiscountCategory = 2
+)
+
+// Enum value maps for FocusCommitmentDiscountCategory.
+var (
+	FocusCommitmentDiscountCategory_name = map[int32]string{
+		0: "FOCUS_COMMITMENT_DISCOUNT_CATEGORY_UNSPECIFIED",
+		1: "FOCUS_COMMITMENT_DISCOUNT_CATEGORY_SPEND",
+		2: "FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE",
+	}
+	FocusCommitmentDiscountCategory_value = map[string]int32{
+		"FOCUS_COMMITMENT_DISCOUNT_CATEGORY_UNSPECIFIED": 0,
+		"FOCUS_COMMITMENT_DISCOUNT_CATEGORY_SPEND":       1,
+		"FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE":       2,
+	}
+)
+
+func (x FocusCommitmentDiscountCategory) Enum() *FocusCommitmentDiscountCategory {
+	p := new(FocusCommitmentDiscountCategory)
+	*p = x
+	return p
+}
+
+func (x FocusCommitmentDiscountCategory) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (FocusCommitmentDiscountCategory) Descriptor() protoreflect.EnumDescriptor {
+	return file_pulumicost_v1_enums_proto_enumTypes[5].Descriptor()
+}
+
+func (FocusCommitmentDiscountCategory) Type() protoreflect.EnumType {
+	return &file_pulumicost_v1_enums_proto_enumTypes[5]
+}
+
+func (x FocusCommitmentDiscountCategory) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use FocusCommitmentDiscountCategory.Descriptor instead.
+func (FocusCommitmentDiscountCategory) EnumDescriptor() ([]byte, []int) {
+	return file_pulumicost_v1_enums_proto_rawDescGZIP(), []int{5}
+}
+
+// FocusCommitmentDiscountStatus represents the utilization status of a
+// commitment discount. FOCUS 1.2 Section 3.17: Commitment Discount Status
+type FocusCommitmentDiscountStatus int32
+
+const (
+	FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED FocusCommitmentDiscountStatus = 0
+	// Used: Charges utilizing a specific commitment discount amount.
+	FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_USED FocusCommitmentDiscountStatus = 1
+	// Unused: Charges representing the unused portion of a commitment discount.
+	FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED FocusCommitmentDiscountStatus = 2
+)
+
+// Enum value maps for FocusCommitmentDiscountStatus.
+var (
+	FocusCommitmentDiscountStatus_name = map[int32]string{
+		0: "FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED",
+		1: "FOCUS_COMMITMENT_DISCOUNT_STATUS_USED",
+		2: "FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED",
+	}
+	FocusCommitmentDiscountStatus_value = map[string]int32{
+		"FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED": 0,
+		"FOCUS_COMMITMENT_DISCOUNT_STATUS_USED":        1,
+		"FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED":      2,
+	}
+)
+
+func (x FocusCommitmentDiscountStatus) Enum() *FocusCommitmentDiscountStatus {
+	p := new(FocusCommitmentDiscountStatus)
+	*p = x
+	return p
+}
+
+func (x FocusCommitmentDiscountStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (FocusCommitmentDiscountStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_pulumicost_v1_enums_proto_enumTypes[6].Descriptor()
+}
+
+func (FocusCommitmentDiscountStatus) Type() protoreflect.EnumType {
+	return &file_pulumicost_v1_enums_proto_enumTypes[6]
+}
+
+func (x FocusCommitmentDiscountStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use FocusCommitmentDiscountStatus.Descriptor instead.
+func (FocusCommitmentDiscountStatus) EnumDescriptor() ([]byte, []int) {
+	return file_pulumicost_v1_enums_proto_rawDescGZIP(), []int{6}
+}
+
+// FocusCapacityReservationStatus represents the utilization status of a
+// capacity reservation. FOCUS 1.2 Section 3.7: Capacity Reservation Status
+type FocusCapacityReservationStatus int32
+
+const (
+	FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED FocusCapacityReservationStatus = 0
+	// Used: Charges utilizing a specific capacity reservation amount.
+	FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_USED FocusCapacityReservationStatus = 1
+	// Unused: Charges representing the unused portion of a capacity reservation.
+	FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED FocusCapacityReservationStatus = 2
+)
+
+// Enum value maps for FocusCapacityReservationStatus.
+var (
+	FocusCapacityReservationStatus_name = map[int32]string{
+		0: "FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED",
+		1: "FOCUS_CAPACITY_RESERVATION_STATUS_USED",
+		2: "FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED",
+	}
+	FocusCapacityReservationStatus_value = map[string]int32{
+		"FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED": 0,
+		"FOCUS_CAPACITY_RESERVATION_STATUS_USED":        1,
+		"FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED":      2,
+	}
+)
+
+func (x FocusCapacityReservationStatus) Enum() *FocusCapacityReservationStatus {
+	p := new(FocusCapacityReservationStatus)
+	*p = x
+	return p
+}
+
+func (x FocusCapacityReservationStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (FocusCapacityReservationStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_pulumicost_v1_enums_proto_enumTypes[7].Descriptor()
+}
+
+func (FocusCapacityReservationStatus) Type() protoreflect.EnumType {
+	return &file_pulumicost_v1_enums_proto_enumTypes[7]
+}
+
+func (x FocusCapacityReservationStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use FocusCapacityReservationStatus.Descriptor instead.
+func (FocusCapacityReservationStatus) EnumDescriptor() ([]byte, []int) {
+	return file_pulumicost_v1_enums_proto_rawDescGZIP(), []int{7}
+}
+
 var File_pulumicost_v1_enums_proto protoreflect.FileDescriptor
 
 const file_pulumicost_v1_enums_proto_rawDesc = "" +
@@ -245,7 +508,28 @@ const file_pulumicost_v1_enums_proto_rawDesc = "" +
 	"\x1fFOCUS_PRICING_CATEGORY_STANDARD\x10\x01\x12$\n" +
 	" FOCUS_PRICING_CATEGORY_COMMITTED\x10\x02\x12\"\n" +
 	"\x1eFOCUS_PRICING_CATEGORY_DYNAMIC\x10\x03\x12 \n" +
-	"\x1cFOCUS_PRICING_CATEGORY_OTHER\x10\x04B4Z2github.com/rshade/pulumicost-spec/sdk/go/proto;pbcb\x06proto3"
+	"\x1cFOCUS_PRICING_CATEGORY_OTHER\x10\x04*y\n" +
+	"\x10FocusChargeClass\x12\"\n" +
+	"\x1eFOCUS_CHARGE_CLASS_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aFOCUS_CHARGE_CLASS_REGULAR\x10\x01\x12!\n" +
+	"\x1dFOCUS_CHARGE_CLASS_CORRECTION\x10\x02*\xb1\x01\n" +
+	"\x14FocusChargeFrequency\x12&\n" +
+	"\"FOCUS_CHARGE_FREQUENCY_UNSPECIFIED\x10\x00\x12#\n" +
+	"\x1fFOCUS_CHARGE_FREQUENCY_ONE_TIME\x10\x01\x12$\n" +
+	" FOCUS_CHARGE_FREQUENCY_RECURRING\x10\x02\x12&\n" +
+	"\"FOCUS_CHARGE_FREQUENCY_USAGE_BASED\x10\x03*\xb1\x01\n" +
+	"\x1fFocusCommitmentDiscountCategory\x122\n" +
+	".FOCUS_COMMITMENT_DISCOUNT_CATEGORY_UNSPECIFIED\x10\x00\x12,\n" +
+	"(FOCUS_COMMITMENT_DISCOUNT_CATEGORY_SPEND\x10\x01\x12,\n" +
+	"(FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE\x10\x02*\xa9\x01\n" +
+	"\x1dFocusCommitmentDiscountStatus\x120\n" +
+	",FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED\x10\x00\x12)\n" +
+	"%FOCUS_COMMITMENT_DISCOUNT_STATUS_USED\x10\x01\x12+\n" +
+	"'FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED\x10\x02*\xad\x01\n" +
+	"\x1eFocusCapacityReservationStatus\x121\n" +
+	"-FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED\x10\x00\x12*\n" +
+	"&FOCUS_CAPACITY_RESERVATION_STATUS_USED\x10\x01\x12,\n" +
+	"(FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED\x10\x02B4Z2github.com/rshade/pulumicost-spec/sdk/go/proto;pbcb\x06proto3"
 
 var (
 	file_pulumicost_v1_enums_proto_rawDescOnce sync.Once
@@ -259,11 +543,16 @@ func file_pulumicost_v1_enums_proto_rawDescGZIP() []byte {
 	return file_pulumicost_v1_enums_proto_rawDescData
 }
 
-var file_pulumicost_v1_enums_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_pulumicost_v1_enums_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
 var file_pulumicost_v1_enums_proto_goTypes = []any{
-	(FocusServiceCategory)(0), // 0: pulumicost.v1.FocusServiceCategory
-	(FocusChargeCategory)(0),  // 1: pulumicost.v1.FocusChargeCategory
-	(FocusPricingCategory)(0), // 2: pulumicost.v1.FocusPricingCategory
+	(FocusServiceCategory)(0),            // 0: pulumicost.v1.FocusServiceCategory
+	(FocusChargeCategory)(0),             // 1: pulumicost.v1.FocusChargeCategory
+	(FocusPricingCategory)(0),            // 2: pulumicost.v1.FocusPricingCategory
+	(FocusChargeClass)(0),                // 3: pulumicost.v1.FocusChargeClass
+	(FocusChargeFrequency)(0),            // 4: pulumicost.v1.FocusChargeFrequency
+	(FocusCommitmentDiscountCategory)(0), // 5: pulumicost.v1.FocusCommitmentDiscountCategory
+	(FocusCommitmentDiscountStatus)(0),   // 6: pulumicost.v1.FocusCommitmentDiscountStatus
+	(FocusCapacityReservationStatus)(0),  // 7: pulumicost.v1.FocusCapacityReservationStatus
 }
 var file_pulumicost_v1_enums_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -283,7 +572,7 @@ func file_pulumicost_v1_enums_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pulumicost_v1_enums_proto_rawDesc), len(file_pulumicost_v1_enums_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      8,
 			NumMessages:   0,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/sdk/go/proto/pulumicost/v1/focus.pb.go
+++ b/sdk/go/proto/pulumicost/v1/focus.pb.go
@@ -23,40 +23,151 @@ const (
 )
 
 // FocusCostRecord represents a single cost line item normalized to the
-// FinOps FOCUS 1.2 specification.
+// FinOps FOCUS 1.2 specification. All field names follow FOCUS naming conventions.
+// Reference: https://focus.finops.org
 type FocusCostRecord struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// --- Identity & Hierarchy ---
-	ProviderName       string `protobuf:"bytes,1,opt,name=provider_name,json=providerName,proto3" json:"provider_name,omitempty"`
-	BillingAccountId   string `protobuf:"bytes,2,opt,name=billing_account_id,json=billingAccountId,proto3" json:"billing_account_id,omitempty"`
+	// ProviderName: The name of the cloud provider (e.g., "AWS", "Azure", "GCP").
+	ProviderName string `protobuf:"bytes,1,opt,name=provider_name,json=providerName,proto3" json:"provider_name,omitempty"`
+	// BillingAccountId: The identifier for the billing account.
+	BillingAccountId string `protobuf:"bytes,2,opt,name=billing_account_id,json=billingAccountId,proto3" json:"billing_account_id,omitempty"`
+	// BillingAccountName: The display name for the billing account.
 	BillingAccountName string `protobuf:"bytes,3,opt,name=billing_account_name,json=billingAccountName,proto3" json:"billing_account_name,omitempty"`
-	// --- Time ---
+	// SubAccountId: The identifier for the sub-account (e.g., AWS Account ID,
+	// Azure Subscription ID, GCP Project ID).
+	SubAccountId string `protobuf:"bytes,24,opt,name=sub_account_id,json=subAccountId,proto3" json:"sub_account_id,omitempty"`
+	// SubAccountName: The display name for the sub-account.
+	SubAccountName string `protobuf:"bytes,25,opt,name=sub_account_name,json=subAccountName,proto3" json:"sub_account_name,omitempty"`
+	// BillingAccountType: Provider-assigned name to identify the type of billing
+	// account. FOCUS 1.2 Section 3.3: Billing Account Type (CONDITIONAL).
+	BillingAccountType string `protobuf:"bytes,42,opt,name=billing_account_type,json=billingAccountType,proto3" json:"billing_account_type,omitempty"`
+	// SubAccountType: Provider-assigned identifier for sub-account classification.
+	// FOCUS 1.2 Section 3.45: Sub Account Type (CONDITIONAL).
+	SubAccountType string `protobuf:"bytes,43,opt,name=sub_account_type,json=subAccountType,proto3" json:"sub_account_type,omitempty"`
+	// BillingPeriodStart: The start date/time of the billing period.
+	BillingPeriodStart *timestamppb.Timestamp `protobuf:"bytes,26,opt,name=billing_period_start,json=billingPeriodStart,proto3" json:"billing_period_start,omitempty"`
+	// BillingPeriodEnd: The end date/time of the billing period.
+	BillingPeriodEnd *timestamppb.Timestamp `protobuf:"bytes,27,opt,name=billing_period_end,json=billingPeriodEnd,proto3" json:"billing_period_end,omitempty"`
+	// BillingCurrency: The currency used for billing (ISO 4217 code).
+	BillingCurrency string `protobuf:"bytes,18,opt,name=billing_currency,json=billingCurrency,proto3" json:"billing_currency,omitempty"`
+	// ChargePeriodStart: The start date/time when the charge was incurred.
 	ChargePeriodStart *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=charge_period_start,json=chargePeriodStart,proto3" json:"charge_period_start,omitempty"`
-	ChargePeriodEnd   *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=charge_period_end,json=chargePeriodEnd,proto3" json:"charge_period_end,omitempty"`
-	// --- Service & Product ---
-	ServiceCategory FocusServiceCategory `protobuf:"varint,6,opt,name=service_category,json=serviceCategory,proto3,enum=pulumicost.v1.FocusServiceCategory" json:"service_category,omitempty"`
-	ServiceName     string               `protobuf:"bytes,7,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
-	ResourceId      string               `protobuf:"bytes,12,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
-	ResourceName    string               `protobuf:"bytes,13,opt,name=resource_name,json=resourceName,proto3" json:"resource_name,omitempty"`
-	SkuId           string               `protobuf:"bytes,14,opt,name=sku_id,json=skuId,proto3" json:"sku_id,omitempty"`
-	RegionId        string               `protobuf:"bytes,10,opt,name=region_id,json=regionId,proto3" json:"region_id,omitempty"`
-	RegionName      string               `protobuf:"bytes,11,opt,name=region_name,json=regionName,proto3" json:"region_name,omitempty"`
-	// --- Charge Details ---
-	ChargeCategory  FocusChargeCategory  `protobuf:"varint,8,opt,name=charge_category,json=chargeCategory,proto3,enum=pulumicost.v1.FocusChargeCategory" json:"charge_category,omitempty"`
+	// ChargePeriodEnd: The end date/time when the charge was incurred.
+	ChargePeriodEnd *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=charge_period_end,json=chargePeriodEnd,proto3" json:"charge_period_end,omitempty"`
+	// ChargeCategory: The nature of the charge (Usage, Purchase, Credit, etc.).
+	ChargeCategory FocusChargeCategory `protobuf:"varint,8,opt,name=charge_category,json=chargeCategory,proto3,enum=pulumicost.v1.FocusChargeCategory" json:"charge_category,omitempty"`
+	// ChargeClass: Classification of the charge (Regular, Correction).
+	// New in FOCUS 1.0+.
+	ChargeClass FocusChargeClass `protobuf:"varint,28,opt,name=charge_class,json=chargeClass,proto3,enum=pulumicost.v1.FocusChargeClass" json:"charge_class,omitempty"`
+	// ChargeDescription: A human-readable description of the charge.
+	ChargeDescription string `protobuf:"bytes,29,opt,name=charge_description,json=chargeDescription,proto3" json:"charge_description,omitempty"`
+	// ChargeFrequency: How often the charge is applied (OneTime, Recurring, UsageBased).
+	ChargeFrequency FocusChargeFrequency `protobuf:"varint,30,opt,name=charge_frequency,json=chargeFrequency,proto3,enum=pulumicost.v1.FocusChargeFrequency" json:"charge_frequency,omitempty"`
+	// PricingCategory: The pricing model applied (Standard, Committed, Dynamic).
 	PricingCategory FocusPricingCategory `protobuf:"varint,9,opt,name=pricing_category,json=pricingCategory,proto3,enum=pulumicost.v1.FocusPricingCategory" json:"pricing_category,omitempty"`
-	// --- Financials ---
-	BilledCost    float64 `protobuf:"fixed64,15,opt,name=billed_cost,json=billedCost,proto3" json:"billed_cost,omitempty"`
-	ListCost      float64 `protobuf:"fixed64,16,opt,name=list_cost,json=listCost,proto3" json:"list_cost,omitempty"`
+	// PricingQuantity: The quantity used for pricing calculations.
+	PricingQuantity float64 `protobuf:"fixed64,31,opt,name=pricing_quantity,json=pricingQuantity,proto3" json:"pricing_quantity,omitempty"`
+	// PricingUnit: The unit of measure for pricing (e.g., "Hours", "GB").
+	PricingUnit string `protobuf:"bytes,32,opt,name=pricing_unit,json=pricingUnit,proto3" json:"pricing_unit,omitempty"`
+	// ListUnitPrice: The published unit price before any discounts.
+	ListUnitPrice float64 `protobuf:"fixed64,33,opt,name=list_unit_price,json=listUnitPrice,proto3" json:"list_unit_price,omitempty"`
+	// PricingCurrency: Currency for pricing-related columns when different from
+	// billing currency. FOCUS 1.2 Section 3.34: Pricing Currency (CONDITIONAL).
+	// Format: ISO 4217 currency code.
+	PricingCurrency string `protobuf:"bytes,51,opt,name=pricing_currency,json=pricingCurrency,proto3" json:"pricing_currency,omitempty"`
+	// PricingCurrencyContractedUnitPrice: Contracted unit price denominated in
+	// pricing currency. FOCUS 1.2 Section 3.35 (CONDITIONAL).
+	PricingCurrencyContractedUnitPrice float64 `protobuf:"fixed64,52,opt,name=pricing_currency_contracted_unit_price,json=pricingCurrencyContractedUnitPrice,proto3" json:"pricing_currency_contracted_unit_price,omitempty"`
+	// PricingCurrencyEffectiveCost: Effective cost denominated in pricing
+	// currency. FOCUS 1.2 Section 3.36 (CONDITIONAL).
+	PricingCurrencyEffectiveCost float64 `protobuf:"fixed64,53,opt,name=pricing_currency_effective_cost,json=pricingCurrencyEffectiveCost,proto3" json:"pricing_currency_effective_cost,omitempty"`
+	// PricingCurrencyListUnitPrice: List unit price denominated in pricing
+	// currency. FOCUS 1.2 Section 3.37 (CONDITIONAL).
+	PricingCurrencyListUnitPrice float64 `protobuf:"fixed64,54,opt,name=pricing_currency_list_unit_price,json=pricingCurrencyListUnitPrice,proto3" json:"pricing_currency_list_unit_price,omitempty"`
+	// ServiceCategory: The category of the service (Compute, Storage, Network, etc.).
+	ServiceCategory FocusServiceCategory `protobuf:"varint,6,opt,name=service_category,json=serviceCategory,proto3,enum=pulumicost.v1.FocusServiceCategory" json:"service_category,omitempty"`
+	// ServiceName: The name of the service (e.g., "Amazon EC2", "Azure VMs").
+	ServiceName string `protobuf:"bytes,7,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
+	// ServiceSubcategory: Granular service classification supporting functional
+	// categorization. FOCUS 1.2 Section 3.43: Service Subcategory (CONDITIONAL).
+	ServiceSubcategory string `protobuf:"bytes,56,opt,name=service_subcategory,json=serviceSubcategory,proto3" json:"service_subcategory,omitempty"`
+	// Publisher: Entity that published the service or product.
+	// FOCUS 1.2 Section 3.39: Publisher (CONDITIONAL).
+	Publisher string `protobuf:"bytes,55,opt,name=publisher,proto3" json:"publisher,omitempty"`
+	// ResourceId: The unique identifier for the resource.
+	ResourceId string `protobuf:"bytes,12,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	// ResourceName: The display name of the resource.
+	ResourceName string `protobuf:"bytes,13,opt,name=resource_name,json=resourceName,proto3" json:"resource_name,omitempty"`
+	// ResourceType: The type of resource (e.g., "m5.large", "Standard_D2s_v3").
+	ResourceType string `protobuf:"bytes,34,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
+	// SkuId: The identifier for the SKU.
+	SkuId string `protobuf:"bytes,14,opt,name=sku_id,json=skuId,proto3" json:"sku_id,omitempty"`
+	// SkuPriceId: The identifier for the specific SKU price.
+	SkuPriceId string `protobuf:"bytes,35,opt,name=sku_price_id,json=skuPriceId,proto3" json:"sku_price_id,omitempty"`
+	// SkuMeter: Provider-assigned meter identifier for the SKU.
+	// FOCUS 1.2 Section 3.46: SKU Meter (CONDITIONAL).
+	SkuMeter string `protobuf:"bytes,57,opt,name=sku_meter,json=skuMeter,proto3" json:"sku_meter,omitempty"`
+	// SkuPriceDetails: Additional provider-specific pricing details.
+	// FOCUS 1.2 Section 3.48: SKU Price Details (CONDITIONAL).
+	SkuPriceDetails string `protobuf:"bytes,58,opt,name=sku_price_details,json=skuPriceDetails,proto3" json:"sku_price_details,omitempty"`
+	// RegionId: The identifier for the region (e.g., "us-east-1", "eastus").
+	RegionId string `protobuf:"bytes,10,opt,name=region_id,json=regionId,proto3" json:"region_id,omitempty"`
+	// RegionName: The display name of the region.
+	RegionName string `protobuf:"bytes,11,opt,name=region_name,json=regionName,proto3" json:"region_name,omitempty"`
+	// AvailabilityZone: The availability zone within the region (conditional).
+	AvailabilityZone string `protobuf:"bytes,36,opt,name=availability_zone,json=availabilityZone,proto3" json:"availability_zone,omitempty"`
+	// BilledCost: The amount billed for the charge.
+	BilledCost float64 `protobuf:"fixed64,15,opt,name=billed_cost,json=billedCost,proto3" json:"billed_cost,omitempty"`
+	// ListCost: The cost at list price before any discounts.
+	ListCost float64 `protobuf:"fixed64,16,opt,name=list_cost,json=listCost,proto3" json:"list_cost,omitempty"`
+	// EffectiveCost: The actual cost after all discounts and adjustments.
 	EffectiveCost float64 `protobuf:"fixed64,17,opt,name=effective_cost,json=effectiveCost,proto3" json:"effective_cost,omitempty"`
-	Currency      string  `protobuf:"bytes,18,opt,name=currency,proto3" json:"currency,omitempty"`
-	InvoiceId     string  `protobuf:"bytes,19,opt,name=invoice_id,json=invoiceId,proto3" json:"invoice_id,omitempty"`
-	// --- Usage ---
-	UsageQuantity float64 `protobuf:"fixed64,20,opt,name=usage_quantity,json=usageQuantity,proto3" json:"usage_quantity,omitempty"`
-	UsageUnit     string  `protobuf:"bytes,21,opt,name=usage_unit,json=usageUnit,proto3" json:"usage_unit,omitempty"`
-	// --- Metadata & Extension ---
+	// ContractedCost: Cost calculated by multiplying contracted unit price and
+	// pricing quantity. FOCUS 1.2 Section 3.20: Contracted Cost (MANDATORY).
+	// Constraint: Must equal ContractedUnitPrice × PricingQuantity when both
+	// are present and ChargeClass is not "Correction".
+	ContractedCost float64 `protobuf:"fixed64,41,opt,name=contracted_cost,json=contractedCost,proto3" json:"contracted_cost,omitempty"`
+	// ContractedUnitPrice: Agreed-upon unit price per pricing unit for the
+	// associated SKU. FOCUS 1.2 Section 3.21: Contracted Unit Price (CONDITIONAL).
+	ContractedUnitPrice float64 `protobuf:"fixed64,50,opt,name=contracted_unit_price,json=contractedUnitPrice,proto3" json:"contracted_unit_price,omitempty"`
+	// ConsumedQuantity: The amount of usage consumed.
+	ConsumedQuantity float64 `protobuf:"fixed64,20,opt,name=consumed_quantity,json=consumedQuantity,proto3" json:"consumed_quantity,omitempty"`
+	// ConsumedUnit: The unit of measure for consumption (e.g., "Hours", "GB").
+	ConsumedUnit string `protobuf:"bytes,21,opt,name=consumed_unit,json=consumedUnit,proto3" json:"consumed_unit,omitempty"`
+	// CommitmentDiscountCategory: The type of commitment discount (Spend, Usage).
+	CommitmentDiscountCategory FocusCommitmentDiscountCategory `protobuf:"varint,37,opt,name=commitment_discount_category,json=commitmentDiscountCategory,proto3,enum=pulumicost.v1.FocusCommitmentDiscountCategory" json:"commitment_discount_category,omitempty"`
+	// CommitmentDiscountId: The identifier for the commitment discount.
+	CommitmentDiscountId string `protobuf:"bytes,38,opt,name=commitment_discount_id,json=commitmentDiscountId,proto3" json:"commitment_discount_id,omitempty"`
+	// CommitmentDiscountName: The display name of the commitment discount.
+	CommitmentDiscountName string `protobuf:"bytes,39,opt,name=commitment_discount_name,json=commitmentDiscountName,proto3" json:"commitment_discount_name,omitempty"`
+	// CommitmentDiscountQuantity: Amount of commitment discount purchased or
+	// accounted for. FOCUS 1.2 Section 3.14 (CONDITIONAL).
+	CommitmentDiscountQuantity float64 `protobuf:"fixed64,46,opt,name=commitment_discount_quantity,json=commitmentDiscountQuantity,proto3" json:"commitment_discount_quantity,omitempty"`
+	// CommitmentDiscountStatus: Utilization status of commitment discount.
+	// FOCUS 1.2 Section 3.17 (CONDITIONAL). Required when CommitmentDiscountId
+	// is not null and ChargeCategory is "Usage".
+	CommitmentDiscountStatus FocusCommitmentDiscountStatus `protobuf:"varint,47,opt,name=commitment_discount_status,json=commitmentDiscountStatus,proto3,enum=pulumicost.v1.FocusCommitmentDiscountStatus" json:"commitment_discount_status,omitempty"`
+	// CommitmentDiscountType: Provider-assigned identifier for the type of
+	// commitment discount applied. FOCUS 1.2 Section 3.18 (CONDITIONAL).
+	CommitmentDiscountType string `protobuf:"bytes,48,opt,name=commitment_discount_type,json=commitmentDiscountType,proto3" json:"commitment_discount_type,omitempty"`
+	// CommitmentDiscountUnit: Provider-specified measurement unit for commitment
+	// discount quantity. FOCUS 1.2 Section 3.19 (CONDITIONAL).
+	CommitmentDiscountUnit string `protobuf:"bytes,49,opt,name=commitment_discount_unit,json=commitmentDiscountUnit,proto3" json:"commitment_discount_unit,omitempty"`
+	// CapacityReservationId: Identifier assigned to a capacity reservation by
+	// the provider. FOCUS 1.2 Section 3.6 (CONDITIONAL).
+	CapacityReservationId string `protobuf:"bytes,44,opt,name=capacity_reservation_id,json=capacityReservationId,proto3" json:"capacity_reservation_id,omitempty"`
+	// CapacityReservationStatus: Utilization status of capacity reservation.
+	// FOCUS 1.2 Section 3.7 (CONDITIONAL). Required when CapacityReservationId
+	// is not null and ChargeCategory is "Usage".
+	CapacityReservationStatus FocusCapacityReservationStatus `protobuf:"varint,45,opt,name=capacity_reservation_status,json=capacityReservationStatus,proto3,enum=pulumicost.v1.FocusCapacityReservationStatus" json:"capacity_reservation_status,omitempty"`
+	// InvoiceId: The identifier for the invoice. Critical for reconciliation.
+	InvoiceId string `protobuf:"bytes,19,opt,name=invoice_id,json=invoiceId,proto3" json:"invoice_id,omitempty"`
+	// InvoiceIssuer: The entity that issued the invoice.
+	InvoiceIssuer string `protobuf:"bytes,40,opt,name=invoice_issuer,json=invoiceIssuer,proto3" json:"invoice_issuer,omitempty"`
+	// Tags: User-defined key-value pairs for resource tagging.
 	Tags map[string]string `protobuf:"bytes,22,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// The "Backpack": Supports future FOCUS columns or provider-specific
-	// extensions without requiring a schema update.
+	// ExtendedColumns: The "Backpack" - supports future FOCUS columns or
+	// provider-specific extensions without requiring a schema update.
 	ExtendedColumns map[string]string `protobuf:"bytes,23,rep,name=extended_columns,json=extendedColumns,proto3" json:"extended_columns,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
@@ -113,6 +224,55 @@ func (x *FocusCostRecord) GetBillingAccountName() string {
 	return ""
 }
 
+func (x *FocusCostRecord) GetSubAccountId() string {
+	if x != nil {
+		return x.SubAccountId
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetSubAccountName() string {
+	if x != nil {
+		return x.SubAccountName
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetBillingAccountType() string {
+	if x != nil {
+		return x.BillingAccountType
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetSubAccountType() string {
+	if x != nil {
+		return x.SubAccountType
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetBillingPeriodStart() *timestamppb.Timestamp {
+	if x != nil {
+		return x.BillingPeriodStart
+	}
+	return nil
+}
+
+func (x *FocusCostRecord) GetBillingPeriodEnd() *timestamppb.Timestamp {
+	if x != nil {
+		return x.BillingPeriodEnd
+	}
+	return nil
+}
+
+func (x *FocusCostRecord) GetBillingCurrency() string {
+	if x != nil {
+		return x.BillingCurrency
+	}
+	return ""
+}
+
 func (x *FocusCostRecord) GetChargePeriodStart() *timestamppb.Timestamp {
 	if x != nil {
 		return x.ChargePeriodStart
@@ -127,6 +287,90 @@ func (x *FocusCostRecord) GetChargePeriodEnd() *timestamppb.Timestamp {
 	return nil
 }
 
+func (x *FocusCostRecord) GetChargeCategory() FocusChargeCategory {
+	if x != nil {
+		return x.ChargeCategory
+	}
+	return FocusChargeCategory_FOCUS_CHARGE_CATEGORY_UNSPECIFIED
+}
+
+func (x *FocusCostRecord) GetChargeClass() FocusChargeClass {
+	if x != nil {
+		return x.ChargeClass
+	}
+	return FocusChargeClass_FOCUS_CHARGE_CLASS_UNSPECIFIED
+}
+
+func (x *FocusCostRecord) GetChargeDescription() string {
+	if x != nil {
+		return x.ChargeDescription
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetChargeFrequency() FocusChargeFrequency {
+	if x != nil {
+		return x.ChargeFrequency
+	}
+	return FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_UNSPECIFIED
+}
+
+func (x *FocusCostRecord) GetPricingCategory() FocusPricingCategory {
+	if x != nil {
+		return x.PricingCategory
+	}
+	return FocusPricingCategory_FOCUS_PRICING_CATEGORY_UNSPECIFIED
+}
+
+func (x *FocusCostRecord) GetPricingQuantity() float64 {
+	if x != nil {
+		return x.PricingQuantity
+	}
+	return 0
+}
+
+func (x *FocusCostRecord) GetPricingUnit() string {
+	if x != nil {
+		return x.PricingUnit
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetListUnitPrice() float64 {
+	if x != nil {
+		return x.ListUnitPrice
+	}
+	return 0
+}
+
+func (x *FocusCostRecord) GetPricingCurrency() string {
+	if x != nil {
+		return x.PricingCurrency
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetPricingCurrencyContractedUnitPrice() float64 {
+	if x != nil {
+		return x.PricingCurrencyContractedUnitPrice
+	}
+	return 0
+}
+
+func (x *FocusCostRecord) GetPricingCurrencyEffectiveCost() float64 {
+	if x != nil {
+		return x.PricingCurrencyEffectiveCost
+	}
+	return 0
+}
+
+func (x *FocusCostRecord) GetPricingCurrencyListUnitPrice() float64 {
+	if x != nil {
+		return x.PricingCurrencyListUnitPrice
+	}
+	return 0
+}
+
 func (x *FocusCostRecord) GetServiceCategory() FocusServiceCategory {
 	if x != nil {
 		return x.ServiceCategory
@@ -137,6 +381,20 @@ func (x *FocusCostRecord) GetServiceCategory() FocusServiceCategory {
 func (x *FocusCostRecord) GetServiceName() string {
 	if x != nil {
 		return x.ServiceName
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetServiceSubcategory() string {
+	if x != nil {
+		return x.ServiceSubcategory
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetPublisher() string {
+	if x != nil {
+		return x.Publisher
 	}
 	return ""
 }
@@ -155,9 +413,37 @@ func (x *FocusCostRecord) GetResourceName() string {
 	return ""
 }
 
+func (x *FocusCostRecord) GetResourceType() string {
+	if x != nil {
+		return x.ResourceType
+	}
+	return ""
+}
+
 func (x *FocusCostRecord) GetSkuId() string {
 	if x != nil {
 		return x.SkuId
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetSkuPriceId() string {
+	if x != nil {
+		return x.SkuPriceId
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetSkuMeter() string {
+	if x != nil {
+		return x.SkuMeter
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetSkuPriceDetails() string {
+	if x != nil {
+		return x.SkuPriceDetails
 	}
 	return ""
 }
@@ -176,18 +462,11 @@ func (x *FocusCostRecord) GetRegionName() string {
 	return ""
 }
 
-func (x *FocusCostRecord) GetChargeCategory() FocusChargeCategory {
+func (x *FocusCostRecord) GetAvailabilityZone() string {
 	if x != nil {
-		return x.ChargeCategory
+		return x.AvailabilityZone
 	}
-	return FocusChargeCategory_FOCUS_CHARGE_CATEGORY_UNSPECIFIED
-}
-
-func (x *FocusCostRecord) GetPricingCategory() FocusPricingCategory {
-	if x != nil {
-		return x.PricingCategory
-	}
-	return FocusPricingCategory_FOCUS_PRICING_CATEGORY_UNSPECIFIED
+	return ""
 }
 
 func (x *FocusCostRecord) GetBilledCost() float64 {
@@ -211,11 +490,95 @@ func (x *FocusCostRecord) GetEffectiveCost() float64 {
 	return 0
 }
 
-func (x *FocusCostRecord) GetCurrency() string {
+func (x *FocusCostRecord) GetContractedCost() float64 {
 	if x != nil {
-		return x.Currency
+		return x.ContractedCost
+	}
+	return 0
+}
+
+func (x *FocusCostRecord) GetContractedUnitPrice() float64 {
+	if x != nil {
+		return x.ContractedUnitPrice
+	}
+	return 0
+}
+
+func (x *FocusCostRecord) GetConsumedQuantity() float64 {
+	if x != nil {
+		return x.ConsumedQuantity
+	}
+	return 0
+}
+
+func (x *FocusCostRecord) GetConsumedUnit() string {
+	if x != nil {
+		return x.ConsumedUnit
 	}
 	return ""
+}
+
+func (x *FocusCostRecord) GetCommitmentDiscountCategory() FocusCommitmentDiscountCategory {
+	if x != nil {
+		return x.CommitmentDiscountCategory
+	}
+	return FocusCommitmentDiscountCategory_FOCUS_COMMITMENT_DISCOUNT_CATEGORY_UNSPECIFIED
+}
+
+func (x *FocusCostRecord) GetCommitmentDiscountId() string {
+	if x != nil {
+		return x.CommitmentDiscountId
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetCommitmentDiscountName() string {
+	if x != nil {
+		return x.CommitmentDiscountName
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetCommitmentDiscountQuantity() float64 {
+	if x != nil {
+		return x.CommitmentDiscountQuantity
+	}
+	return 0
+}
+
+func (x *FocusCostRecord) GetCommitmentDiscountStatus() FocusCommitmentDiscountStatus {
+	if x != nil {
+		return x.CommitmentDiscountStatus
+	}
+	return FocusCommitmentDiscountStatus_FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED
+}
+
+func (x *FocusCostRecord) GetCommitmentDiscountType() string {
+	if x != nil {
+		return x.CommitmentDiscountType
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetCommitmentDiscountUnit() string {
+	if x != nil {
+		return x.CommitmentDiscountUnit
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetCapacityReservationId() string {
+	if x != nil {
+		return x.CapacityReservationId
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetCapacityReservationStatus() FocusCapacityReservationStatus {
+	if x != nil {
+		return x.CapacityReservationStatus
+	}
+	return FocusCapacityReservationStatus_FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED
 }
 
 func (x *FocusCostRecord) GetInvoiceId() string {
@@ -225,16 +588,9 @@ func (x *FocusCostRecord) GetInvoiceId() string {
 	return ""
 }
 
-func (x *FocusCostRecord) GetUsageQuantity() float64 {
+func (x *FocusCostRecord) GetInvoiceIssuer() string {
 	if x != nil {
-		return x.UsageQuantity
-	}
-	return 0
-}
-
-func (x *FocusCostRecord) GetUsageUnit() string {
-	if x != nil {
-		return x.UsageUnit
+		return x.InvoiceIssuer
 	}
 	return ""
 }
@@ -257,35 +613,70 @@ var File_pulumicost_v1_focus_proto protoreflect.FileDescriptor
 
 const file_pulumicost_v1_focus_proto_rawDesc = "" +
 	"\n" +
-	"\x19pulumicost/v1/focus.proto\x12\rpulumicost.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x19pulumicost/v1/enums.proto\"\xd6\t\n" +
+	"\x19pulumicost/v1/focus.proto\x12\rpulumicost.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x19pulumicost/v1/enums.proto\"\xb7\x19\n" +
 	"\x0fFocusCostRecord\x12#\n" +
 	"\rprovider_name\x18\x01 \x01(\tR\fproviderName\x12,\n" +
 	"\x12billing_account_id\x18\x02 \x01(\tR\x10billingAccountId\x120\n" +
-	"\x14billing_account_name\x18\x03 \x01(\tR\x12billingAccountName\x12J\n" +
+	"\x14billing_account_name\x18\x03 \x01(\tR\x12billingAccountName\x12$\n" +
+	"\x0esub_account_id\x18\x18 \x01(\tR\fsubAccountId\x12(\n" +
+	"\x10sub_account_name\x18\x19 \x01(\tR\x0esubAccountName\x120\n" +
+	"\x14billing_account_type\x18* \x01(\tR\x12billingAccountType\x12(\n" +
+	"\x10sub_account_type\x18+ \x01(\tR\x0esubAccountType\x12L\n" +
+	"\x14billing_period_start\x18\x1a \x01(\v2\x1a.google.protobuf.TimestampR\x12billingPeriodStart\x12H\n" +
+	"\x12billing_period_end\x18\x1b \x01(\v2\x1a.google.protobuf.TimestampR\x10billingPeriodEnd\x12)\n" +
+	"\x10billing_currency\x18\x12 \x01(\tR\x0fbillingCurrency\x12J\n" +
 	"\x13charge_period_start\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\x11chargePeriodStart\x12F\n" +
-	"\x11charge_period_end\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x0fchargePeriodEnd\x12N\n" +
+	"\x11charge_period_end\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x0fchargePeriodEnd\x12K\n" +
+	"\x0fcharge_category\x18\b \x01(\x0e2\".pulumicost.v1.FocusChargeCategoryR\x0echargeCategory\x12B\n" +
+	"\fcharge_class\x18\x1c \x01(\x0e2\x1f.pulumicost.v1.FocusChargeClassR\vchargeClass\x12-\n" +
+	"\x12charge_description\x18\x1d \x01(\tR\x11chargeDescription\x12N\n" +
+	"\x10charge_frequency\x18\x1e \x01(\x0e2#.pulumicost.v1.FocusChargeFrequencyR\x0fchargeFrequency\x12N\n" +
+	"\x10pricing_category\x18\t \x01(\x0e2#.pulumicost.v1.FocusPricingCategoryR\x0fpricingCategory\x12)\n" +
+	"\x10pricing_quantity\x18\x1f \x01(\x01R\x0fpricingQuantity\x12!\n" +
+	"\fpricing_unit\x18  \x01(\tR\vpricingUnit\x12&\n" +
+	"\x0flist_unit_price\x18! \x01(\x01R\rlistUnitPrice\x12)\n" +
+	"\x10pricing_currency\x183 \x01(\tR\x0fpricingCurrency\x12R\n" +
+	"&pricing_currency_contracted_unit_price\x184 \x01(\x01R\"pricingCurrencyContractedUnitPrice\x12E\n" +
+	"\x1fpricing_currency_effective_cost\x185 \x01(\x01R\x1cpricingCurrencyEffectiveCost\x12F\n" +
+	" pricing_currency_list_unit_price\x186 \x01(\x01R\x1cpricingCurrencyListUnitPrice\x12N\n" +
 	"\x10service_category\x18\x06 \x01(\x0e2#.pulumicost.v1.FocusServiceCategoryR\x0fserviceCategory\x12!\n" +
-	"\fservice_name\x18\a \x01(\tR\vserviceName\x12\x1f\n" +
+	"\fservice_name\x18\a \x01(\tR\vserviceName\x12/\n" +
+	"\x13service_subcategory\x188 \x01(\tR\x12serviceSubcategory\x12\x1c\n" +
+	"\tpublisher\x187 \x01(\tR\tpublisher\x12\x1f\n" +
 	"\vresource_id\x18\f \x01(\tR\n" +
 	"resourceId\x12#\n" +
-	"\rresource_name\x18\r \x01(\tR\fresourceName\x12\x15\n" +
-	"\x06sku_id\x18\x0e \x01(\tR\x05skuId\x12\x1b\n" +
+	"\rresource_name\x18\r \x01(\tR\fresourceName\x12#\n" +
+	"\rresource_type\x18\" \x01(\tR\fresourceType\x12\x15\n" +
+	"\x06sku_id\x18\x0e \x01(\tR\x05skuId\x12 \n" +
+	"\fsku_price_id\x18# \x01(\tR\n" +
+	"skuPriceId\x12\x1b\n" +
+	"\tsku_meter\x189 \x01(\tR\bskuMeter\x12*\n" +
+	"\x11sku_price_details\x18: \x01(\tR\x0fskuPriceDetails\x12\x1b\n" +
 	"\tregion_id\x18\n" +
 	" \x01(\tR\bregionId\x12\x1f\n" +
 	"\vregion_name\x18\v \x01(\tR\n" +
-	"regionName\x12K\n" +
-	"\x0fcharge_category\x18\b \x01(\x0e2\".pulumicost.v1.FocusChargeCategoryR\x0echargeCategory\x12N\n" +
-	"\x10pricing_category\x18\t \x01(\x0e2#.pulumicost.v1.FocusPricingCategoryR\x0fpricingCategory\x12\x1f\n" +
+	"regionName\x12+\n" +
+	"\x11availability_zone\x18$ \x01(\tR\x10availabilityZone\x12\x1f\n" +
 	"\vbilled_cost\x18\x0f \x01(\x01R\n" +
 	"billedCost\x12\x1b\n" +
 	"\tlist_cost\x18\x10 \x01(\x01R\blistCost\x12%\n" +
-	"\x0eeffective_cost\x18\x11 \x01(\x01R\reffectiveCost\x12\x1a\n" +
-	"\bcurrency\x18\x12 \x01(\tR\bcurrency\x12\x1d\n" +
+	"\x0eeffective_cost\x18\x11 \x01(\x01R\reffectiveCost\x12'\n" +
+	"\x0fcontracted_cost\x18) \x01(\x01R\x0econtractedCost\x122\n" +
+	"\x15contracted_unit_price\x182 \x01(\x01R\x13contractedUnitPrice\x12+\n" +
+	"\x11consumed_quantity\x18\x14 \x01(\x01R\x10consumedQuantity\x12#\n" +
+	"\rconsumed_unit\x18\x15 \x01(\tR\fconsumedUnit\x12p\n" +
+	"\x1ccommitment_discount_category\x18% \x01(\x0e2..pulumicost.v1.FocusCommitmentDiscountCategoryR\x1acommitmentDiscountCategory\x124\n" +
+	"\x16commitment_discount_id\x18& \x01(\tR\x14commitmentDiscountId\x128\n" +
+	"\x18commitment_discount_name\x18' \x01(\tR\x16commitmentDiscountName\x12@\n" +
+	"\x1ccommitment_discount_quantity\x18. \x01(\x01R\x1acommitmentDiscountQuantity\x12j\n" +
+	"\x1acommitment_discount_status\x18/ \x01(\x0e2,.pulumicost.v1.FocusCommitmentDiscountStatusR\x18commitmentDiscountStatus\x128\n" +
+	"\x18commitment_discount_type\x180 \x01(\tR\x16commitmentDiscountType\x128\n" +
+	"\x18commitment_discount_unit\x181 \x01(\tR\x16commitmentDiscountUnit\x126\n" +
+	"\x17capacity_reservation_id\x18, \x01(\tR\x15capacityReservationId\x12m\n" +
+	"\x1bcapacity_reservation_status\x18- \x01(\x0e2-.pulumicost.v1.FocusCapacityReservationStatusR\x19capacityReservationStatus\x12\x1d\n" +
 	"\n" +
 	"invoice_id\x18\x13 \x01(\tR\tinvoiceId\x12%\n" +
-	"\x0eusage_quantity\x18\x14 \x01(\x01R\rusageQuantity\x12\x1d\n" +
-	"\n" +
-	"usage_unit\x18\x15 \x01(\tR\tusageUnit\x12<\n" +
+	"\x0einvoice_issuer\x18( \x01(\tR\rinvoiceIssuer\x12<\n" +
 	"\x04tags\x18\x16 \x03(\v2(.pulumicost.v1.FocusCostRecord.TagsEntryR\x04tags\x12^\n" +
 	"\x10extended_columns\x18\x17 \x03(\v23.pulumicost.v1.FocusCostRecord.ExtendedColumnsEntryR\x0fextendedColumns\x1a7\n" +
 	"\tTagsEntry\x12\x10\n" +
@@ -309,27 +700,39 @@ func file_pulumicost_v1_focus_proto_rawDescGZIP() []byte {
 
 var file_pulumicost_v1_focus_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_pulumicost_v1_focus_proto_goTypes = []any{
-	(*FocusCostRecord)(nil),       // 0: pulumicost.v1.FocusCostRecord
-	nil,                           // 1: pulumicost.v1.FocusCostRecord.TagsEntry
-	nil,                           // 2: pulumicost.v1.FocusCostRecord.ExtendedColumnsEntry
-	(*timestamppb.Timestamp)(nil), // 3: google.protobuf.Timestamp
-	(FocusServiceCategory)(0),     // 4: pulumicost.v1.FocusServiceCategory
-	(FocusChargeCategory)(0),      // 5: pulumicost.v1.FocusChargeCategory
-	(FocusPricingCategory)(0),     // 6: pulumicost.v1.FocusPricingCategory
+	(*FocusCostRecord)(nil),              // 0: pulumicost.v1.FocusCostRecord
+	nil,                                  // 1: pulumicost.v1.FocusCostRecord.TagsEntry
+	nil,                                  // 2: pulumicost.v1.FocusCostRecord.ExtendedColumnsEntry
+	(*timestamppb.Timestamp)(nil),        // 3: google.protobuf.Timestamp
+	(FocusChargeCategory)(0),             // 4: pulumicost.v1.FocusChargeCategory
+	(FocusChargeClass)(0),                // 5: pulumicost.v1.FocusChargeClass
+	(FocusChargeFrequency)(0),            // 6: pulumicost.v1.FocusChargeFrequency
+	(FocusPricingCategory)(0),            // 7: pulumicost.v1.FocusPricingCategory
+	(FocusServiceCategory)(0),            // 8: pulumicost.v1.FocusServiceCategory
+	(FocusCommitmentDiscountCategory)(0), // 9: pulumicost.v1.FocusCommitmentDiscountCategory
+	(FocusCommitmentDiscountStatus)(0),   // 10: pulumicost.v1.FocusCommitmentDiscountStatus
+	(FocusCapacityReservationStatus)(0),  // 11: pulumicost.v1.FocusCapacityReservationStatus
 }
 var file_pulumicost_v1_focus_proto_depIdxs = []int32{
-	3, // 0: pulumicost.v1.FocusCostRecord.charge_period_start:type_name -> google.protobuf.Timestamp
-	3, // 1: pulumicost.v1.FocusCostRecord.charge_period_end:type_name -> google.protobuf.Timestamp
-	4, // 2: pulumicost.v1.FocusCostRecord.service_category:type_name -> pulumicost.v1.FocusServiceCategory
-	5, // 3: pulumicost.v1.FocusCostRecord.charge_category:type_name -> pulumicost.v1.FocusChargeCategory
-	6, // 4: pulumicost.v1.FocusCostRecord.pricing_category:type_name -> pulumicost.v1.FocusPricingCategory
-	1, // 5: pulumicost.v1.FocusCostRecord.tags:type_name -> pulumicost.v1.FocusCostRecord.TagsEntry
-	2, // 6: pulumicost.v1.FocusCostRecord.extended_columns:type_name -> pulumicost.v1.FocusCostRecord.ExtendedColumnsEntry
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	3,  // 0: pulumicost.v1.FocusCostRecord.billing_period_start:type_name -> google.protobuf.Timestamp
+	3,  // 1: pulumicost.v1.FocusCostRecord.billing_period_end:type_name -> google.protobuf.Timestamp
+	3,  // 2: pulumicost.v1.FocusCostRecord.charge_period_start:type_name -> google.protobuf.Timestamp
+	3,  // 3: pulumicost.v1.FocusCostRecord.charge_period_end:type_name -> google.protobuf.Timestamp
+	4,  // 4: pulumicost.v1.FocusCostRecord.charge_category:type_name -> pulumicost.v1.FocusChargeCategory
+	5,  // 5: pulumicost.v1.FocusCostRecord.charge_class:type_name -> pulumicost.v1.FocusChargeClass
+	6,  // 6: pulumicost.v1.FocusCostRecord.charge_frequency:type_name -> pulumicost.v1.FocusChargeFrequency
+	7,  // 7: pulumicost.v1.FocusCostRecord.pricing_category:type_name -> pulumicost.v1.FocusPricingCategory
+	8,  // 8: pulumicost.v1.FocusCostRecord.service_category:type_name -> pulumicost.v1.FocusServiceCategory
+	9,  // 9: pulumicost.v1.FocusCostRecord.commitment_discount_category:type_name -> pulumicost.v1.FocusCommitmentDiscountCategory
+	10, // 10: pulumicost.v1.FocusCostRecord.commitment_discount_status:type_name -> pulumicost.v1.FocusCommitmentDiscountStatus
+	11, // 11: pulumicost.v1.FocusCostRecord.capacity_reservation_status:type_name -> pulumicost.v1.FocusCapacityReservationStatus
+	1,  // 12: pulumicost.v1.FocusCostRecord.tags:type_name -> pulumicost.v1.FocusCostRecord.TagsEntry
+	2,  // 13: pulumicost.v1.FocusCostRecord.extended_columns:type_name -> pulumicost.v1.FocusCostRecord.ExtendedColumnsEntry
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_pulumicost_v1_focus_proto_init() }

--- a/specs/010-focus-column-audit/checklists/requirements.md
+++ b/specs/010-focus-column-audit/checklists/requirements.md
@@ -1,0 +1,73 @@
+# Specification Quality Checklist: FOCUS 1.2 Column Audit
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-28
+**Updated**: 2025-11-28 (Post-clarification with official FOCUS 1.2 validation)
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Documentation Coverage
+
+- [x] Documentation requirements specified (FR-010 through FR-015)
+- [x] Documentation success criteria defined (SC-007 through SC-011)
+- [x] Developer documentation scope defined (SDK guide, godoc, examples)
+- [x] User documentation scope defined (FOCUS column reference, provider mappings)
+- [x] 80%+ godoc coverage requirement specified
+
+## FOCUS 1.2 Validation (Clarification Session)
+
+- [x] Official FOCUS 1.2 specification consulted as authoritative source
+- [x] All 57 columns identified and catalogued
+- [x] Column types verified (String, Decimal, DateTime)
+- [x] Feature levels documented (Mandatory, Recommended, Conditional)
+- [x] BillingFrequency confirmed as non-existent (ChargeFrequency is correct)
+- [x] Missing mandatory column identified: ContractedCost
+- [x] 18 missing conditional columns documented
+
+## Audit Summary
+
+| Metric | Original Claim | Corrected Value |
+|--------|----------------|-----------------|
+| Total FOCUS 1.2 Columns | 35 | **57** |
+| Currently Implemented | 34 | **38** |
+| Missing | 1 | **19** |
+| Missing Mandatory | 0 | **1 (ContractedCost)** |
+
+## Notes
+
+- All items pass validation
+- Specification corrected based on official FOCUS 1.2 specification research
+- Original claim of "BillingFrequency missing" was incorrect - no such column exists
+- ChargeFrequency (One-Time, Recurring, Usage-Based) is already implemented
+- **Critical finding**: ContractedCost is the only missing MANDATORY column
+- 18 conditional columns remain unimplemented but are lower priority
+- Specification is ready for `/speckit.plan`
+
+## Sources
+
+- [FOCUS Specification v1.2](https://focus.finops.org/focus-specification/v1-2/)
+- [FOCUS Column Library](https://focus.finops.org/focus-columns/)

--- a/specs/010-focus-column-audit/contracts/focus_proto_additions.proto
+++ b/specs/010-focus-column-audit/contracts/focus_proto_additions.proto
@@ -1,0 +1,152 @@
+// FOCUS 1.2 Column Audit - Proto Field Additions
+// This file documents the proto field additions required for full FOCUS 1.2 compliance.
+// These definitions should be merged into proto/pulumicost/v1/focus.proto and enums.proto.
+
+syntax = "proto3";
+
+package pulumicost.v1;
+
+// =============================================================================
+// NEW ENUM TYPES (add to enums.proto)
+// =============================================================================
+
+// FocusCommitmentDiscountStatus represents the status of commitment discount usage.
+// FOCUS 1.2 Section 3.17: Commitment Discount Status
+enum FocusCommitmentDiscountStatus {
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED = 0;
+  // Used: Charges utilizing a specific commitment discount amount.
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_USED = 1;
+  // Unused: Charges representing the unused portion of a commitment discount.
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED = 2;
+}
+
+// FocusCapacityReservationStatus represents the status of capacity reservation usage.
+// FOCUS 1.2 Section 3.7: Capacity Reservation Status
+enum FocusCapacityReservationStatus {
+  FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED = 0;
+  // Used: Charges utilizing a specific capacity reservation amount.
+  FOCUS_CAPACITY_RESERVATION_STATUS_USED = 1;
+  // Unused: Charges representing the unused portion of a capacity reservation.
+  FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED = 2;
+}
+
+// =============================================================================
+// NEW FIELDS FOR FocusCostRecord (add to focus.proto)
+// =============================================================================
+
+// The following fields should be added to the FocusCostRecord message.
+// Field numbers 41-58 are reserved for these additions.
+
+message FocusCostRecordAdditions {
+  // ==========================================================================
+  // Financial Fields (FOCUS 1.2 Section 3.20)
+  // ==========================================================================
+
+  // ContractedCost: Cost calculated by multiplying contracted unit price and
+  // pricing quantity. MANDATORY column.
+  // Constraint: Must equal ContractedUnitPrice × PricingQuantity when both
+  // are present and ChargeClass is not "Correction".
+  double contracted_cost = 41;
+
+  // ==========================================================================
+  // Account Type Fields (FOCUS 1.2 Sections 3.3, 3.45)
+  // ==========================================================================
+
+  // BillingAccountType: Provider-assigned name to identify the type of
+  // billing account. CONDITIONAL column.
+  string billing_account_type = 42;
+
+  // SubAccountType: Provider-assigned identifier for sub-account
+  // classification. CONDITIONAL column.
+  string sub_account_type = 43;
+
+  // ==========================================================================
+  // Capacity Reservation Fields (FOCUS 1.2 Sections 3.6, 3.7)
+  // ==========================================================================
+
+  // CapacityReservationId: Identifier assigned to a capacity reservation
+  // by the provider. CONDITIONAL column.
+  string capacity_reservation_id = 44;
+
+  // CapacityReservationStatus: Used/Unused status of capacity reservation.
+  // CONDITIONAL column. Required when CapacityReservationId is not null
+  // and ChargeCategory is "Usage".
+  FocusCapacityReservationStatus capacity_reservation_status = 45;
+
+  // ==========================================================================
+  // Commitment Discount Extended Fields (FOCUS 1.2 Sections 3.14-3.19)
+  // ==========================================================================
+
+  // CommitmentDiscountQuantity: Amount of commitment discount purchased or
+  // accounted for. CONDITIONAL column.
+  double commitment_discount_quantity = 46;
+
+  // CommitmentDiscountStatus: Used/Unused status of commitment discount.
+  // CONDITIONAL column. Required when CommitmentDiscountId is not null
+  // and ChargeCategory is "Usage".
+  FocusCommitmentDiscountStatus commitment_discount_status = 47;
+
+  // CommitmentDiscountType: Provider-assigned identifier for the type of
+  // commitment discount applied. CONDITIONAL column.
+  string commitment_discount_type = 48;
+
+  // CommitmentDiscountUnit: Provider-specified measurement unit for
+  // commitment discount quantity. CONDITIONAL column.
+  string commitment_discount_unit = 49;
+
+  // ==========================================================================
+  // Contracted Pricing Fields (FOCUS 1.2 Section 3.21)
+  // ==========================================================================
+
+  // ContractedUnitPrice: Agreed-upon unit price per pricing unit for
+  // associated SKU. CONDITIONAL column.
+  double contracted_unit_price = 50;
+
+  // ==========================================================================
+  // Pricing Currency Fields (FOCUS 1.2 Sections 3.34-3.37)
+  // ==========================================================================
+
+  // PricingCurrency: Currency for pricing-related columns when different
+  // from billing currency. ISO 4217 format. CONDITIONAL column.
+  string pricing_currency = 51;
+
+  // PricingCurrencyContractedUnitPrice: Contracted unit price denominated
+  // in pricing currency. CONDITIONAL column.
+  double pricing_currency_contracted_unit_price = 52;
+
+  // PricingCurrencyEffectiveCost: Effective cost denominated in pricing
+  // currency. CONDITIONAL column.
+  double pricing_currency_effective_cost = 53;
+
+  // PricingCurrencyListUnitPrice: List unit price denominated in pricing
+  // currency. CONDITIONAL column.
+  double pricing_currency_list_unit_price = 54;
+
+  // ==========================================================================
+  // Origination Fields (FOCUS 1.2 Section 3.39)
+  // ==========================================================================
+
+  // Publisher: Entity that published the service or product.
+  // CONDITIONAL column.
+  string publisher = 55;
+
+  // ==========================================================================
+  // Service Fields (FOCUS 1.2 Section 3.43)
+  // ==========================================================================
+
+  // ServiceSubcategory: Granular service classification supporting
+  // functional categorization. CONDITIONAL column.
+  string service_subcategory = 56;
+
+  // ==========================================================================
+  // SKU Extended Fields (FOCUS 1.2 Sections 3.46, 3.48)
+  // ==========================================================================
+
+  // SkuMeter: Provider-assigned meter identifier for the SKU.
+  // CONDITIONAL column.
+  string sku_meter = 57;
+
+  // SkuPriceDetails: Additional provider-specific pricing details.
+  // CONDITIONAL column.
+  string sku_price_details = 58;
+}

--- a/specs/010-focus-column-audit/data-model.md
+++ b/specs/010-focus-column-audit/data-model.md
@@ -1,0 +1,198 @@
+# Data Model: FOCUS 1.2 Column Audit
+
+**Date**: 2025-11-28
+**Feature**: 010-focus-column-audit
+
+## Entity Overview
+
+This feature extends the existing `FocusCostRecord` proto message with 19 additional
+columns and adds 2 new enum types to achieve full FOCUS 1.2 compliance.
+
+## Primary Entity: FocusCostRecord
+
+### Current State (38 fields)
+
+The existing `FocusCostRecord` message in `proto/pulumicost/v1/focus.proto` contains
+38 fields covering 13 of 14 mandatory columns and 24 of 42 conditional columns.
+
+### Target State (57 fields)
+
+After implementation, `FocusCostRecord` will contain all 57 FOCUS 1.2 columns:
+
+- 14 mandatory columns (100%)
+- 1 recommended column (100%)
+- 42 conditional columns (100%)
+
+## New Fields
+
+### Financial Fields (Mandatory + Conditional)
+
+| Field | Proto Type | FOCUS Type | Level | Description |
+|-------|------------|------------|-------|-------------|
+| contracted_cost | double | Decimal | Mandatory | Cost = ContractedUnitPrice × PricingQuantity |
+| contracted_unit_price | double | Decimal | Conditional | Agreed-upon unit price per pricing unit |
+
+### Account Fields (Conditional)
+
+| Field | Proto Type | FOCUS Type | Level | Description |
+|-------|------------|------------|-------|-------------|
+| billing_account_type | string | String | Conditional | Type of billing account |
+| sub_account_type | string | String | Conditional | Type of sub-account |
+
+### Capacity Reservation Fields (Conditional)
+
+| Field | Proto Type | FOCUS Type | Level | Description |
+|-------|------------|------------|-------|-------------|
+| capacity_reservation_id | string | String | Conditional | Capacity reservation identifier |
+| capacity_reservation_status | FocusCapacityReservationStatus | String | Conditional | Used/Unused |
+
+### Commitment Discount Fields (Conditional)
+
+| Field | Proto Type | FOCUS Type | Level | Description |
+|-------|------------|------------|-------|-------------|
+| commitment_discount_quantity | double | Decimal | Conditional | Amount of discount |
+| commitment_discount_status | FocusCommitmentDiscountStatus | String | Conditional | Used/Unused |
+| commitment_discount_type | string | String | Conditional | Type of commitment discount |
+| commitment_discount_unit | string | String | Conditional | Unit of measurement |
+
+### Pricing Currency Fields (Conditional)
+
+| Field | Proto Type | FOCUS Type | Level | Description |
+|-------|------------|------------|-------|-------------|
+| pricing_currency | string | String | Conditional | ISO 4217 currency code |
+| pricing_currency_contracted_unit_price | double | Decimal | Conditional | Price in pricing currency |
+| pricing_currency_effective_cost | double | Decimal | Conditional | Cost in pricing currency |
+| pricing_currency_list_unit_price | double | Decimal | Conditional | List price in pricing currency |
+
+### Origination Fields (Conditional)
+
+| Field | Proto Type | FOCUS Type | Level | Description |
+|-------|------------|------------|-------|-------------|
+| publisher | string | String | Conditional | Entity that published the service |
+
+### Service Fields (Conditional)
+
+| Field | Proto Type | FOCUS Type | Level | Description |
+|-------|------------|------------|-------|-------------|
+| service_subcategory | string | String | Conditional | Granular service classification |
+
+### SKU Fields (Conditional)
+
+| Field | Proto Type | FOCUS Type | Level | Description |
+|-------|------------|------------|-------|-------------|
+| sku_meter | string | String | Conditional | Meter identifier |
+| sku_price_details | string | String | Conditional | Additional pricing details |
+
+## New Enum Types
+
+### FocusCommitmentDiscountStatus
+
+```text
+FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED = 0
+FOCUS_COMMITMENT_DISCOUNT_STATUS_USED = 1
+FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED = 2
+```
+
+**Validation Rules**:
+
+- Required when CommitmentDiscountId is not null AND ChargeCategory is Usage
+- Must be USED or UNUSED (not UNSPECIFIED) when applicable
+
+### FocusCapacityReservationStatus
+
+```text
+FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED = 0
+FOCUS_CAPACITY_RESERVATION_STATUS_USED = 1
+FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED = 2
+```
+
+**Validation Rules**:
+
+- Required when CapacityReservationId is not null AND ChargeCategory is Usage
+- Must be USED or UNUSED (not UNSPECIFIED) when applicable
+
+## Field Relationships
+
+### ContractedCost Calculation
+
+```text
+IF ContractedUnitPrice != null AND PricingQuantity != null AND ChargeClass != "Correction":
+    ContractedCost MUST EQUAL ContractedUnitPrice × PricingQuantity
+```
+
+### Commitment Discount Dependencies
+
+```text
+IF CommitmentDiscountId != null:
+    CommitmentDiscountType MUST be present
+    CommitmentDiscountUnit SHOULD be present
+    IF ChargeCategory == "Usage":
+        CommitmentDiscountStatus MUST be present
+        CommitmentDiscountQuantity SHOULD be present
+```
+
+### Capacity Reservation Dependencies
+
+```text
+IF CapacityReservationId != null AND ChargeCategory == "Usage":
+    CapacityReservationStatus MUST be present
+```
+
+### Pricing Currency Dependencies
+
+```text
+IF PricingCurrency != null AND PricingCurrency != BillingCurrency:
+    PricingCurrencyContractedUnitPrice MAY be present
+    PricingCurrencyEffectiveCost MAY be present
+    PricingCurrencyListUnitPrice MAY be present
+```
+
+## State Transitions
+
+Not applicable - FocusCostRecord is an immutable value object representing a point-in-time
+cost record. There are no state transitions.
+
+## Validation Rules Summary
+
+### Field-Level Validation
+
+| Field | Rule |
+|-------|------|
+| contracted_cost | Must be >= 0 when present |
+| pricing_currency | Must be valid ISO 4217 code when present |
+| capacity_reservation_status | Must not be UNSPECIFIED when CapacityReservationId present |
+| commitment_discount_status | Must not be UNSPECIFIED when CommitmentDiscountId present |
+
+### Cross-Field Validation
+
+| Rule | Fields Involved |
+|------|-----------------|
+| ContractedCost calculation | contracted_cost, contracted_unit_price, pricing_quantity |
+| Commitment discount completeness | commitment_discount_* fields |
+| Capacity reservation completeness | capacity_reservation_* fields |
+| Pricing currency consistency | pricing_currency, pricing_currency_* fields |
+
+## Builder Method Mapping
+
+Each new field requires a corresponding builder method:
+
+| Field | Builder Method |
+|-------|---------------|
+| contracted_cost | WithContractedCost(cost float64) |
+| billing_account_type | WithBillingAccountType(accountType string) |
+| sub_account_type | WithSubAccountType(accountType string) |
+| capacity_reservation_id | WithCapacityReservation(id string, status) |
+| capacity_reservation_status | (included in WithCapacityReservation) |
+| commitment_discount_quantity | WithCommitmentDiscountDetails(qty, status, discountType, unit) |
+| commitment_discount_status | (included in WithCommitmentDiscountDetails) |
+| commitment_discount_type | (included in WithCommitmentDiscountDetails) |
+| commitment_discount_unit | (included in WithCommitmentDiscountDetails) |
+| contracted_unit_price | WithContractedUnitPrice(price float64) |
+| pricing_currency | WithPricingCurrency(currency string) |
+| pricing_currency_contracted_unit_price | WithPricingCurrencyPrices(contracted, effective, list) |
+| pricing_currency_effective_cost | (included in WithPricingCurrencyPrices) |
+| pricing_currency_list_unit_price | (included in WithPricingCurrencyPrices) |
+| publisher | WithPublisher(publisher string) |
+| service_subcategory | WithServiceSubcategory(subcategory string) |
+| sku_meter | WithSkuDetails(meter, priceDetails string) |
+| sku_price_details | (included in WithSkuDetails) |

--- a/specs/010-focus-column-audit/plan.md
+++ b/specs/010-focus-column-audit/plan.md
@@ -1,0 +1,125 @@
+# Implementation Plan: FOCUS 1.2 Column Audit
+
+**Branch**: `010-focus-column-audit` | **Date**: 2025-11-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/010-focus-column-audit/spec.md`
+
+## Summary
+
+Complete the FOCUS 1.2 column implementation by adding 19 missing columns (1 mandatory,
+18 conditional) to `focus.proto`, updating the `FocusRecordBuilder` with corresponding
+methods, creating an automated audit script, and providing comprehensive documentation
+with 80%+ godoc coverage.
+
+## Technical Context
+
+**Language/Version**: Go 1.24+ (toolchain go1.25.4), Protocol Buffers v3
+**Primary Dependencies**: google.golang.org/protobuf, google.golang.org/grpc, buf v1.32.1
+**Storage**: N/A (specification repository - no runtime storage)
+**Testing**: go test, conformance tests via bufconn harness, buf lint/breaking
+**Target Platform**: Cross-platform gRPC specification and Go SDK
+**Project Type**: gRPC specification repository with generated SDK
+**Performance Goals**: Zero-allocation enum validation (5-12 ns/op), conformance test pass
+**Constraints**: Backward compatible proto changes, buf breaking check must pass
+**Scale/Scope**: 57 total FOCUS columns, 19 new proto fields, ~20 new builder methods
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Principle I: gRPC Proto Specification-First Development ✅
+
+- [x] Proto definitions updated before SDK code
+- [x] Proto changes drive SDK generation via `make generate`
+- [x] Comprehensive validation via buf lint
+
+### Principle II: Multi-Provider gRPC Consistency ✅
+
+- [x] New columns support all providers (AWS, Azure, GCP, Kubernetes)
+- [x] FOCUS 1.2 is inherently provider-agnostic specification
+- [x] Examples will demonstrate cross-provider mappings
+
+### Principle III: Test-First Protocol ✅
+
+- [x] Conformance tests will validate new column behavior
+- [x] Tests defined before proto implementation
+- [x] Red-Green-Refactor enforced
+
+### Principle IV: Protobuf Backward Compatibility ✅
+
+- [x] Adding new fields is backward compatible (non-breaking)
+- [x] No field removals or type changes
+- [x] buf breaking check will pass
+- [x] Field numbers carefully assigned to avoid conflicts
+
+### Principle V: Comprehensive Documentation ✅
+
+- [x] 80%+ godoc coverage required (FR-010)
+- [x] Proto comments with FOCUS section references (FR-007)
+- [x] Developer guide and user reference planned (FR-012, FR-013)
+
+### Principle VI: Performance as a gRPC Requirement ✅
+
+- [x] Zero-allocation enum validation pattern maintained
+- [x] Benchmarks for new enum types
+- [x] No performance regression expected
+
+### Principle VII: Validation at Multiple Levels ✅
+
+- [x] Protobuf layer: buf lint/breaking
+- [x] Service layer: conformance tests
+- [x] SDK layer: integration tests
+- [x] CI layer: all validation in GitHub Actions
+
+**Constitution Gate Status**: ✅ PASSED - All principles satisfied
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-focus-column-audit/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (proto field definitions)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+proto/pulumicost/v1/
+├── focus.proto          # Add 19 missing FOCUS columns
+└── enums.proto          # Add new enum types (CommitmentDiscountStatus, etc.)
+
+sdk/go/
+├── proto/               # Generated protobuf code (via buf generate)
+│   └── pulumicost/v1/
+│       ├── focus.pb.go
+│       └── enums.pb.go
+└── pluginsdk/
+    ├── focus_builder.go       # Add ~20 new With* methods
+    ├── focus_builder_test.go  # Tests for new methods
+    └── README.md              # Developer guide
+
+docs/
+└── focus-columns.md     # User-facing FOCUS column reference
+
+examples/plugins/
+└── focus_example.go     # Complete FOCUS record example
+
+scripts/
+└── audit_focus_columns.go  # Automated column audit script
+```
+
+**Structure Decision**: Single project structure - this is a specification repository
+with proto definitions and generated SDK code. No web/mobile components.
+
+## Complexity Tracking
+
+> No constitution violations requiring justification.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |

--- a/specs/010-focus-column-audit/quickstart.md
+++ b/specs/010-focus-column-audit/quickstart.md
@@ -1,0 +1,326 @@
+# Quickstart: FOCUS 1.2 Column Audit
+
+**Date**: 2025-11-28
+**Feature**: 010-focus-column-audit
+
+## Overview
+
+This quickstart guide demonstrates how to use the new FOCUS 1.2 columns added by
+this feature. After implementation, the `FocusCostRecord` message and
+`FocusRecordBuilder` will support all 57 FOCUS 1.2 columns.
+
+## Prerequisites
+
+- Go 1.24+
+- pulumicost-spec SDK v0.5.0+ (after this feature is merged)
+
+## Basic Usage
+
+### Building a Complete FOCUS Record
+
+```go
+package main
+
+import (
+    "time"
+
+    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+func main() {
+    now := time.Now()
+    periodStart := now.AddDate(0, -1, 0) // Last month
+    periodEnd := now
+
+    record, err := pluginsdk.NewFocusRecordBuilder().
+        // Identity (Mandatory)
+        WithIdentity("AWS", "123456789012", "Production Account").
+        WithSubAccount("111222333444", "Development").
+        WithBillingAccountType("Organization").       // NEW
+        WithSubAccountType("Member").                  // NEW
+
+        // Billing Period (Mandatory)
+        WithBillingPeriod(periodStart, periodEnd, "USD").
+
+        // Charge Period (Mandatory)
+        WithChargePeriod(periodStart, periodEnd).
+
+        // Charge Details (Mandatory)
+        WithChargeDetails(
+            pbc.FOCUS_CHARGE_CATEGORY_USAGE,
+            pbc.FOCUS_PRICING_CATEGORY_STANDARD,
+        ).
+        WithChargeClassification(
+            pbc.FOCUS_CHARGE_CLASS_REGULAR,
+            "EC2 Instance Usage",
+            pbc.FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+        ).
+
+        // Financial (Mandatory)
+        WithFinancials(100.00, 120.00, 100.00, "USD", "INV-2024-001").
+        WithContractedCost(95.00).                     // NEW - MANDATORY
+        WithContractedUnitPrice(0.095).                // NEW
+
+        // Service (Conditional)
+        WithService(pbc.FOCUS_SERVICE_CATEGORY_COMPUTE, "Amazon EC2").
+        WithServiceSubcategory("Virtual Machines").    // NEW
+        WithPublisher("AWS").                          // NEW
+
+        // Resource (Conditional)
+        WithResource("i-1234567890abcdef0", "web-server-1", "m5.large").
+
+        // SKU (Conditional)
+        WithSKU("sku-12345", "price-67890").
+        WithSkuDetails("hour", "On-Demand Linux/UNIX"). // NEW
+
+        // Location (Conditional)
+        WithLocation("us-east-1", "US East (N. Virginia)", "us-east-1a").
+
+        // Pricing (Conditional)
+        WithPricing(720.0, "Hours", 0.10).
+        WithPricingCurrency("EUR").                    // NEW
+        WithPricingCurrencyPrices(0.085, 90.00, 0.095). // NEW
+
+        // Usage (Conditional)
+        WithUsage(720.0, "Hours").
+
+        // Commitment Discount (Conditional)
+        WithCommitmentDiscount(
+            pbc.FOCUS_COMMITMENT_DISCOUNT_CATEGORY_USAGE,
+            "ri-12345",
+            "1-year Reserved Instance",
+        ).
+        WithCommitmentDiscountDetails(               // NEW
+            720.0, // quantity
+            pbc.FOCUS_COMMITMENT_DISCOUNT_STATUS_USED,
+            "Reserved Instance",
+            "Hours",
+        ).
+
+        // Capacity Reservation (Conditional) - NEW
+        WithCapacityReservation(
+            "cr-12345",
+            pbc.FOCUS_CAPACITY_RESERVATION_STATUS_USED,
+        ).
+
+        // Invoice (Conditional)
+        WithInvoice("INV-2024-001", "Amazon Web Services").
+
+        // Tags (Conditional)
+        WithTags(map[string]string{
+            "Environment": "Production",
+            "Team":        "Platform",
+        }).
+
+        Build()
+
+    if err != nil {
+        panic(err)
+    }
+
+    // Use the record...
+    _ = record
+}
+```
+
+## New Builder Methods
+
+### Financial Methods
+
+```go
+// ContractedCost - MANDATORY
+builder.WithContractedCost(95.00)
+
+// ContractedUnitPrice - Conditional
+builder.WithContractedUnitPrice(0.095)
+```
+
+### Account Type Methods
+
+```go
+// BillingAccountType - Conditional
+builder.WithBillingAccountType("Organization")
+
+// SubAccountType - Conditional
+builder.WithSubAccountType("Member")
+```
+
+### Capacity Reservation Methods
+
+```go
+// CapacityReservation - Conditional (sets both ID and Status)
+builder.WithCapacityReservation(
+    "cr-12345",
+    pbc.FOCUS_CAPACITY_RESERVATION_STATUS_USED,
+)
+```
+
+### Commitment Discount Extended Methods
+
+```go
+// CommitmentDiscountDetails - Conditional (sets quantity, status, type, unit)
+builder.WithCommitmentDiscountDetails(
+    720.0,                                          // quantity
+    pbc.FOCUS_COMMITMENT_DISCOUNT_STATUS_USED,      // status
+    "Reserved Instance",                            // type
+    "Hours",                                        // unit
+)
+```
+
+### Pricing Currency Methods
+
+```go
+// PricingCurrency - Conditional (ISO 4217 code)
+builder.WithPricingCurrency("EUR")
+
+// PricingCurrencyPrices - Conditional (sets all three pricing currency fields)
+builder.WithPricingCurrencyPrices(
+    0.085,  // contracted unit price in pricing currency
+    90.00,  // effective cost in pricing currency
+    0.095,  // list unit price in pricing currency
+)
+```
+
+### Service/SKU Extended Methods
+
+```go
+// Publisher - Conditional
+builder.WithPublisher("AWS")
+
+// ServiceSubcategory - Conditional
+builder.WithServiceSubcategory("Virtual Machines")
+
+// SkuDetails - Conditional (sets both meter and price details)
+builder.WithSkuDetails("hour", "On-Demand Linux/UNIX")
+```
+
+## New Enum Types
+
+### FocusCommitmentDiscountStatus
+
+```go
+pbc.FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED // 0
+pbc.FOCUS_COMMITMENT_DISCOUNT_STATUS_USED        // 1
+pbc.FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED      // 2
+```
+
+### FocusCapacityReservationStatus
+
+```go
+pbc.FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED // 0
+pbc.FOCUS_CAPACITY_RESERVATION_STATUS_USED        // 1
+pbc.FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED      // 2
+```
+
+## Validation
+
+The builder validates all fields when `Build()` is called. Validation includes:
+
+1. **Mandatory field presence**: ContractedCost must be set
+2. **Cross-field consistency**: ContractedCost = ContractedUnitPrice × PricingQuantity
+3. **Enum value validity**: Status enums must not be UNSPECIFIED when IDs are present
+4. **ISO 4217 compliance**: PricingCurrency must be valid currency code
+
+## Running the Audit Script
+
+After implementation, verify column completeness:
+
+```bash
+go run scripts/audit_focus_columns.go
+```
+
+Expected output:
+
+```text
+FOCUS 1.2 Column Audit
+======================
+Total columns: 57
+Implemented: 57
+Missing: 0
+
+✅ All FOCUS 1.2 columns are implemented
+```
+
+## Migration Guide
+
+If upgrading from a previous version:
+
+1. **Field renames**: Some fields were renamed to align with FOCUS 1.2 naming
+2. **Optional fields**: All new conditional fields default to zero values
+3. **Mandatory field**: `ContractedCost` is now mandatory - set it to match
+   your billed cost if contracted pricing is not applicable
+
+### Field Rename Migration
+
+The following fields were renamed for FOCUS 1.2 compliance:
+
+| Old Name | New Name | Migration |
+|----------|----------|-----------|
+| `Currency` | `BillingCurrency` | Use `WithFinancials()` or set directly |
+| `UsageQuantity` | `ConsumedQuantity` | Use `WithUsage()` or set directly |
+| `UsageUnit` | `ConsumedUnit` | Use `WithUsage()` or set directly |
+
+**Before (v0.1.x):**
+
+```go
+record.Currency = "USD"
+record.UsageQuantity = 720.0
+record.UsageUnit = "Hours"
+```
+
+**After (v0.2.0):**
+
+```go
+// Option 1: Use builder methods (recommended)
+builder.WithFinancials(billed, list, effective, "USD", invoiceID)
+builder.WithUsage(720.0, "Hours")
+
+// Option 2: Direct field access
+record.BillingCurrency = "USD"
+record.ConsumedQuantity = 720.0
+record.ConsumedUnit = "Hours"
+```
+
+### Adding ContractedCost
+
+```go
+// Minimal migration - use billed cost as fallback:
+builder.WithContractedCost(billedCost)
+
+// If you have contracted pricing:
+builder.WithContractedCost(contractedUnitPrice * pricingQuantity)
+builder.WithContractedUnitPrice(contractedUnitPrice)
+```
+
+### Complete Migration Example
+
+```go
+// Before: Old plugin returning raw cost data
+func (p *OldPlugin) GetCost() float64 {
+    return 100.0
+}
+
+// After: FOCUS 1.2 compliant record
+func (p *NewPlugin) GetCostRecord() (*pbc.FocusCostRecord, error) {
+    cost := 100.0
+    return pluginsdk.NewFocusRecordBuilder().
+        WithIdentity("AWS", p.AccountID, p.AccountName).
+        WithBillingPeriod(p.PeriodStart, p.PeriodEnd, "USD").
+        WithChargePeriod(p.ChargeStart, p.ChargeEnd).
+        WithChargeDetails(
+            pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+            pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
+        ).
+        WithChargeClassification(
+            pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+            "Usage charge",
+            pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+        ).
+        WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE, "EC2").
+        WithFinancials(cost, cost, cost, "USD", "").
+        WithContractedCost(cost). // Required for FOCUS 1.2
+        WithUsage(1.0, "Hour").
+        Build()
+}
+```

--- a/specs/010-focus-column-audit/research.md
+++ b/specs/010-focus-column-audit/research.md
@@ -1,0 +1,308 @@
+# Research: FOCUS 1.2 Column Audit
+
+**Date**: 2025-11-28
+**Feature**: 010-focus-column-audit
+**Source**: [FOCUS Specification v1.2](https://focus.finops.org/focus-specification/v1-2/)
+
+## Research Summary
+
+All NEEDS CLARIFICATION items have been resolved through research of the official
+FOCUS 1.2 specification. This document captures the decisions and rationale for
+implementing the 19 missing columns.
+
+## Missing Column Specifications
+
+### 1. ContractedCost (MANDATORY)
+
+**Decision**: Add as `double contracted_cost` field
+**Rationale**: Required for FOCUS compliance; calculated as ContractedUnitPrice ×
+PricingQuantity
+**Alternatives Considered**: None - mandatory column
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | Decimal → `double` in proto |
+| Feature Level | Mandatory |
+| Allows Nulls | No |
+| Description | Cost calculated by multiplying contracted unit price and pricing quantity |
+
+### 2. CommitmentDiscountStatus (CONDITIONAL)
+
+**Decision**: Add as enum `FocusCommitmentDiscountStatus` with values: Used, Unused
+**Rationale**: Limited set of allowed values suits enum pattern
+**Alternatives Considered**: String field - rejected for type safety
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String (enum) → `FocusCommitmentDiscountStatus` |
+| Feature Level | Conditional |
+| Allowed Values | Used, Unused |
+| Constraint | Required when CommitmentDiscountId not null and ChargeCategory is Usage |
+
+### 3. CommitmentDiscountType (CONDITIONAL)
+
+**Decision**: Add as `string commitment_discount_type` field
+**Rationale**: Provider-assigned identifier with no fixed values
+**Alternatives Considered**: None - string is appropriate
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Provider-assigned identifier for the type of commitment discount |
+
+### 4. CommitmentDiscountQuantity (CONDITIONAL)
+
+**Decision**: Add as `double commitment_discount_quantity` field
+**Rationale**: Decimal type for quantity values
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | Decimal → `double` |
+| Feature Level | Conditional |
+| Description | Amount of commitment discount purchased or accounted for |
+
+### 5. CommitmentDiscountUnit (CONDITIONAL)
+
+**Decision**: Add as `string commitment_discount_unit` field
+**Rationale**: Provider-specified measurement unit
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Provider-specified measurement unit for commitment discount quantity |
+
+### 6. CapacityReservationId (CONDITIONAL)
+
+**Decision**: Add as `string capacity_reservation_id` field
+**Rationale**: Provider-assigned identifier
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Identifier assigned to a capacity reservation by the provider |
+
+### 7. CapacityReservationStatus (CONDITIONAL)
+
+**Decision**: Add as enum `FocusCapacityReservationStatus` with values: Used, Unused
+**Rationale**: Limited set of allowed values suits enum pattern
+**Alternatives Considered**: String field - rejected for type safety
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String (enum) → `FocusCapacityReservationStatus` |
+| Feature Level | Conditional |
+| Allowed Values | Used, Unused |
+| Constraint | Required when CapacityReservationId not null and ChargeCategory is Usage |
+
+### 8. BillingAccountType (CONDITIONAL)
+
+**Decision**: Add as `string billing_account_type` field
+**Rationale**: Provider-assigned name with no fixed values
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Provider-assigned name to identify the type of billing account |
+
+### 9. SubAccountType (CONDITIONAL)
+
+**Decision**: Add as `string sub_account_type` field
+**Rationale**: Provider-assigned identifier with no fixed values
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Provider-assigned identifier for sub-account classification |
+
+### 10. ContractedUnitPrice (CONDITIONAL)
+
+**Decision**: Add as `double contracted_unit_price` field
+**Rationale**: Decimal type for price values
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | Decimal → `double` |
+| Feature Level | Conditional |
+| Description | Agreed-upon unit price per pricing unit for associated SKU |
+
+### 11. PricingCurrency (CONDITIONAL)
+
+**Decision**: Add as `string pricing_currency` field
+**Rationale**: ISO 4217 currency code
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Currency for pricing-related columns when different from billing currency |
+| Format | ISO 4217 currency code |
+
+### 12. PricingCurrencyContractedUnitPrice (CONDITIONAL)
+
+**Decision**: Add as `double pricing_currency_contracted_unit_price` field
+**Rationale**: Decimal type for price values in pricing currency
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | Decimal → `double` |
+| Feature Level | Conditional |
+| Description | Contracted unit price denominated in pricing currency |
+
+### 13. PricingCurrencyEffectiveCost (CONDITIONAL)
+
+**Decision**: Add as `double pricing_currency_effective_cost` field
+**Rationale**: Decimal type for cost values in pricing currency
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | Decimal → `double` |
+| Feature Level | Conditional |
+| Description | Effective cost denominated in pricing currency |
+
+### 14. PricingCurrencyListUnitPrice (CONDITIONAL)
+
+**Decision**: Add as `double pricing_currency_list_unit_price` field
+**Rationale**: Decimal type for price values in pricing currency
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | Decimal → `double` |
+| Feature Level | Conditional |
+| Description | List unit price denominated in pricing currency |
+
+### 15. Publisher (CONDITIONAL)
+
+**Decision**: Add as `string publisher` field
+**Rationale**: Provider-assigned identifier for the entity that published the service
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Entity that published the service or product |
+
+### 16. ServiceSubcategory (CONDITIONAL)
+
+**Decision**: Add as `string service_subcategory` field
+**Rationale**: Granular service classification
+**Alternatives Considered**: Enum - rejected due to variable provider values
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Granular service classification supporting functional categorization |
+
+### 17. SkuMeter (CONDITIONAL)
+
+**Decision**: Add as `string sku_meter` field
+**Rationale**: Provider-assigned meter identifier
+**Alternatives Considered**: None
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Provider-assigned meter identifier for the SKU |
+
+### 18. SkuPriceDetails (CONDITIONAL)
+
+**Decision**: Add as `string sku_price_details` field
+**Rationale**: Provider-specific pricing information
+**Alternatives Considered**: Structured type - rejected for flexibility
+
+| Attribute | Value |
+|-----------|-------|
+| Data Type | String |
+| Feature Level | Conditional |
+| Description | Additional provider-specific pricing details for the SKU |
+
+## New Enum Types Required
+
+### FocusCommitmentDiscountStatus
+
+```protobuf
+enum FocusCommitmentDiscountStatus {
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_UNSPECIFIED = 0;
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_USED = 1;
+  FOCUS_COMMITMENT_DISCOUNT_STATUS_UNUSED = 2;
+}
+```
+
+### FocusCapacityReservationStatus
+
+```protobuf
+enum FocusCapacityReservationStatus {
+  FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED = 0;
+  FOCUS_CAPACITY_RESERVATION_STATUS_USED = 1;
+  FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED = 2;
+}
+```
+
+## Proto Field Number Assignment
+
+Starting from field number 41 (last used is 40 for `invoice_issuer`):
+
+| Field Number | Column Name |
+|--------------|-------------|
+| 41 | contracted_cost |
+| 42 | billing_account_type |
+| 43 | sub_account_type |
+| 44 | capacity_reservation_id |
+| 45 | capacity_reservation_status |
+| 46 | commitment_discount_quantity |
+| 47 | commitment_discount_status |
+| 48 | commitment_discount_type |
+| 49 | commitment_discount_unit |
+| 50 | contracted_unit_price |
+| 51 | pricing_currency |
+| 52 | pricing_currency_contracted_unit_price |
+| 53 | pricing_currency_effective_cost |
+| 54 | pricing_currency_list_unit_price |
+| 55 | publisher |
+| 56 | service_subcategory |
+| 57 | sku_meter |
+| 58 | sku_price_details |
+
+## Best Practices Applied
+
+### Protobuf Design
+
+- **Field numbering**: Sequential from 41-58, avoiding reserved ranges
+- **Naming convention**: snake_case matching existing pattern
+- **Type mapping**: FOCUS Decimal → proto double, FOCUS DateTime → Timestamp
+- **Enums**: Used for columns with fixed allowed values (CommitmentDiscountStatus,
+  CapacityReservationStatus)
+
+### Documentation
+
+- **Proto comments**: Include FOCUS section reference (e.g., "// Section 3.XX")
+- **Godoc comments**: Describe purpose, parameters, return values
+- **Examples**: Show real-world usage for each new column
+
+### Testing
+
+- **Conformance tests**: Validate new column presence and types
+- **Builder tests**: Test each new With* method
+- **Audit script**: Verify 57/57 columns present
+
+## Sources
+
+- [FOCUS Specification v1.2](https://focus.finops.org/focus-specification/v1-2/)
+- [FOCUS Column Library](https://focus.finops.org/focus-columns/)

--- a/specs/010-focus-column-audit/spec.md
+++ b/specs/010-focus-column-audit/spec.md
@@ -1,0 +1,340 @@
+# Feature Specification: FOCUS 1.2 Column Audit
+
+**Feature Branch**: `010-focus-column-audit`
+**Created**: 2025-11-28
+**Status**: Draft
+**Input**: User description: "Pulumicost Spec - FinOps FOCUS 1.2 Column Audit"
+
+## Clarifications
+
+### Session 2025-11-28
+
+- Q: What is the correct column for billing frequency in FOCUS 1.2? → A: There is no
+  `BillingFrequency` column in FOCUS 1.2. The correct column is `ChargeFrequency` with
+  values: One-Time, Recurring, Usage-Based. This column is already implemented.
+- Q: How many columns are in the official FOCUS 1.2 specification? → A: 57 columns total
+  (not 35 as originally stated). Source: [FOCUS Column Library](https://focus.finops.org/focus-columns/)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Schema Completeness Verification (Priority: P1)
+
+A plugin developer wants to ensure their FOCUS 1.2 implementation covers all mandatory
+columns defined by the FinOps Foundation, so they can certify their plugin's compliance.
+
+**Why this priority**: Without complete column coverage, plugins cannot claim FOCUS 1.2
+compliance, which is a core value proposition of PulumiCost.
+
+**Independent Test**: Can be verified by comparing the proto definition against the official
+FOCUS 1.2 specification and running an automated audit script.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `focus.proto` file exists, **When** an audit script parses all field
+   definitions, **Then** every mandatory FOCUS 1.2 column is present with the correct
+   protobuf type.
+2. **Given** a missing column is detected, **When** the audit report is generated,
+   **Then** the report lists the specific column name, expected type, and FOCUS
+   specification section reference.
+
+---
+
+### User Story 2 - Type Correctness Validation (Priority: P2)
+
+A data engineer needs confidence that Protobuf types align with FOCUS data types so that
+data transformations preserve accuracy when converting between formats.
+
+**Why this priority**: Incorrect types can cause data loss or silent corruption during
+cost aggregation and reporting.
+
+**Independent Test**: Can be validated by mapping each proto field type to its FOCUS
+equivalent and verifying semantic compatibility.
+
+**Acceptance Scenarios**:
+
+1. **Given** a field defined as `google.protobuf.Timestamp` in proto, **When** compared
+   to FOCUS specification, **Then** the corresponding FOCUS column is documented as
+   DateTime type.
+2. **Given** a field defined as `double` in proto, **When** compared to FOCUS
+   specification, **Then** the corresponding FOCUS column is documented as Decimal type.
+3. **Given** an enum type in proto, **When** compared to FOCUS specification, **Then**
+   all valid enum values from FOCUS are represented in the proto enum.
+
+---
+
+### User Story 3 - Builder API Completeness (Priority: P3)
+
+A plugin developer using the Go SDK needs builder methods for all FOCUS columns so they
+can construct fully compliant cost records without directly manipulating the proto struct.
+
+**Why this priority**: Builder pattern provides a safer, more ergonomic API that reduces
+errors and improves developer experience.
+
+**Independent Test**: Can be verified by ensuring every field in `FocusCostRecord` has a
+corresponding builder method in `focus_builder.go`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new column is added to `focus.proto`, **When** the builder is updated,
+   **Then** a corresponding `With*` method exists that sets the field value.
+2. **Given** a developer uses only builder methods, **When** they call `Build()`,
+   **Then** all FOCUS mandatory fields can be populated without accessing the underlying
+   struct directly.
+
+---
+
+### User Story 4 - Developer Documentation (Priority: P2)
+
+A new plugin developer needs comprehensive documentation to understand how to use the
+FOCUS 1.2 types, builder patterns, and validation functions without reading source code.
+
+**Why this priority**: Good documentation reduces onboarding time and support burden,
+enabling faster plugin development and fewer integration errors.
+
+**Independent Test**: Can be verified by having a new developer successfully implement
+a FOCUS-compliant plugin using only the documentation (no source code reading required).
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads the SDK documentation, **When** they look up any FOCUS
+   column, **Then** they find a clear description, valid values, and usage examples.
+2. **Given** a developer wants to use the builder API, **When** they consult the
+   documentation, **Then** they find complete method signatures with parameter
+   descriptions and example code.
+3. **Given** a developer encounters a validation error, **When** they check the
+   documentation, **Then** they find troubleshooting guidance and common error resolutions.
+
+---
+
+### User Story 5 - User-Facing Documentation (Priority: P3)
+
+A FinOps practitioner or cost analyst needs reference documentation to understand what
+each FOCUS column means and how it maps to their cloud provider's billing data.
+
+**Why this priority**: End users need to understand the data model to effectively
+analyze and report on cloud costs.
+
+**Independent Test**: Can be verified by a non-developer successfully understanding
+the meaning and purpose of each FOCUS column from the documentation alone.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reads the FOCUS column reference, **When** they look up any column,
+   **Then** they find a plain-language description suitable for non-developers.
+2. **Given** a user wants to understand provider mappings, **When** they consult the
+   documentation, **Then** they find examples showing how AWS/Azure/GCP fields map to
+   FOCUS columns.
+
+---
+
+### Edge Cases
+
+- What happens when a FOCUS column is marked "conditional" rather than "mandatory"?
+  - Conditional columns should still be present in the proto but documented as optional.
+- How does the system handle FOCUS columns that may be added in future versions?
+  - The `extended_columns` map provides forward-compatibility for new columns.
+- How should documentation handle provider-specific variations?
+  - Document the canonical FOCUS representation, then provide provider-specific mapping
+    tables showing how each provider's field names translate to FOCUS columns.
+- What if a provider doesn't support a particular FOCUS column?
+  - Document which columns are universally supported vs. provider-specific, and explain
+    how to handle missing data (null values, default values, or omission).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST define all 57 FOCUS 1.2 columns in `focus.proto`, including
+  14 mandatory, 1 recommended, and 42 conditional columns.
+- **FR-002**: System MUST use `google.protobuf.Timestamp` for all DateTime fields.
+- **FR-003**: System MUST use `double` for all Decimal/Numeric fields.
+- **FR-004**: System MUST use enum types for all FOCUS enumerated columns
+  (ChargeCategory, ChargeClass, ChargeFrequency, PricingCategory, ServiceCategory,
+  CommitmentDiscountCategory).
+- **FR-005**: System MUST add the missing mandatory column `ContractedCost` (Decimal).
+- **FR-006**: System MUST add the 19 missing columns (1 mandatory, 18 conditional)
+  identified in the audit.
+- **FR-007**: Each proto field MUST include a comment referencing the specific FOCUS
+  section (e.g., "// Section 3.14: Charge Frequency").
+- **FR-008**: The `FocusRecordBuilder` MUST provide `With*` methods for all proto fields.
+- **FR-009**: An audit script MUST be created to automatically verify column coverage
+  against the official FOCUS 1.2 specification.
+
+### Documentation Requirements
+
+- **FR-010**: All exported Go functions, types, and methods MUST have godoc comments
+  achieving 80%+ documentation coverage.
+- **FR-011**: Each builder method MUST include a godoc comment describing its purpose,
+  parameters, and the FOCUS section it implements.
+- **FR-012**: A developer guide (`sdk/go/pluginsdk/README.md`) MUST be created or updated
+  with:
+  - Quick start example for building FOCUS records
+  - Complete builder method reference with examples
+  - Validation error troubleshooting guide
+  - Migration guide for existing plugins
+- **FR-013**: A user-facing FOCUS column reference (`docs/focus-columns.md`) MUST be
+  created with:
+  - Plain-language description of each FOCUS column
+  - Data type and valid values for each column
+  - Provider mapping examples (AWS, Azure, GCP to FOCUS)
+  - Common use cases and query patterns
+- **FR-014**: Proto file comments MUST serve as inline documentation, including:
+  - Column description matching FOCUS specification
+  - Data type constraints and valid value ranges
+  - Cross-references to related columns
+- **FR-015**: Code examples MUST be provided in `examples/plugins/` demonstrating:
+  - Building a complete FOCUS record with all columns
+  - Handling optional/conditional columns
+  - Validating records before submission
+
+### Key Entities
+
+- **FocusCostRecord**: The primary proto message containing all FOCUS 1.2 columns
+  representing a single cost line item.
+- **FOCUS Enum Types**: `FocusChargeCategory`, `FocusChargeClass`, `FocusChargeFrequency`,
+  `FocusPricingCategory`, `FocusServiceCategory`, `FocusCommitmentDiscountCategory`,
+  plus new enums for `CommitmentDiscountStatus`, `CommitmentDiscountType`,
+  `CapacityReservationStatus`.
+- **FocusRecordBuilder**: Go SDK helper that provides fluent API for constructing
+  valid FOCUS records.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of FOCUS 1.2 mandatory columns are present in `focus.proto`
+  (14/14 mandatory columns).
+- **SC-002**: All 57 FOCUS 1.2 columns are defined in `focus.proto`.
+- **SC-003**: 100% of proto fields have corresponding builder methods in
+  `focus_builder.go`.
+- **SC-004**: Audit script completes with zero missing mandatory columns reported.
+- **SC-005**: All enum types contain all valid values specified in FOCUS 1.2
+  documentation.
+- **SC-006**: Every proto field includes a documentation comment with FOCUS
+  section reference.
+
+### Documentation Outcomes
+
+- **SC-007**: Go documentation coverage is 80% or higher as measured by
+  `go doc` coverage tools.
+- **SC-008**: Developer guide includes working code examples that compile and
+  pass validation.
+- **SC-009**: User-facing documentation covers all 57 FOCUS columns with
+  plain-language descriptions.
+- **SC-010**: Provider mapping documentation includes at least one example per
+  major cloud provider (AWS, Azure, GCP).
+- **SC-011**: New developers can build a valid FOCUS record using only the
+  documentation within 30 minutes (validated by user testing).
+
+## Appendix: FOCUS 1.2 Column Reference
+
+### Audit Summary
+
+**Source**: [FOCUS Specification v1.2](https://focus.finops.org/focus-specification/v1-2/)
+and [FOCUS Column Library](https://focus.finops.org/focus-columns/)
+
+| Metric | Count |
+|--------|-------|
+| Total FOCUS 1.2 Columns | 57 |
+| Currently Implemented | 38 |
+| Missing | 19 |
+| Missing Mandatory | 1 |
+| Missing Conditional | 18 |
+
+### Implemented Columns (38)
+
+#### Mandatory Columns (13 of 14 implemented)
+
+| Column | Type | Proto Field |
+|--------|------|-------------|
+| BilledCost | Decimal | `billed_cost` |
+| BillingAccountId | String | `billing_account_id` |
+| BillingAccountName | String | `billing_account_name` |
+| BillingCurrency | String | `billing_currency` |
+| BillingPeriodEnd | DateTime | `billing_period_end` |
+| BillingPeriodStart | DateTime | `billing_period_start` |
+| ChargeCategory | String | `charge_category` (enum) |
+| ChargeClass | String | `charge_class` (enum) |
+| ChargeDescription | String | `charge_description` |
+| ChargePeriodEnd | DateTime | `charge_period_end` |
+| ChargePeriodStart | DateTime | `charge_period_start` |
+| Provider | String | `provider_name` |
+
+#### Recommended Columns (1 of 1 implemented)
+
+| Column | Type | Proto Field |
+|--------|------|-------------|
+| ChargeFrequency | String | `charge_frequency` (enum) |
+
+#### Conditional Columns (24 of 42 implemented)
+
+| Column | Type | Proto Field |
+|--------|------|-------------|
+| AvailabilityZone | String | `availability_zone` |
+| CommitmentDiscountCategory | String | `commitment_discount_category` (enum) |
+| CommitmentDiscountId | String | `commitment_discount_id` |
+| CommitmentDiscountName | String | `commitment_discount_name` |
+| ConsumedQuantity | Decimal | `consumed_quantity` |
+| ConsumedUnit | String | `consumed_unit` |
+| EffectiveCost | Decimal | `effective_cost` |
+| InvoiceId | String | `invoice_id` |
+| InvoiceIssuer | String | `invoice_issuer` |
+| ListCost | Decimal | `list_cost` |
+| ListUnitPrice | Decimal | `list_unit_price` |
+| PricingCategory | String | `pricing_category` (enum) |
+| PricingQuantity | Decimal | `pricing_quantity` |
+| PricingUnit | String | `pricing_unit` |
+| RegionId | String | `region_id` |
+| RegionName | String | `region_name` |
+| ResourceId | String | `resource_id` |
+| ResourceName | String | `resource_name` |
+| ResourceType | String | `resource_type` |
+| ServiceCategory | String | `service_category` (enum) |
+| ServiceName | String | `service_name` |
+| SkuId | String | `sku_id` |
+| SkuPriceId | String | `sku_price_id` |
+| SubAccountId | String | `sub_account_id` |
+| SubAccountName | String | `sub_account_name` |
+| Tags | String | `tags` (map) |
+
+### Missing Columns (19)
+
+#### Missing Mandatory (1) - HIGH PRIORITY
+
+| Column | Type | Category |
+|--------|------|----------|
+| **ContractedCost** | Decimal | Financial |
+
+#### Missing Conditional (18)
+
+| Column | Type | Category |
+|--------|------|----------|
+| BillingAccountType | String | Account |
+| SubAccountType | String | Account |
+| CapacityReservationId | String | Capacity |
+| CapacityReservationStatus | String | Capacity |
+| CommitmentDiscountQuantity | Decimal | Commitment |
+| CommitmentDiscountStatus | String | Commitment |
+| CommitmentDiscountType | String | Commitment |
+| CommitmentDiscountUnit | String | Commitment |
+| ContractedUnitPrice | Decimal | Pricing |
+| PricingCurrency | String | Pricing |
+| PricingCurrencyContractedUnitPrice | Decimal | Pricing |
+| PricingCurrencyEffectiveCost | Decimal | Pricing |
+| PricingCurrencyListUnitPrice | Decimal | Pricing |
+| Publisher | String | Origination |
+| ServiceSubcategory | String | Service |
+| SkuMeter | String | SKU |
+| SkuPriceDetails | String | SKU |
+
+### Assumptions
+
+- The [FOCUS Specification v1.2](https://focus.finops.org/focus-specification/v1-2/) is
+  the authoritative source for column definitions.
+- The `extended_columns` map provides adequate forward-compatibility for future FOCUS
+  versions.
+- Protobuf `double` type is acceptable for FOCUS Decimal fields (no precision
+  requirements specified in FOCUS).
+- Enum values in the current implementation align with FOCUS 1.2 specification values.
+- Conditional columns are important for full FOCUS compliance but can be prioritized
+  after mandatory columns are complete.

--- a/specs/010-focus-column-audit/tasks.md
+++ b/specs/010-focus-column-audit/tasks.md
@@ -1,0 +1,328 @@
+# Tasks: FOCUS 1.2 Column Audit
+
+**Input**: Design documents from `/specs/010-focus-column-audit/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: Tests ARE included as this is a spec/SDK project where conformance testing is required.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Tech Stack
+
+- **Language**: Go 1.24+ (toolchain go1.25.4), Protocol Buffers v3
+- **Dependencies**: google.golang.org/protobuf, google.golang.org/grpc, buf v1.32.1
+- **Testing**: go test, conformance tests via bufconn harness, buf lint/breaking
+- **Constraints**: Backward compatible proto changes, buf breaking check must pass
+
+## Path Conventions
+
+- **Proto definitions**: `proto/pulumicost/v1/`
+- **Generated code**: `sdk/go/proto/pulumicost/v1/`
+- **SDK code**: `sdk/go/pluginsdk/`
+- **Documentation**: `docs/`, `sdk/go/pluginsdk/README.md`
+- **Examples**: `examples/plugins/`
+- **Scripts**: `scripts/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Validate current state and prepare for implementation
+
+- [x] T001 Create feature branch `010-focus-column-audit` if not exists
+- [x] T002 [P] Verify buf CLI v1.32.1 is installed via `make generate`
+- [x] T003 [P] Run `buf breaking` to establish baseline compatibility check
+
+---
+
+## Phase 2: Foundational (Proto Definitions)
+
+**Purpose**: Add new enum types and proto fields - BLOCKS all SDK implementation
+
+**⚠️ CRITICAL**: No SDK work can begin until proto changes are complete and generated
+
+### New Enum Types
+
+- [x] T004 [P] Add `FocusCommitmentDiscountStatus` enum to `proto/pulumicost/v1/enums.proto`
+- [x] T005 [P] Add `FocusCapacityReservationStatus` enum to `proto/pulumicost/v1/enums.proto`
+
+### Proto Field Additions (19 fields)
+
+- [x] T006 [P] Add `contracted_cost` (field 41) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T007 [P] Add `billing_account_type` (field 42) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T008 [P] Add `sub_account_type` (field 43) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T009 [P] Add `capacity_reservation_id` (field 44) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T010 [P] Add `capacity_reservation_status` (field 45) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T011 [P] Add `commitment_discount_quantity` (field 46) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T012 [P] Add `commitment_discount_status` (field 47) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T013 [P] Add `commitment_discount_type` (field 48) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T014 [P] Add `commitment_discount_unit` (field 49) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T015 [P] Add `contracted_unit_price` (field 50) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T016 [P] Add `pricing_currency` (field 51) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T017 [P] Add `pricing_currency_contracted_unit_price` (field 52) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T018 [P] Add `pricing_currency_effective_cost` (field 53) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T019 [P] Add `pricing_currency_list_unit_price` (field 54) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T020 [P] Add `publisher` (field 55) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T021 [P] Add `service_subcategory` (field 56) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T022 [P] Add `sku_meter` (field 57) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T023 [P] Add `sku_price_details` (field 58) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+
+### Proto Validation and Generation
+
+- [x] T024 Run `buf lint` to validate proto syntax in `proto/pulumicost/v1/`
+- [x] T025 Run `buf breaking` to confirm backward compatibility
+- [x] T026 Run `make generate` to regenerate Go code in `sdk/go/proto/pulumicost/v1/`
+- [x] T027 Run `go build ./...` to verify generated code compiles
+
+**Checkpoint**: Proto definitions complete - SDK implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Schema Completeness Verification (Priority: P1) 🎯 MVP
+
+**Goal**: Verify all 57 FOCUS 1.2 columns are present in focus.proto with correct types
+
+**Independent Test**: Run audit script to compare proto against FOCUS 1.2 specification
+
+### Tests for User Story 1
+
+- [x] T028 [US1] Write conformance test for 57 FOCUS columns in `sdk/go/pluginsdk/focus_conformance_test.go`
+- [x] T029 [US1] Write test for new enum types validation in `sdk/go/pluginsdk/focus_conformance_test.go`
+
+### Implementation for User Story 1
+
+- [x] T030 [US1] Create audit script `scripts/audit_focus_columns.go` to verify column coverage
+- [x] T031 [US1] Add FOCUS section reference comments to all 19 new fields in `proto/pulumicost/v1/focus.proto`
+- [x] T032 [US1] Add FOCUS section reference comments to new enums in `proto/pulumicost/v1/enums.proto`
+- [x] T033 [US1] Run audit script and verify 57/57 columns pass
+
+**Checkpoint**: All 57 FOCUS 1.2 columns verified in proto with correct types
+
+---
+
+## Phase 4: User Story 2 - Type Correctness Validation (Priority: P2)
+
+**Goal**: Ensure proto types align with FOCUS data types (Decimal→double, DateTime→Timestamp)
+
+**Independent Test**: Audit script validates type mappings
+
+### Tests for User Story 2
+
+- [x] T034 [US2] Add type mapping tests to `sdk/go/pluginsdk/focus_conformance_test.go`
+- [x] T035 [US2] Add enum value completeness tests to `sdk/go/pluginsdk/focus_conformance_test.go`
+
+### Implementation for User Story 2
+
+- [x] T036 [US2] Extend audit script to validate type mappings in `scripts/audit_focus_columns.go`
+- [x] T037 [US2] Verify all enum values match FOCUS 1.2 specification (run enum conformance tests)
+- [x] T038 [US2] Update `sdk/go/pluginsdk/focus_conformance.go` with new column validation
+
+**Checkpoint**: Type correctness verified - proto types match FOCUS specification
+
+---
+
+## Phase 5: User Story 3 - Builder API Completeness (Priority: P3)
+
+**Goal**: Add builder methods for all 19 new FOCUS columns
+
+**Independent Test**: Every field in FocusCostRecord has a corresponding builder method
+
+### Tests for User Story 3
+
+- [x] T039 [US3] Write tests for `WithContractedCost` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T040 [P] [US3] Write tests for `WithBillingAccountType` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T041 [P] [US3] Write tests for `WithSubAccountType` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T042 [P] [US3] Write tests for `WithCapacityReservation` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T043 [P] [US3] Write tests for `WithCommitmentDiscountDetails` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T044 [P] [US3] Write tests for `WithContractedUnitPrice` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T045 [P] [US3] Write tests for `WithPricingCurrency` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T046 [P] [US3] Write tests for `WithPricingCurrencyPrices` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T047 [P] [US3] Write tests for `WithPublisher` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T048 [P] [US3] Write tests for `WithServiceSubcategory` in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T049 [P] [US3] Write tests for `WithSkuDetails` in `sdk/go/pluginsdk/focus_builder_test.go`
+
+### Implementation for User Story 3
+
+- [x] T050 [US3] Implement `WithContractedCost(cost float64)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T051 [P] [US3] Implement `WithBillingAccountType(accountType string)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T052 [P] [US3] Implement `WithSubAccountType(accountType string)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T053 [P] [US3] Implement `WithCapacityReservation(id string, status)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T054 [P] [US3] Implement `WithCommitmentDiscountDetails(qty, status, discountType, unit)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T055 [P] [US3] Implement `WithContractedUnitPrice(price float64)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T056 [P] [US3] Implement `WithPricingCurrency(currency string)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T057 [P] [US3] Implement `WithPricingCurrencyPrices(contracted, effective, list float64)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T058 [P] [US3] Implement `WithPublisher(publisher string)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T059 [P] [US3] Implement `WithServiceSubcategory(subcategory string)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T060 [P] [US3] Implement `WithSkuDetails(meter, priceDetails string)` in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T061 [US3] Update `ValidateFocusRecord` to validate ContractedCost (mandatory) in `sdk/go/pluginsdk/focus_conformance.go`
+- [x] T062 [US3] Run all builder tests and verify 100% pass rate
+
+**Checkpoint**: All 19 new columns have builder methods with tests
+
+---
+
+## Phase 6: User Story 4 - Developer Documentation (Priority: P2)
+
+**Goal**: Achieve 80%+ godoc coverage with comprehensive developer guide
+
+**Independent Test**: New developer can build FOCUS record using only documentation
+
+### Tests for User Story 4
+
+- [x] T063 [US4] Verify godoc coverage meets 80%+ threshold
+
+### Implementation for User Story 4
+
+- [x] T064 [P] [US4] Add godoc comments to all new builder methods in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T065 [P] [US4] Add godoc comments to new enum types in generated code comments (proto source)
+- [x] T066 [US4] Update `sdk/go/pluginsdk/README.md` with quick start example for new columns
+- [x] T067 [US4] Add migration guide section to `sdk/go/pluginsdk/README.md`
+- [x] T068 [US4] Add troubleshooting guide for validation errors to `sdk/go/pluginsdk/README.md`
+
+**Checkpoint**: 80%+ godoc coverage achieved, developer guide complete
+
+---
+
+## Phase 7: User Story 5 - User-Facing Documentation (Priority: P3)
+
+**Goal**: Create FOCUS column reference with provider mappings
+
+**Independent Test**: Non-developer can understand each column from documentation alone
+
+### Implementation for User Story 5
+
+- [x] T069 [P] [US5] Create `docs/focus-columns.md` with plain-language column descriptions
+- [x] T070 [P] [US5] Add provider mapping table (AWS, Azure, GCP) to `docs/focus-columns.md`
+- [x] T071 [US5] Add common use cases and query patterns to `docs/focus-columns.md`
+- [x] T072 [US5] Update `examples/plugins/focus_example.go` with complete 57-column example
+
+**Checkpoint**: User documentation complete with provider mappings
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cleanup
+
+- [x] T073 [P] Run `make lint` to ensure all code passes linting
+- [x] T074 [P] Run `make test` to verify all tests pass
+- [x] T075 [P] Run `buf breaking` to confirm final backward compatibility
+- [x] T076 Run `scripts/audit_focus_columns.go` and verify 57/57 columns pass
+- [x] T077 Run quickstart.md validation (compile and run example code)
+- [ ] T078 Update CHANGELOG.md with feature changes (via release-please PR)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup - BLOCKS all SDK implementation
+- **User Stories (Phase 3-7)**: All depend on Foundational phase completion
+  - US1 (Schema Completeness) must complete before US2 (Type Correctness)
+  - US2 and US3 can proceed in parallel after US1
+  - US4 (Developer Docs) and US5 (User Docs) can proceed in parallel after US3
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+```text
+Phase 1: Setup
+    ↓
+Phase 2: Foundational (Proto changes + generation)
+    ↓
+Phase 3: US1 - Schema Completeness ────────────────┐
+    ↓                                              │
+Phase 4: US2 - Type Correctness                    │
+    ↓                                              │
+Phase 5: US3 - Builder API ←───────────────────────┘
+    ↓
+    ├── Phase 6: US4 - Developer Docs ──┐
+    │                                   ├── Phase 8: Polish
+    └── Phase 7: US5 - User Docs ───────┘
+```
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Proto fields before builder methods
+- Builder methods before validation updates
+- Implementation before documentation
+
+### Parallel Opportunities
+
+**Phase 2 (Proto Changes)**: T004-T023 can all run in parallel (different lines in proto files)
+
+**Phase 5 (Builder Methods)**: T040-T049 tests and T051-T060 implementations can run in parallel
+
+**Phase 6-7 (Documentation)**: US4 and US5 can run in parallel after US3 completes
+
+---
+
+## Parallel Example: Proto Field Additions
+
+```bash
+# Launch all proto field additions together (Phase 2):
+Task: "Add contracted_cost (field 41) to FocusCostRecord"
+Task: "Add billing_account_type (field 42) to FocusCostRecord"
+Task: "Add sub_account_type (field 43) to FocusCostRecord"
+# ... all 19 fields in parallel
+```
+
+## Parallel Example: Builder Method Tests
+
+```bash
+# Launch all builder tests together (Phase 5):
+Task: "Write tests for WithBillingAccountType"
+Task: "Write tests for WithSubAccountType"
+Task: "Write tests for WithCapacityReservation"
+# ... all 11 method tests in parallel
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (Proto changes)
+3. Complete Phase 3: User Story 1 (Schema Completeness)
+4. **STOP and VALIDATE**: Run audit script to verify 57/57 columns
+5. This provides immediate value: FOCUS 1.2 compliance verified
+
+### Incremental Delivery
+
+1. Setup + Foundational → Proto changes complete
+2. US1 (Schema Completeness) → Audit script validates all columns
+3. US2 (Type Correctness) → Type mapping verified
+4. US3 (Builder API) → Full SDK support for new columns
+5. US4 + US5 (Documentation) → Developer and user guides complete
+6. Polish → Final validation and release preparation
+
+### Single Developer Strategy
+
+With one developer, complete phases sequentially:
+
+1. Phase 1 → Phase 2 → Phase 3 (MVP complete)
+2. Phase 4 → Phase 5 → Phase 6/7 → Phase 8
+
+Estimated effort: ~40-60 tasks, ~2-3 hours for proto changes, ~4-6 hours for builder + tests
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently testable via audit script and conformance tests
+- Commit after each phase completion
+- Stop at any checkpoint to validate incrementally
+- Proto field numbers 41-58 are reserved for these additions


### PR DESCRIPTION
## Summary

This PR completes the FOCUS 1.2 Column Audit feature, adding all 57 columns defined in the FinOps FOCUS 1.2 specification to the FocusCostRecord proto message with corresponding builder methods and comprehensive documentation.

## Changes

### Proto Definitions

- Added 2 new enum types to `enums.proto`:
  - `FocusCommitmentDiscountStatus` (Used, Unused)
  - `FocusCapacityReservationStatus` (Used, Unused)
- Added 19 new fields to `FocusCostRecord` (fields 41-58):
  - Financial: `contracted_cost`, `contracted_unit_price`
  - Identity: `billing_account_type`, `sub_account_type`
  - Capacity: `capacity_reservation_id`, `capacity_reservation_status`
  - Commitment: `commitment_discount_quantity`, `commitment_discount_status`, `commitment_discount_type`, `commitment_discount_unit`
  - Pricing: `pricing_currency`, `pricing_currency_contracted_unit_price`, `pricing_currency_effective_cost`, `pricing_currency_list_unit_price`
  - Service: `publisher`, `service_subcategory`
  - SKU: `sku_meter`, `sku_price_details`

### Builder API

- Added 11 new builder methods to `FocusRecordBuilder`:
  - `WithContractedCost`
  - `WithBillingAccountType`
  - `WithSubAccountType`
  - `WithCapacityReservation`
  - `WithCommitmentDiscountDetails`
  - `WithContractedUnitPrice`
  - `WithPricingCurrency`
  - `WithPricingCurrencyPrices`
  - `WithPublisher`
  - `WithServiceSubcategory`
  - `WithSkuDetails`

### Validation Enhancements

- Extended `ValidateFocusRecord` with comprehensive FOCUS 1.2 compliance:
  - 12 mandatory field validations (ProviderName, BillingAccountId, BillingPeriod, ChargePeriod, ChargeCategory, ChargeClass, ChargeDescription, ServiceCategory, ServiceName, BillingCurrency)
  - ISO 4217 currency validation for billing_currency and pricing_currency
  - ContractedCost business rule: must equal ContractedUnitPrice × PricingQuantity (with 0.01% tolerance for floating-point precision)
  - Correction charges exempt from ContractedCost calculation rule
- Refactored validation into helper functions for maintainability

### Testing

- Created `focus_conformance_test.go` with tests for:
  - 57-column schema completeness verification
  - 14 mandatory column validation
  - Type mapping verification (Decimal to float64, DateTime to Timestamp)
  - Enum value completeness for all 8 enum types
  - Mandatory field validation tests (12 test cases)
  - ISO 4217 currency validation tests (12 test cases)
  - ContractedCost business rule tests (7 test cases)
  - Usage quantity rule tests (4 test cases)
- Added comprehensive builder method tests in `focus_builder_test.go`
- Created `scripts/audit_focus_columns.go` for standalone column verification

### Documentation

- Updated `sdk/go/pluginsdk/README.md` with:
  - FOCUS 1.2 column coverage tables
  - Builder method reference by category
  - Migration guide for new mandatory field (ContractedCost)
  - Troubleshooting guide for validation errors
- Created `docs/focus-columns.md` with:
  - Complete 57-column reference with descriptions
  - Provider mappings for AWS, Azure, GCP, and Kubernetes
  - Common use cases and SQL query patterns
- Updated `examples/plugins/focus_example.go` to demonstrate all 57 columns

## FOCUS 1.2 Coverage

| Level | Count | Status |
|-------|-------|--------|
| Mandatory | 14 | Complete |
| Recommended | 1 | Complete |
| Conditional | 42 | Complete |
| **Total** | **57** | **100%** |

## Test Plan

- [x] All conformance tests pass (`go test ./sdk/go/pluginsdk/...`)
- [x] Audit script confirms 57/57 columns (`go run scripts/audit_focus_columns.go`)
- [x] All linting passes (`make lint`)
- [x] All tests pass (`make test`)
- [x] Example code compiles (`go build ./examples/plugins/...`)

## Breaking Changes

The following field renames were introduced in a previous PR (#99) to align with FOCUS 1.2 naming conventions:

- `currency` renamed to `billing_currency`
- `usage_quantity` renamed to `consumed_quantity`
- `usage_unit` renamed to `consumed_unit`

## References

- [FOCUS 1.2 Specification](https://focus.finops.org/focus-specification/v1-2/)
- Spec: `specs/010-focus-column-audit/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full FOCUS 1.2 support: 57 columns, new enums, extended record fields, multi-currency pricing, charge classifications, capacity reservations, commitment discounts, and a builder API for full-record construction.

* **Documentation**
  * Comprehensive FOCUS 1.2 reference and migration guide detailing field renames and migration steps.

* **Tests**
  * Extensive conformance, validation tests and benchmarks covering schema, types, and business rules.

* **Tools**
  * Column-audit tooling and lint configuration to acknowledge intentional schema alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->