### PR TITLE
docs(006-estimate-cost): update data-model.md with actual decimal typ…

### DIFF
--- a/specs/006-estimate-cost/data-model.md
+++ b/specs/006-estimate-cost/data-model.md
@@ -54,13 +54,13 @@ EstimateCostRequest {
 | Field        | Type               | Number | Required | Description            | Constraints                                    |
 | ------------ | ------------------ | ------ | -------- | ---------------------- | ---------------------------------------------- |
 | currency     | string             | 1      | Yes      | ISO 4217 currency code | Typically "USD", must be uppercase             |
-| cost_monthly | double             | 2      | Yes      | Estimated monthly cost | Non-negative, precision per existing cost RPCs |
+| cost_monthly | double             | 2      | Yes      | Estimated monthly cost | Non-negative; `double` type consistent with `GetProjectedCostResponse.cost_per_month` |
 
 **Validation Rules**:
 
 - `currency` MUST be a valid ISO 4217 currency code (3 uppercase letters)
 - `cost_monthly` MUST be non-negative (≥0)
-- `cost_monthly` precision follows existing GetActualCost/GetProjectedCost patterns
+- `cost_monthly` uses `double` type, consistent with `GetProjectedCostResponse.cost_per_month`
 - Zero cost is valid (e.g., free tier resources per FR-013)
 
 **Example** (Successful Estimation):
@@ -68,7 +68,7 @@ EstimateCostRequest {
 ```protobuf
 EstimateCostResponse {
   currency: "USD"
-  cost_monthly: "7.30"  // Type depends on existing RPC pattern
+  cost_monthly: 7.30  // double, consistent with GetProjectedCost.cost_per_month
 }
 ```
 
@@ -77,7 +77,7 @@ EstimateCostResponse {
 ```protobuf
 EstimateCostResponse {
   currency: "USD"
-  cost_monthly: "0.00"
+  cost_monthly: 0.0
 }
 ```
 
@@ -134,7 +134,7 @@ rpc EstimateCost(EstimateCostRequest) returns (EstimateCostResponse);
 │   EstimateCostResponse          │
 │                                 │
 │  + currency: string             │
-│  + cost_monthly: decimal        │
+│  + cost_monthly: double         │
 │                                 │
 └─────────────────────────────────┘
 ```


### PR DESCRIPTION
…e (T054)

## Summary

- Replace placeholder `decimal` type with actual `double` type in EstimateCostResponse documentation
- Add rationale referencing consistency with `GetProjectedCostResponse.cost_per_month`
- Fix examples to use numeric format instead of string format

## Changes

### data-model.md Updates

1. **Table constraints (line 57)**: Updated to explicitly reference `GetProjectedCostResponse.cost_per_month` consistency
2. **Validation rules (line 63)**: Clarified `double` type choice with rationale
3. **Examples (lines 71, 80)**: Changed from string format (`"7.30"`) to numeric format (`7.30`)
4. **Diagram (line 137)**: Changed `cost_monthly: decimal` to `cost_monthly: double`

## Verification

Verified against actual implementation:

- Proto definition (`costsource.proto:487`): `double cost_monthly = 2;`
- Generated Go code (`costsource.pb.go:2416`): `CostMonthly float64`
- Reference field (`costsource.pb.go:693`): `GetProjectedCostResponse.CostPerMonth float64`

## Test Plan

- [x] `make validate` passes
- [x] Markdown linting passes
- [x] Documentation matches proto definition
- [x] Documentation matches generated Go code

Closes #89