### PR TITLE
feat(ci): Add Lefthook git hooks with commitlint validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,29 @@ jobs:
 
       - name: Validate examples against schema
         run: node validate_examples.js
+
+  validate-commits:
+    name: Validate Commit Messages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.11.1'
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Validate PR commits
+        run: |
+          npx commitlint \
+            --from ${{ github.event.pull_request.base.sha }} \
+            --to ${{ github.event.pull_request.head.sha }} \
+            --verbose

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,6 +45,10 @@ jobs:
             Use Context7 to get the latest documentation for any libraries or frameworks referenced in the code.
 
             Be constructive and helpful in your feedback.
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+
           claude_args: |
             --model claude-sonnet-4-5-20250929
             --allowedTools Edit,Read,Write,Bash,Glob,Grep,Task

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,18 @@ npm run lint:markdown
 
 - Project board: <https://github.com/users/rshade/projects/3>
 
+## Commit Message Validation
+
+This project uses **Lefthook** with **commitlint** to enforce Conventional Commits.
+
+```bash
+make install-lefthook    # Install git hooks
+make commitlint          # Validate last commit
+make validate-commit     # Validate PR_MESSAGE.md or last commit
+```
+
+Configuration: `lefthook.yml`, `commitlint.config.js`
+
 ## Common Issues & Solutions
 
 ### YAML Linting Configuration

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ validate-npm:
 
 validate: test lint validate-npm
 
-depend:
+depend: install-lefthook
 	@echo "Installing Go development tools..."
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.4.0
 	@go install golang.org/x/tools/cmd/goimports@latest
@@ -72,3 +72,29 @@ depend:
 	@go install github.com/AlekSi/gocov-xml@latest
 	@go install github.com/tebeka/go2xunit@latest
 	@echo "Go development tools installed successfully!"
+
+# Lefthook git hooks management
+.PHONY: install-lefthook uninstall-lefthook commitlint validate-commit
+
+install-lefthook:
+	@echo "Installing Lefthook..."
+	@go install github.com/evilmartians/lefthook@latest
+	@lefthook install
+	@echo "Git hooks installed successfully!"
+
+uninstall-lefthook:
+	@echo "Uninstalling Lefthook git hooks..."
+	@lefthook uninstall
+	@echo "Git hooks uninstalled."
+
+commitlint:
+	@npx commitlint --from HEAD~1
+
+validate-commit:
+	@if [ -f PR_MESSAGE.md ]; then \
+		echo "Validating PR commit message..."; \
+		npx commitlint --edit PR_MESSAGE.md; \
+	else \
+		echo "Validating last commit message..."; \
+		git log -1 --pretty=%B | npx commitlint; \
+	fi

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,77 @@
+// Commitlint configuration for Conventional Commits
+// https://commitlint.js.org
+
 module.exports = {
-  extends: ['@commitlint/config-conventional']
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Type validation
+    'type-enum': [
+      2, // error
+      'always',
+      [
+        'feat', // New feature (minor version bump)
+        'fix', // Bug fix (patch version bump)
+        'docs', // Documentation only
+        'style', // Formatting, missing semi colons, etc
+        'refactor', // Code change that neither fixes bug nor adds feature
+        'perf', // Performance improvement
+        'test', // Adding missing tests
+        'chore', // Maintenance tasks (no version bump)
+        'ci', // CI/CD changes
+        'build', // Build system or dependencies
+        'revert', // Revert previous commit
+      ],
+    ],
+
+    // Scope validation (optional but recommended)
+    'scope-enum': [
+      2,
+      'always',
+      [
+        'proto', // Protocol buffer definitions
+        'schema', // JSON schema changes
+        'sdk', // Go SDK changes
+        'testing', // Testing framework
+        'pricing', // Pricing package
+        'registry', // Registry package
+        'currency', // Currency package
+        'pluginsdk', // Plugin SDK package
+        'examples', // Example files
+        'ci', // CI/CD pipeline
+        'deps', // Dependencies
+        'docs', // Documentation
+      ],
+    ],
+
+    // Allow empty scope for general changes
+    'scope-empty': [0],
+
+    // Length constraints
+    'header-max-length': [2, 'always', 72],
+    'body-max-line-length': [2, 'always', 100],
+
+    // Required elements
+    'type-empty': [2, 'never'],
+    'subject-empty': [2, 'never'],
+
+    // Format rules
+    'type-case': [2, 'always', 'lower-case'],
+    'subject-case': [2, 'always', ['sentence-case', 'lower-case', 'start-case']],
+
+    // No period at end of subject
+    'subject-full-stop': [2, 'never', '.'],
+
+    // Body should be separated by blank line
+    'body-leading-blank': [2, 'always'],
+
+    // Footer should be separated by blank line
+    'footer-leading-blank': [2, 'always'],
+  },
+  ignores: [
+    // Ignore WIP commits
+    (message) => message.includes('WIP'),
+    // Ignore merge commits
+    (message) => message.includes('Merge branch'),
+    (message) => message.includes('Merge pull request'),
+  ],
 };

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,65 @@
+# Lefthook configuration for pulumicost-spec
+# https://github.com/evilmartians/lefthook
+#
+# Install hooks: make install-lefthook
+# Skip hooks temporarily: git commit --no-verify
+
+# Parallel execution for performance
+parallel: true
+
+# Skip on merge/rebase commits
+skip_merge: true
+
+commit-msg:
+  commands:
+    commitlint:
+      run: npx commitlint --edit {1}
+      fail_text: |
+        ❌ Commit message validation failed
+
+        Your commit message must follow Conventional Commits format:
+        <type>[optional scope]: <description>
+
+        Valid types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert
+
+        Valid scopes: proto, schema, sdk, testing, pricing, registry, currency, pluginsdk,
+                      examples, ci, deps, docs
+
+        Examples:
+          feat: add support for hourly billing mode
+          fix(schema): correct currency enum validation
+          docs: update plugin registry examples
+
+        See: https://www.conventionalcommits.org
+
+pre-commit:
+  parallel: true
+  commands:
+    golangci-lint:
+      glob: "*.go"
+      run: PATH=~/go/bin:$PATH golangci-lint run --new-from-rev=HEAD~1
+      skip:
+        - merge
+        - rebase
+
+    markdown-lint:
+      glob: "*.md"
+      run: npm run lint:markdown
+      skip:
+        - merge
+        - rebase
+
+    yaml-lint:
+      glob: "*.{yml,yaml}"
+      run: yamllint .github/
+      skip:
+        - merge
+        - rebase
+
+pre-push:
+  commands:
+    tests:
+      run: make test
+      skip:
+        - merge
+        - rebase

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "lint:changelog": "npx keep-a-changelog lint CHANGELOG.md",
     "lint": "npm run lint:markdown && npm run lint:yaml && npm run lint:changelog",
     "test": "npm run validate && npm run lint",
-    "format": "npm run lint:markdown:fix"
+    "format": "npm run lint:markdown:fix",
+    "commitlint": "commitlint --edit",
+    "commitlint:last": "commitlint --from HEAD~1"
   },
   "dependencies": {
     "ajv": "^8.17.1",


### PR DESCRIPTION
## Summary

- Integrate Lefthook (Go-based git hooks manager) with commitlint
- Enforce Conventional Commits for release-please compatibility
- Add CI/CD validation for PR commit messages

## Changes

### New Files

1. **`lefthook.yml`**: Git hooks configuration
   - `commit-msg`: Validates commit messages via commitlint
   - `pre-commit`: Runs Go, markdown, and YAML linting
   - `pre-push`: Runs tests before push

### Modified Files

1. **`commitlint.config.js`**: Enhanced with project-specific rules
   - Valid types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert
   - Valid scopes: proto, schema, sdk, testing, pricing, registry, currency, etc.

2. **`package.json`**: Added commitlint scripts

3. **`Makefile`**: Added targets
   - `install-lefthook`: Install and activate git hooks
   - `uninstall-lefthook`: Remove git hooks
   - `commitlint`: Validate last commit
   - `validate-commit`: Validate PR_MESSAGE.md or last commit

4. **`.github/workflows/ci.yml`**: Added `validate-commits` job for PRs

5. **`CLAUDE.md`**: Added commit validation documentation

## Verification

- [x] `make lint` passes
- [x] `make test` passes
- [x] Commitlint validates correctly (valid/invalid messages tested)

Closes #55