### PR TITLE
feat(pluginsdk): centralize environment variable handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,6 +534,9 @@ cd schemas && /init            # JSON Schema validation
 
 ## Active Technologies
 
+- Go 1.25.5 (per go.mod toolchain) + Go stdlib only (`os`, `strconv`, `strings`) (013-pluginsdk-env)
+- N/A (reads environment variables at runtime) (013-pluginsdk-env)
+
 - Go 1.25.5 (as per go.mod) + google.golang.org/grpc, prometheus/client_golang (new) (014-plugin-metrics)
 - N/A (in-memory metrics only) (014-plugin-metrics)
 

--- a/sdk/go/pluginsdk/README.md
+++ b/sdk/go/pluginsdk/README.md
@@ -269,10 +269,10 @@ http.Handle("/metrics", promhttp.HandlerFor(
 
 ### Available Metrics
 
-| Metric | Type | Labels | Description |
-| ------ | ---- | ------ | ----------- |
-| `pulumicost_plugin_requests_total` | Counter | `grpc_method`, `grpc_code`, `plugin_name` | Total gRPC requests |
-| `pulumicost_plugin_request_duration_seconds` | Histogram | `grpc_method`, `plugin_name` | Request latency distribution |
+| Metric                                       | Type      | Labels                                    | Description                  |
+| -------------------------------------------- | --------- | ----------------------------------------- | ---------------------------- |
+| `pulumicost_plugin_requests_total`           | Counter   | `grpc_method`, `grpc_code`, `plugin_name` | Total gRPC requests          |
+| `pulumicost_plugin_request_duration_seconds` | Histogram | `grpc_method`, `plugin_name`              | Request latency distribution |
 
 **Histogram Buckets**: 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s
 
@@ -303,21 +303,21 @@ For handlers with typical work (1ms+), the metrics overhead is under 1% of total
 
 ### Metrics Functions
 
-| Function | Description |
-| -------- | ----------- |
-| `NewPluginMetrics(pluginName)` | Create metrics with custom registry |
+| Function                                    | Description                              |
+| ------------------------------------------- | ---------------------------------------- |
+| `NewPluginMetrics(pluginName)`              | Create metrics with custom registry      |
 | `MetricsUnaryServerInterceptor(pluginName)` | Create interceptor with default registry |
-| `MetricsInterceptorWithRegistry(metrics)` | Create interceptor with custom registry |
-| `StartMetricsServer(config)` | Start optional HTTP metrics server |
+| `MetricsInterceptorWithRegistry(metrics)`   | Create interceptor with custom registry  |
+| `StartMetricsServer(config)`                | Start optional HTTP metrics server       |
 
 ### Metrics Constants
 
-| Constant | Value | Description |
-| -------- | ----- | ----------- |
-| `MetricNamespace` | `pulumicost` | Prometheus namespace |
-| `MetricSubsystem` | `plugin` | Prometheus subsystem |
-| `DefaultMetricsPort` | `9090` | Default HTTP port |
-| `DefaultMetricsPath` | `/metrics` | Default URL path |
+| Constant             | Value        | Description          |
+| -------------------- | ------------ | -------------------- |
+| `MetricNamespace`    | `pulumicost` | Prometheus namespace |
+| `MetricSubsystem`    | `plugin`     | Prometheus subsystem |
+| `DefaultMetricsPort` | `9090`       | Default HTTP port    |
+| `DefaultMetricsPath` | `/metrics`   | Default URL path     |
 
 ## Server Configuration
 
@@ -335,7 +335,7 @@ pluginsdk.Serve(ctx, pluginsdk.ServeConfig{
 ### Port Resolution
 
 1. If `Port > 0`, uses that port
-2. If `PORT` environment variable is set, uses that
+2. If `PULUMICOST_PLUGIN_PORT` environment variable is set, uses that
 3. Otherwise, uses an ephemeral port
 
 The selected port is printed to stdout as `PORT=<port>`.
@@ -423,9 +423,9 @@ func TestPluginConformance(t *testing.T) {
 
 **Conformance Levels**:
 
-| Level                           | Description                                 | Use Case                       |
-| ------------------------------- | ------------------------------------------- | ------------------------------ |
-| `RunBasicConformance(plugin)`   | Core functionality, required for all        | Minimum validation             |
+| Level                            | Description                                | Use Case                       |
+| -------------------------------- | ------------------------------------------ | ------------------------------ |
+| `RunBasicConformance(plugin)`    | Core functionality, required for all       | Minimum validation             |
 | `RunStandardConformance(plugin)` | Production-ready (includes error handling) | Production deployments         |
 | `RunAdvancedConformance(plugin)` | High performance (strict latency limits)   | Performance-critical scenarios |
 

--- a/sdk/go/pluginsdk/env.go
+++ b/sdk/go/pluginsdk/env.go
@@ -1,0 +1,111 @@
+// Package pluginsdk provides environment variable handling for PulumiCost plugins.
+package pluginsdk
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Environment variable constants for PulumiCost plugins.
+// These constants define the canonical names for all supported environment variables.
+const (
+	// EnvPort is the canonical environment variable for plugin gRPC port.
+	// Plugins MUST use PULUMICOST_PLUGIN_PORT (no fallback to PORT).
+	EnvPort = "PULUMICOST_PLUGIN_PORT"
+
+	// EnvLogLevel is the canonical environment variable for log verbosity.
+	// Supported values: debug, info, warn, error (plugin-specific validation).
+	EnvLogLevel = "PULUMICOST_LOG_LEVEL"
+
+	// EnvLogLevelFallback is the legacy environment variable for log verbosity.
+	// GetLogLevel() checks PULUMICOST_LOG_LEVEL first, then falls back to LOG_LEVEL.
+	EnvLogLevelFallback = "LOG_LEVEL"
+
+	// EnvLogFormat is the environment variable for log output format.
+	// Supported values: json, text (plugin-specific validation).
+	EnvLogFormat = "PULUMICOST_LOG_FORMAT"
+
+	// EnvLogFile is the environment variable for log file path.
+	// Empty string means stdout.
+	EnvLogFile = "PULUMICOST_LOG_FILE"
+
+	// EnvTraceID is the environment variable for distributed tracing.
+	// When set, this ID should be included in all related logs and responses.
+	EnvTraceID = "PULUMICOST_TRACE_ID"
+
+	// EnvTestMode is the environment variable for enabling test mode.
+	// Only "true" enables test mode; all other values disable it.
+	EnvTestMode = "PULUMICOST_TEST_MODE"
+)
+
+// GetPort returns the plugin port from PULUMICOST_PLUGIN_PORT environment variable.
+// Returns 0 if not set or invalid. There is no fallback to PORT.
+// Callers should treat 0 as "port not configured" and handle accordingly.
+func GetPort() int {
+	v := os.Getenv(EnvPort)
+	if v == "" {
+		return 0
+	}
+	port, err := strconv.Atoi(v)
+	if err != nil || port <= 0 {
+		return 0
+	}
+	return port
+}
+
+// GetLogLevel returns the log level from environment variables.
+// Checks PULUMICOST_LOG_LEVEL first, then falls back to LOG_LEVEL.
+// Returns empty string if neither is set.
+func GetLogLevel() string {
+	if v := os.Getenv(EnvLogLevel); v != "" {
+		return v
+	}
+	return os.Getenv(EnvLogLevelFallback)
+}
+
+// GetLogFormat returns the log format from PULUMICOST_LOG_FORMAT.
+// Returns empty string if not set.
+func GetLogFormat() string {
+	return os.Getenv(EnvLogFormat)
+}
+
+// GetLogFile returns the log file path from PULUMICOST_LOG_FILE.
+// Returns empty string if not set (meaning stdout).
+func GetLogFile() string {
+	return os.Getenv(EnvLogFile)
+}
+
+// GetTraceID returns the trace ID from PULUMICOST_TRACE_ID.
+// Returns empty string if not set.
+func GetTraceID() string {
+	return os.Getenv(EnvTraceID)
+}
+
+// GetTestMode returns true if PULUMICOST_TEST_MODE is set to "true".
+// Logs a warning if the value is set but not "true" or "false".
+// Returns false for any value other than "true".
+func GetTestMode() bool {
+	v := os.Getenv(EnvTestMode)
+	if v == "" {
+		return false
+	}
+	if v == "true" {
+		return true
+	}
+	if v != "false" {
+		log.Warn().
+			Str("variable", EnvTestMode).
+			Str("value", v).
+			Msg("invalid test mode value, expected 'true' or 'false', defaulting to disabled")
+	}
+	return false
+}
+
+// IsTestMode returns true if PULUMICOST_TEST_MODE is set to "true".
+// Unlike GetTestMode, this function does not log warnings for invalid values.
+// Use this for repeated checks to avoid log spam.
+func IsTestMode() bool {
+	return os.Getenv(EnvTestMode) == "true"
+}

--- a/sdk/go/pluginsdk/env_test.go
+++ b/sdk/go/pluginsdk/env_test.go
@@ -1,0 +1,266 @@
+package pluginsdk_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+)
+
+// setEnv sets an environment variable and restores it on cleanup.
+func setEnv(t *testing.T, key, value string) {
+	t.Helper()
+	t.Setenv(key, value)
+}
+
+// unsetEnv clears an environment variable and restores it on cleanup.
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	original, existed := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("failed to unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if existed {
+			t.Setenv(key, original)
+		}
+	})
+}
+
+// ============================================================================
+// User Story 1: Port Configuration Tests
+// ============================================================================
+
+func TestGetPort_Set(t *testing.T) {
+	setEnv(t, pluginsdk.EnvPort, "8080")
+	got := pluginsdk.GetPort()
+	if got != 8080 {
+		t.Errorf("GetPort() = %d, want 8080", got)
+	}
+}
+
+func TestGetPort_NotSet_ReturnsZero(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvPort)
+	got := pluginsdk.GetPort()
+	if got != 0 {
+		t.Errorf("GetPort() = %d, want 0 when not set", got)
+	}
+}
+
+func TestGetPort_InvalidValue_ReturnsZero(t *testing.T) {
+	setEnv(t, pluginsdk.EnvPort, "abc")
+	got := pluginsdk.GetPort()
+	if got != 0 {
+		t.Errorf("GetPort() = %d, want 0 for invalid value", got)
+	}
+}
+
+func TestGetPort_NonPositive_ReturnsZero(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"zero", "0"},
+		{"negative", "-1"},
+		{"negative large", "-8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setEnv(t, pluginsdk.EnvPort, tt.value)
+			got := pluginsdk.GetPort()
+			if got != 0 {
+				t.Errorf("GetPort() = %d, want 0 for %s", got, tt.name)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// User Story 2: Logging Configuration Tests
+// ============================================================================
+
+func TestGetLogLevel_CanonicalVariable(t *testing.T) {
+	setEnv(t, pluginsdk.EnvLogLevel, "debug")
+	unsetEnv(t, pluginsdk.EnvLogLevelFallback)
+	got := pluginsdk.GetLogLevel()
+	if got != "debug" {
+		t.Errorf("GetLogLevel() = %q, want %q", got, "debug")
+	}
+}
+
+func TestGetLogLevel_FallbackVariable(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvLogLevel)
+	setEnv(t, pluginsdk.EnvLogLevelFallback, "info")
+	got := pluginsdk.GetLogLevel()
+	if got != "info" {
+		t.Errorf("GetLogLevel() = %q, want %q", got, "info")
+	}
+}
+
+func TestGetLogLevel_CanonicalTakesPrecedence(t *testing.T) {
+	setEnv(t, pluginsdk.EnvLogLevel, "debug")
+	setEnv(t, pluginsdk.EnvLogLevelFallback, "info")
+	got := pluginsdk.GetLogLevel()
+	if got != "debug" {
+		t.Errorf("GetLogLevel() = %q, want %q (canonical should take precedence)", got, "debug")
+	}
+}
+
+func TestGetLogLevel_NeitherSet_ReturnsEmpty(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvLogLevel)
+	unsetEnv(t, pluginsdk.EnvLogLevelFallback)
+	got := pluginsdk.GetLogLevel()
+	if got != "" {
+		t.Errorf("GetLogLevel() = %q, want empty string", got)
+	}
+}
+
+func TestGetLogFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"json format", "json", "json"},
+		{"text format", "text", "text"},
+		{"not set", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.value != "" {
+				setEnv(t, pluginsdk.EnvLogFormat, tt.value)
+			} else {
+				unsetEnv(t, pluginsdk.EnvLogFormat)
+			}
+			got := pluginsdk.GetLogFormat()
+			if got != tt.expected {
+				t.Errorf("GetLogFormat() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetLogFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"file path", "/var/log/plugin.log", "/var/log/plugin.log"},
+		{"not set", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.value != "" {
+				setEnv(t, pluginsdk.EnvLogFile, tt.value)
+			} else {
+				unsetEnv(t, pluginsdk.EnvLogFile)
+			}
+			got := pluginsdk.GetLogFile()
+			if got != tt.expected {
+				t.Errorf("GetLogFile() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// User Story 3: Trace ID Configuration Tests
+// ============================================================================
+
+func TestGetTraceID_Set(t *testing.T) {
+	setEnv(t, pluginsdk.EnvTraceID, "abc123")
+	got := pluginsdk.GetTraceID()
+	if got != "abc123" {
+		t.Errorf("GetTraceID() = %q, want %q", got, "abc123")
+	}
+}
+
+func TestGetTraceID_NotSet_ReturnsEmpty(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvTraceID)
+	got := pluginsdk.GetTraceID()
+	if got != "" {
+		t.Errorf("GetTraceID() = %q, want empty string", got)
+	}
+}
+
+// ============================================================================
+// User Story 4: Test Mode Configuration Tests
+// ============================================================================
+
+func TestGetTestMode_True(t *testing.T) {
+	setEnv(t, pluginsdk.EnvTestMode, "true")
+	got := pluginsdk.GetTestMode()
+	if !got {
+		t.Error("GetTestMode() = false, want true")
+	}
+}
+
+func TestGetTestMode_False(t *testing.T) {
+	setEnv(t, pluginsdk.EnvTestMode, "false")
+	got := pluginsdk.GetTestMode()
+	if got {
+		t.Error("GetTestMode() = true, want false")
+	}
+}
+
+func TestGetTestMode_NotSet_ReturnsFalse(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvTestMode)
+	got := pluginsdk.GetTestMode()
+	if got {
+		t.Error("GetTestMode() = true, want false when not set")
+	}
+}
+
+func TestGetTestMode_InvalidValue_ReturnsFalse(t *testing.T) {
+	tests := []string{"yes", "no", "1", "0", "TRUE", "FALSE", "True"}
+	for _, value := range tests {
+		t.Run(value, func(t *testing.T) {
+			setEnv(t, pluginsdk.EnvTestMode, value)
+			got := pluginsdk.GetTestMode()
+			if got {
+				t.Errorf("GetTestMode() = true for %q, want false", value)
+			}
+		})
+	}
+}
+
+func TestIsTestMode_NoWarning(t *testing.T) {
+	// IsTestMode should return the same result as GetTestMode but without logging.
+	tests := []struct {
+		value    string
+		expected bool
+	}{
+		{"true", true},
+		{"false", false},
+		{"", false},
+		{"yes", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			if tt.value != "" {
+				setEnv(t, pluginsdk.EnvTestMode, tt.value)
+			} else {
+				unsetEnv(t, pluginsdk.EnvTestMode)
+			}
+			got := pluginsdk.IsTestMode()
+			if got != tt.expected {
+				t.Errorf("IsTestMode() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// User Story 5: Migration Support Tests
+// ============================================================================
+
+func TestGetLogLevel_FallbackWorks(t *testing.T) {
+	// This test verifies that LOG_LEVEL fallback works for migration support.
+	unsetEnv(t, pluginsdk.EnvLogLevel)
+	setEnv(t, pluginsdk.EnvLogLevelFallback, "warn")
+	got := pluginsdk.GetLogLevel()
+	if got != "warn" {
+		t.Errorf("GetLogLevel() = %q, want %q (fallback should work)", got, "warn")
+	}
+}

--- a/specs/013-pluginsdk-env/checklists/requirements.md
+++ b/specs/013-pluginsdk-env/checklists/requirements.md
@@ -1,0 +1,60 @@
+# Specification Quality Checklist: Centralized Environment Variable Handling
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-07
+**Updated**: 2025-12-07 (cross-repo analysis)
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Cross-Repository Analysis
+
+- [x] Reviewed pulumicost-core environment variable usage
+- [x] Reviewed pulumicost-plugin-aws-public environment variable usage
+- [x] Reviewed pulumicost-plugin-aws-ce environment variable usage
+- [x] Documented variables used consistently across repos
+- [x] Documented variables requiring migration
+- [x] Documented core-only variables excluded from plugin SDK
+
+## Environment Variables Covered
+
+| Variable | In Spec | Status |
+|----------|---------|--------|
+| `PULUMICOST_PLUGIN_PORT` | Yes | Primary port config |
+| `PORT` | Yes | Fallback for compatibility |
+| `PULUMICOST_LOG_LEVEL` | Yes | Logging verbosity |
+| `PULUMICOST_LOG_FORMAT` | Yes | Logging format (json/text) |
+| `PULUMICOST_LOG_FILE` | Yes | Added after cross-repo review |
+| `PULUMICOST_TRACE_ID` | Yes | Distributed tracing |
+| `PULUMICOST_TEST_MODE` | Yes | Added after cross-repo review |
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- Cross-repository analysis added `PULUMICOST_LOG_FILE` and `PULUMICOST_TEST_MODE`
+- Documented migration path for `LOG_LEVEL` inconsistency in aws-public plugin
+- Core-only variables explicitly excluded from scope

--- a/specs/013-pluginsdk-env/data-model.md
+++ b/specs/013-pluginsdk-env/data-model.md
@@ -1,0 +1,153 @@
+# Data Model: Centralized Environment Variable Handling
+
+**Branch**: `013-pluginsdk-env` | **Date**: 2025-12-07
+
+## Entity Overview
+
+This feature introduces no persistent data storage. All entities are in-memory constants and
+functions that read environment variables at runtime.
+
+## Constants (Environment Variable Names)
+
+### EnvPort
+
+- **Value**: `"PULUMICOST_PLUGIN_PORT"`
+- **Type**: `string` (constant)
+- **Purpose**: Canonical environment variable for plugin gRPC port
+- **Used by**: `GetPort()` function
+
+### EnvLogLevel
+
+- **Value**: `"PULUMICOST_LOG_LEVEL"`
+- **Type**: `string` (constant)
+- **Purpose**: Canonical environment variable for log verbosity
+- **Used by**: `GetLogLevel()` function
+
+### EnvLogLevelFallback
+
+- **Value**: `"LOG_LEVEL"`
+- **Type**: `string` (constant)
+- **Purpose**: Legacy fallback for log level configuration
+- **Used by**: `GetLogLevel()` function when `EnvLogLevel` is not set
+
+### EnvLogFormat
+
+- **Value**: `"PULUMICOST_LOG_FORMAT"`
+- **Type**: `string` (constant)
+- **Purpose**: Environment variable for log output format
+- **Valid values**: `"json"`, `"text"` (or empty for plugin default)
+
+### EnvLogFile
+
+- **Value**: `"PULUMICOST_LOG_FILE"`
+- **Type**: `string` (constant)
+- **Purpose**: Environment variable for log file path
+
+### EnvTraceID
+
+- **Value**: `"PULUMICOST_TRACE_ID"`
+- **Type**: `string` (constant)
+- **Purpose**: Environment variable for injecting external trace IDs
+
+### EnvTestMode
+
+- **Value**: `"PULUMICOST_TEST_MODE"`
+- **Type**: `string` (constant)
+- **Purpose**: Environment variable for enabling plugin test mode
+- **Valid values**: `"true"`, `"false"` (strict matching)
+
+## Functions
+
+### GetPort() int
+
+- **Inputs**: None (reads from environment)
+- **Outputs**: `int` - Port number or 0 if not configured/invalid
+- **Validation**:
+  - Reads `PULUMICOST_PLUGIN_PORT` only (no fallback)
+  - Returns 0 if not set or invalid
+  - Only positive integers are valid
+
+### GetLogLevel() string
+
+- **Inputs**: None (reads from environment)
+- **Outputs**: `string` - Log level or empty string
+- **Validation**:
+  - Reads `PULUMICOST_LOG_LEVEL` first
+  - Falls back to `LOG_LEVEL` if canonical not set
+  - No value validation (plugin responsibility)
+
+### GetLogFormat() string
+
+- **Inputs**: None (reads from environment)
+- **Outputs**: `string` - Log format or empty string
+- **Validation**: None (pass-through)
+
+### GetLogFile() string
+
+- **Inputs**: None (reads from environment)
+- **Outputs**: `string` - File path or empty string
+- **Validation**: None (file system validation is caller responsibility)
+
+### GetTraceID() string
+
+- **Inputs**: None (reads from environment)
+- **Outputs**: `string` - Trace ID or empty string
+- **Validation**: None (pass-through)
+
+### GetTestMode() bool
+
+- **Inputs**: None (reads from environment)
+- **Outputs**: `bool` - true only if `PULUMICOST_TEST_MODE` == `"true"`
+- **Validation**:
+  - Returns true only for exact string `"true"`
+  - Returns false for `"false"`, empty, or any other value
+  - Logs warning via zerolog when value is not `"true"` or `"false"`
+
+### IsTestMode() bool
+
+- **Inputs**: None (reads from environment)
+- **Outputs**: `bool` - Same as `GetTestMode()` but without warning logging
+- **Purpose**: Convenience function for repeated checks without log spam
+
+## State Transitions
+
+Not applicable. All functions are pure reads with no state modifications.
+
+## Relationships
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                    Environment Variables                     │
+├─────────────────────────────────────────────────────────────┤
+│ PULUMICOST_PLUGIN_PORT ─►│──► GetPort() ──► int             │
+│                          │                                  │
+│ PULUMICOST_LOG_LEVEL ───┐│                                  │
+│ LOG_LEVEL ──────────────►│──► GetLogLevel() ──► string      │
+│                          │                                  │
+│ PULUMICOST_LOG_FORMAT ──►│──► GetLogFormat() ──► string     │
+│ PULUMICOST_LOG_FILE ────►│──► GetLogFile() ──► string       │
+│ PULUMICOST_TRACE_ID ────►│──► GetTraceID() ──► string       │
+│ PULUMICOST_TEST_MODE ───►│──► GetTestMode() ──► bool        │
+│                          │                     (logs warn)  │
+│                          │──► IsTestMode() ──► bool         │
+│                          │                     (no logging) │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Validation Rules
+
+| Variable | Validation | Invalid Behavior |
+|----------|------------|------------------|
+| Port | Must be positive integer | Return 0 (no fallback) |
+| Log Level | None | Pass through as-is |
+| Log Format | None | Pass through as-is |
+| Log File | None | Pass through as-is |
+| Trace ID | None | Pass through as-is |
+| Test Mode | Must be `"true"` or `"false"` | Return false, log warning |
+
+## Data Volume / Scale
+
+- Constants: 7 string constants (~180 bytes total)
+- Functions: 7 functions, no allocations per call
+- Performance: O(1) for all operations
+- Memory: No dynamic allocation (stdlib only)

--- a/specs/013-pluginsdk-env/plan.md
+++ b/specs/013-pluginsdk-env/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Centralized Environment Variable Handling
+
+**Branch**: `013-pluginsdk-env` | **Date**: 2025-12-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/013-pluginsdk-env/spec.md`
+
+## Summary
+
+Add centralized environment variable handling to the pluginsdk package to standardize how
+plugins read configuration from environment variables. The implementation provides exported
+constants for canonical variable names and getter functions with fallback support for backward
+compatibility.
+
+**Primary Goal**: Fix the port mismatch issue where core sets `PULUMICOST_PLUGIN_PORT` but
+plugins read `PORT`.
+
+**Technical Approach**: Create `sdk/go/pluginsdk/env.go` with constants and getter functions
+that implement canonical-first, fallback-second reading pattern using Go stdlib only.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5 (per go.mod toolchain)
+**Primary Dependencies**: Go stdlib only (`os`, `strconv`, `strings`)
+**Storage**: N/A (reads environment variables at runtime)
+**Testing**: Go testing framework with table-driven tests
+**Target Platform**: Cross-platform Go library (SDK)
+**Project Type**: Single Go module (SDK library)
+**Performance Goals**: N/A (simple env var reads, ~nanosecond operations)
+**Constraints**: Must maintain 100% backward compatibility with `LOG_LEVEL` (no PORT fallback)
+**Scale/Scope**: Used by all PulumiCost plugins (3+ repos currently)
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Proto-First Development | N/A | SDK helper code, no proto changes |
+| II. Multi-Provider Consistency | PASS | Environment variables are provider-agnostic |
+| III. Test-First Protocol | PASS | Will write unit tests before implementation |
+| IV. Backward Compatibility | PASS | Fallback variables maintain compatibility |
+| V. Documentation | PASS | Will document all env vars and functions |
+| VI. Performance | N/A | Simple env var reads, no performance concerns |
+| VII. Validation | PASS | Tests will run in CI |
+
+**Gate Result**: PASS - All applicable principles satisfied. This is SDK helper code that
+enhances the plugin development experience without modifying the gRPC protocol.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-pluginsdk-env/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A for this feature - no API contracts)
+├── checklists/          # Quality checklists
+│   └── requirements.md  # Specification validation checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+sdk/go/pluginsdk/
+├── env.go               # NEW: Environment variable constants and getters
+├── env_test.go          # NEW: Unit tests for env.go
+├── sdk.go               # MODIFY: Use GetPort() instead of os.Getenv("PORT")
+└── ...                  # Existing pluginsdk files unchanged
+```
+
+**Structure Decision**: Single file addition to existing `sdk/go/pluginsdk/` package. No new
+packages or directories required. This follows the existing SDK structure pattern.
+
+## Complexity Tracking
+
+No constitution violations. All gates pass. No complexity justification required.

--- a/specs/013-pluginsdk-env/quickstart.md
+++ b/specs/013-pluginsdk-env/quickstart.md
@@ -1,0 +1,211 @@
+# Quickstart: Centralized Environment Variable Handling
+
+**Branch**: `013-pluginsdk-env` | **Date**: 2025-12-07
+
+## Overview
+
+This feature adds centralized environment variable handling to the `pluginsdk` package,
+providing a standardized way for PulumiCost plugins to read configuration from the
+environment.
+
+## Installation
+
+The environment handling is part of the existing `pluginsdk` package. No additional
+installation required:
+
+```go
+import "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+```
+
+## Basic Usage
+
+### Reading Port Configuration
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+)
+
+func main() {
+    // GetPort reads PULUMICOST_PLUGIN_PORT only (no fallback)
+    port := pluginsdk.GetPort()
+    if port == 0 {
+        fmt.Println("Error: PULUMICOST_PLUGIN_PORT must be set")
+        return
+    }
+    fmt.Printf("Starting on port %d\n", port)
+}
+```
+
+### Reading Logging Configuration
+
+```go
+// Get log level (PULUMICOST_LOG_LEVEL or LOG_LEVEL)
+logLevel := pluginsdk.GetLogLevel()
+if logLevel == "" {
+    logLevel = "info" // plugin default
+}
+
+// Get log format (PULUMICOST_LOG_FORMAT)
+logFormat := pluginsdk.GetLogFormat()
+if logFormat == "" {
+    logFormat = "json" // plugin default
+}
+
+// Get log file path (PULUMICOST_LOG_FILE)
+logFile := pluginsdk.GetLogFile()
+// Empty means stdout
+```
+
+### Reading Trace ID
+
+```go
+// Get trace ID for distributed tracing (PULUMICOST_TRACE_ID)
+traceID := pluginsdk.GetTraceID()
+if traceID != "" {
+    // Use external trace ID for correlation
+    logger = logger.With().Str("trace_id", traceID).Logger()
+}
+```
+
+### Checking Test Mode
+
+```go
+// IsTestMode returns true only when PULUMICOST_TEST_MODE="true"
+if pluginsdk.IsTestMode() {
+    // Use mock data or bypass external services
+    return mockPricingData()
+}
+
+// GetTestMode does the same but logs a warning for invalid values
+// Use GetTestMode during startup to validate configuration
+if pluginsdk.GetTestMode() {
+    fmt.Println("Running in test mode")
+}
+```
+
+## Using with Serve()
+
+The `pluginsdk.Serve()` function automatically uses `GetPort()` internally:
+
+```go
+func main() {
+    ctx := context.Background()
+    plugin := &MyPlugin{}
+
+    // Serve reads PULUMICOST_PLUGIN_PORT only (no PORT fallback)
+    // Set Port: 0 to use environment variable
+    err := pluginsdk.Serve(ctx, pluginsdk.ServeConfig{
+        Plugin: plugin,
+        Port:   0, // Uses GetPort() internally
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+## Environment Variable Reference
+
+### Port Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `PULUMICOST_PLUGIN_PORT` | Required port variable (no fallback) |
+
+### Logging Configuration
+
+| Variable | Priority | Description |
+|----------|----------|-------------|
+| `PULUMICOST_LOG_LEVEL` | 1 (primary) | Log verbosity (debug, info, warn, error) |
+| `LOG_LEVEL` | 2 (fallback) | Legacy log level variable |
+| `PULUMICOST_LOG_FORMAT` | - | Log format (json, text) |
+| `PULUMICOST_LOG_FILE` | - | Log file path (empty = stdout) |
+
+### Tracing Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `PULUMICOST_TRACE_ID` | External trace ID for distributed tracing |
+
+### Test Mode Configuration
+
+| Variable | Valid Values | Description |
+|----------|--------------|-------------|
+| `PULUMICOST_TEST_MODE` | `"true"`, `"false"` | Enable test mode (strict matching) |
+
+## Accessing Constants
+
+All environment variable names are exported as constants for reference:
+
+```go
+fmt.Println(pluginsdk.EnvPort)             // "PULUMICOST_PLUGIN_PORT"
+fmt.Println(pluginsdk.EnvLogLevel)         // "PULUMICOST_LOG_LEVEL"
+fmt.Println(pluginsdk.EnvLogLevelFallback) // "LOG_LEVEL"
+fmt.Println(pluginsdk.EnvLogFormat)        // "PULUMICOST_LOG_FORMAT"
+fmt.Println(pluginsdk.EnvLogFile)          // "PULUMICOST_LOG_FILE"
+fmt.Println(pluginsdk.EnvTraceID)          // "PULUMICOST_TRACE_ID"
+fmt.Println(pluginsdk.EnvTestMode)         // "PULUMICOST_TEST_MODE"
+```
+
+## Migration Guide
+
+### Migrating from os.Getenv("PORT")
+
+**Breaking Change**: The `PORT` environment variable is no longer supported. You must use
+`PULUMICOST_PLUGIN_PORT` instead.
+
+Before:
+
+```go
+portStr := os.Getenv("PORT")
+port, _ := strconv.Atoi(portStr)
+```
+
+After:
+
+```go
+// Environment: PULUMICOST_PLUGIN_PORT=8080 (required)
+port := pluginsdk.GetPort()
+if port == 0 {
+    log.Fatal("PULUMICOST_PLUGIN_PORT must be set")
+}
+```
+
+### Migrating from os.Getenv("LOG_LEVEL")
+
+Before:
+
+```go
+logLevel := os.Getenv("LOG_LEVEL")
+```
+
+After:
+
+```go
+logLevel := pluginsdk.GetLogLevel()
+```
+
+## Testing
+
+Test your plugin with different environment configurations:
+
+```bash
+# Test with port variable (required)
+PULUMICOST_PLUGIN_PORT=8080 go test ./...
+
+# Test without port (should fail or use explicit default)
+go test ./...
+
+# Test logging configuration
+PULUMICOST_LOG_LEVEL=debug PULUMICOST_LOG_FORMAT=json go test ./...
+
+# Test log level fallback (legacy support)
+LOG_LEVEL=debug go test ./...
+
+# Test mode
+PULUMICOST_TEST_MODE=true go test ./...
+```

--- a/specs/013-pluginsdk-env/research.md
+++ b/specs/013-pluginsdk-env/research.md
@@ -1,0 +1,202 @@
+# Research: Centralized Environment Variable Handling
+
+**Branch**: `013-pluginsdk-env` | **Date**: 2025-12-07
+
+## Research Summary
+
+This feature adds centralized environment variable handling to the pluginsdk package. Research
+focused on understanding existing patterns in the codebase and Go best practices.
+
+## Decisions
+
+### Decision 1: File Location
+
+**Decision**: Create `sdk/go/pluginsdk/env.go`
+
+**Rationale**: The pluginsdk package already contains the `Serve()` function that needs
+modification. Adding env.go to the same package avoids cross-package dependencies and follows
+the existing SDK structure pattern.
+
+**Alternatives considered**:
+
+- `sdk/go/config/` - Would require new package and import cycle risks
+- `sdk/go/env/` - Unnecessary package fragmentation for 7 constants and 7 functions
+
+### Decision 2: Port Implementation Pattern (No Fallback)
+
+**Decision**: Use canonical variable only for port configuration
+
+```go
+func GetPort() int {
+    if v := os.Getenv(EnvPort); v != "" {
+        if port, err := strconv.Atoi(v); err == nil && port > 0 {
+            return port
+        }
+    }
+    return 0
+}
+```
+
+**Rationale**: The `PORT` environment variable has too much potential for conflict with other
+services. Using `PULUMICOST_PLUGIN_PORT` exclusively ensures clear ownership and prevents
+accidental port conflicts. This is a breaking change but provides clearer semantics.
+
+**Alternatives considered**:
+
+- Fallback to PORT - Rejected; too much conflict potential with other services
+- Return error for invalid values - Rejected; complicates API and existing code uses return 0
+
+### Decision 2b: Log Level Fallback Pattern
+
+**Decision**: Use canonical-first, fallback-second for logging configuration only
+
+```go
+func GetLogLevel() string {
+    if v := os.Getenv(EnvLogLevel); v != "" {
+        return v
+    }
+    return os.Getenv(EnvLogLevelFallback)
+}
+```
+
+**Rationale**: LOG_LEVEL is a common convention that doesn't have the same conflict potential
+as PORT. Supporting fallback enables gradual migration of existing plugins.
+
+### Decision 3: Test Mode Validation
+
+**Decision**: Use strict `"true"`/`"false"` string matching with warning logging
+
+**Rationale**: Follows existing pattern in `pulumicost-plugin-aws-public/internal/plugin
+/testmode.go`. Strict matching prevents accidental test mode activation from typos like
+`"yes"` or `"1"`.
+
+**Alternatives considered**:
+
+- Case-insensitive matching - Rejected; too permissive for safety-critical flag
+- Accept `"1"`/`"0"` - Rejected; inconsistent with existing plugin pattern
+
+### Decision 4: Logging for Invalid Values
+
+**Decision**: Only log warnings for invalid `PULUMICOST_TEST_MODE` values (per FR-013)
+
+**Rationale**: Test mode is boolean with discrete valid values; other variables are either
+string pass-through (log level, format) or numeric with silent fallback (port).
+
+**Alternatives considered**:
+
+- Log warnings for all invalid values - Rejected; port fallback is expected behavior
+- No logging at all - Rejected; FR-013 explicitly requires warning
+
+### Decision 5: No Dependencies Beyond stdlib
+
+**Decision**: Use only `os`, `strconv`, `strings` from Go stdlib
+
+**Rationale**: Environment variable reading is trivial and doesn't benefit from external
+dependencies. Avoids adding complexity to the SDK.
+
+**Alternatives considered**:
+
+- Use `envconfig` library - Rejected; overkill for 8 variables
+- Use `viper` - Rejected; massive dependency for simple env reading
+
+## Existing Code Analysis
+
+### Current Port Resolution (`sdk/go/pluginsdk/sdk.go:210-231`)
+
+```go
+func resolvePort(requested int) (int, error) {
+    if requested > 0 {
+        return requested, nil
+    }
+    portEnv := os.Getenv("PORT")
+    if portEnv == "" {
+        return 0, nil
+    }
+    value, err := strconv.Atoi(portEnv)
+    if err != nil {
+        // ... error handling
+        return 0, nil
+    }
+    return value, nil
+}
+```
+
+**Analysis**:
+
+- Only reads `PORT`, not `PULUMICOST_PLUGIN_PORT`
+- Returns 0 when not set (caller handles)
+- Logs to stderr on parse error
+- Will be modified to use `GetPort()` which adds canonical variable
+
+### Existing Test Mode Pattern (`pulumicost-plugin-aws-public`)
+
+```go
+const testModeEnvVar = "PULUMICOST_TEST_MODE"
+
+func IsTestMode() bool {
+    return os.Getenv(testModeEnvVar) == "true"
+}
+
+func ValidateTestModeEnv() {
+    value := os.Getenv(testModeEnvVar)
+    if value != "" && value != "true" && value != "false" {
+        // log warning
+    }
+}
+```
+
+**Analysis**: This pattern will be adopted in the SDK with minor modifications.
+
+### Logging Pattern (`pulumicost-core`)
+
+Uses `zerolog` for structured logging. The SDK already imports zerolog (see `sdk.go:12`).
+
+## Technical Notes
+
+### Environment Variable Constants
+
+All constants follow the `PULUMICOST_` prefix convention established by pulumicost-core:
+
+| Constant | Value | Type |
+|----------|-------|------|
+| EnvPort | `PULUMICOST_PLUGIN_PORT` | Canonical (no fallback) |
+| EnvLogLevel | `PULUMICOST_LOG_LEVEL` | Canonical |
+| EnvLogLevelFallback | `LOG_LEVEL` | Fallback (for logging only) |
+| EnvLogFormat | `PULUMICOST_LOG_FORMAT` | Canonical |
+| EnvLogFile | `PULUMICOST_LOG_FILE` | Canonical |
+| EnvTraceID | `PULUMICOST_TRACE_ID` | Canonical |
+| EnvTestMode | `PULUMICOST_TEST_MODE` | Canonical |
+
+### Function Signatures
+
+Based on existing patterns and requirements:
+
+```go
+// Port - returns 0 when not configured
+func GetPort() int
+
+// Logging - returns empty string when not configured
+func GetLogLevel() string
+func GetLogFormat() string
+func GetLogFile() string
+
+// Tracing - returns empty string when not configured
+func GetTraceID() string
+
+// Test mode - returns false when not configured or invalid
+func GetTestMode() bool      // logs warning for invalid values
+func IsTestMode() bool       // convenience alias, no logging
+```
+
+## No Outstanding Research Items
+
+All NEEDS CLARIFICATION items from Technical Context have been resolved:
+
+- Language/Version: Go 1.25.5 (confirmed from go.mod)
+- Dependencies: stdlib only (`os`, `strconv`, `strings`)
+- Testing: Go testing framework (existing pattern in pluginsdk)
+- Platform: Cross-platform Go library
+
+## Next Phase
+
+Proceed to Phase 1: Design & Contracts with `data-model.md` and `quickstart.md`.

--- a/specs/013-pluginsdk-env/spec.md
+++ b/specs/013-pluginsdk-env/spec.md
@@ -1,0 +1,262 @@
+# Feature Specification: Centralized Environment Variable Handling
+
+**Feature Branch**: `013-pluginsdk-env`
+**Created**: 2025-12-07
+**Status**: Draft
+**Input**: User description: "feat(pluginsdk): Add centralized environment variable handling"
+
+## Clarifications
+
+### Session 2025-12-07
+
+- Q: Should `GetLogLevel()` fall back to reading `LOG_LEVEL` if `PULUMICOST_LOG_LEVEL` is not
+  set? → A: Yes, add fallback: `PULUMICOST_LOG_LEVEL` → `LOG_LEVEL` (matches port pattern)
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Plugin Developer Uses Standard Port Configuration (Priority: P1)
+
+A plugin developer building a new PulumiCost plugin needs their plugin to automatically bind to
+the correct gRPC port. They set `PULUMICOST_PLUGIN_PORT=8080` in their environment and their
+plugin correctly binds to port 8080 without any code changes.
+
+**Why this priority**: This is the core problem that caused E2E testing failures. Plugin port
+configuration must work consistently across all plugins to enable reliable plugin orchestration
+by pulumicost-core.
+
+**Independent Test**: Can be fully tested by setting `PULUMICOST_PLUGIN_PORT=8080`, starting a
+plugin, and verifying it binds to port 8080. Delivers immediate value by fixing the port
+mismatch issue.
+
+**Acceptance Scenarios**:
+
+1. **Given** `PULUMICOST_PLUGIN_PORT=8080` is set, **When** a plugin starts without explicit
+   port configuration, **Then** it binds to port 8080
+2. **Given** `PULUMICOST_PLUGIN_PORT` is not set, **When** a plugin starts without explicit
+   port, **Then** it returns a clear error indicating which environment variable to set
+3. **Given** `PULUMICOST_PLUGIN_PORT` contains an invalid value, **When** a plugin starts,
+   **Then** it returns 0 (caller handles error)
+
+---
+
+### User Story 2 - Plugin Developer Configures Logging via Environment (Priority: P2)
+
+A plugin developer deploying to production wants to control logging behavior without code
+changes. They set `PULUMICOST_LOG_LEVEL=debug`, `PULUMICOST_LOG_FORMAT=json`, and optionally
+`PULUMICOST_LOG_FILE=/var/log/plugin.log` to get structured debug logs suitable for log
+aggregation systems.
+
+**Why this priority**: Logging configuration is essential for production deployments but not
+critical for basic plugin functionality. Plugins can function with default logging.
+
+**Independent Test**: Can be tested by setting log environment variables, starting a plugin,
+and verifying log output format, verbosity, and file destination match expectations.
+
+**Acceptance Scenarios**:
+
+1. **Given** `PULUMICOST_LOG_LEVEL=debug` is set, **When** a plugin reads logging
+   configuration, **Then** the plugin can access the "debug" log level value
+2. **Given** `PULUMICOST_LOG_FORMAT=json` is set, **When** a plugin reads logging
+   configuration, **Then** the plugin can access the "json" format value
+3. **Given** `PULUMICOST_LOG_FILE=/var/log/plugin.log` is set, **When** a plugin reads logging
+   configuration, **Then** the plugin can access the file path for log output
+4. **Given** no logging environment variables are set, **When** a plugin reads logging
+   configuration, **Then** empty strings are returned (plugin uses its defaults)
+
+---
+
+### User Story 3 - Operations Team Traces Requests Across Services (Priority: P2)
+
+An operations team troubleshooting a production issue wants to trace cost calculations across
+the plugin ecosystem. They inject `PULUMICOST_TRACE_ID=abc123` when invoking a plugin, and
+this trace ID appears in all related logs and responses.
+
+**Why this priority**: Distributed tracing is valuable for debugging but not essential for
+basic plugin operation. Plugins work correctly without trace IDs.
+
+**Independent Test**: Can be tested by setting `PULUMICOST_TRACE_ID`, invoking a plugin
+operation, and verifying the trace ID is accessible for correlation.
+
+**Acceptance Scenarios**:
+
+1. **Given** `PULUMICOST_TRACE_ID=abc123` is set, **When** a plugin reads trace configuration,
+   **Then** the plugin can access "abc123" as the trace ID
+2. **Given** no trace ID is set, **When** a plugin reads trace configuration, **Then** an
+   empty string is returned (no trace context)
+
+---
+
+### User Story 4 - Plugin Developer Enables Test Mode (Priority: P2)
+
+A plugin developer writing integration tests needs to enable test mode to use mock data or
+bypass external service calls. They set `PULUMICOST_TEST_MODE=true` and the plugin operates
+in test mode with deterministic behavior.
+
+**Why this priority**: Test mode is essential for reliable plugin testing but not required
+for production operation. Plugins must support both modes.
+
+**Independent Test**: Can be tested by setting `PULUMICOST_TEST_MODE=true`, invoking plugin
+operations, and verifying test-specific behavior is active.
+
+**Acceptance Scenarios**:
+
+1. **Given** `PULUMICOST_TEST_MODE=true` is set, **When** a plugin reads test configuration,
+   **Then** the plugin can detect that test mode is enabled
+2. **Given** `PULUMICOST_TEST_MODE=false` or unset, **When** a plugin reads test
+   configuration, **Then** the plugin operates in normal production mode
+3. **Given** `PULUMICOST_TEST_MODE` contains an invalid value (not "true"/"false"), **When**
+   a plugin reads test configuration, **Then** a warning is logged and test mode is disabled
+
+---
+
+### User Story 5 - Plugin Developer Migrates Logging Configuration (Priority: P3)
+
+A developer with an existing plugin that uses direct `os.Getenv("LOG_LEVEL")` calls wants to
+migrate to the standardized environment handling. They update their imports to use
+`pluginsdk.GetLogLevel()` and their plugin continues to work with both old (`LOG_LEVEL`) and
+new (`PULUMICOST_LOG_LEVEL`) environment variable names.
+
+**Why this priority**: Migration support ensures backward compatibility for logging
+configuration. Port configuration does NOT have fallback - plugins must use
+`PULUMICOST_PLUGIN_PORT` exclusively.
+
+**Independent Test**: Can be tested by setting `LOG_LEVEL=debug` (without PULUMICOST_ prefix),
+calling `pluginsdk.GetLogLevel()`, and verifying it returns "debug".
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing plugin using `os.Getenv("LOG_LEVEL")`, **When** migrated to use
+   `pluginsdk.GetLogLevel()`, **Then** the plugin works identically with `LOG_LEVEL` set
+2. **Given** a migrated plugin, **When** operator switches to `PULUMICOST_LOG_LEVEL`,
+   **Then** the plugin works without code changes
+3. **Given** both `PULUMICOST_LOG_LEVEL` and `LOG_LEVEL` are set, **When** plugin reads
+   config, **Then** `PULUMICOST_LOG_LEVEL` takes precedence
+
+---
+
+### Edge Cases
+
+- What happens when `PULUMICOST_PLUGIN_PORT` contains a non-numeric value like "abc"? The
+  value is treated as invalid, and `GetPort()` returns 0 (no fallback).
+- What happens when port value is negative or zero? Non-positive values are treated as
+  invalid; `GetPort()` returns 0.
+- What happens when port value exceeds valid port range (65535)? Value is accepted as-is;
+  network layer will reject during binding (consistent with standard Go behavior).
+- What happens when environment variable contains leading/trailing whitespace? Standard
+  `os.Getenv` returns the value as-is including whitespace, which will cause parse failures
+  for numeric values.
+- What happens when `PULUMICOST_TEST_MODE` is set to an unexpected value like "yes"? A
+  warning is logged and test mode defaults to disabled for safety.
+- What happens when `PULUMICOST_LOG_FILE` path is not writable? Plugin should fail gracefully
+  with a clear error message (implementation responsibility).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+#### Port Configuration
+
+- **FR-001**: Plugin SDK MUST provide exported constants for all standard PulumiCost
+  environment variable names
+- **FR-002**: Plugin SDK MUST provide a `GetPort()` function that reads
+  `PULUMICOST_PLUGIN_PORT` only (no fallback to PORT)
+- **FR-003**: `GetPort()` MUST return 0 when no valid port is configured (caller handles
+  error)
+- **FR-004**: `GetPort()` MUST reject non-positive port values as invalid
+- **FR-005**: `pluginsdk.Serve()` MUST use the centralized `GetPort()` function instead of
+  direct environment variable access
+- **FR-006**: Error messages for missing port configuration MUST explicitly name
+  `PULUMICOST_PLUGIN_PORT` as the required variable
+
+#### Logging Configuration
+
+- **FR-007**: Plugin SDK MUST provide `GetLogLevel()` function that reads
+  `PULUMICOST_LOG_LEVEL` first, then falls back to `LOG_LEVEL`, returning empty string if
+  neither is set
+- **FR-008**: Plugin SDK MUST provide `GetLogFormat()` function returning the configured log
+  format or empty string
+- **FR-009**: Plugin SDK MUST provide `GetLogFile()` function returning the configured log
+  file path or empty string
+
+#### Tracing Configuration
+
+- **FR-010**: Plugin SDK MUST provide `GetTraceID()` function returning the configured trace
+  ID or empty string
+
+#### Test Mode Configuration
+
+- **FR-011**: Plugin SDK MUST provide `GetTestMode()` function returning true only when
+  `PULUMICOST_TEST_MODE` is explicitly set to "true"
+- **FR-012**: Plugin SDK MUST provide `IsTestMode()` convenience function returning boolean
+- **FR-013**: `GetTestMode()` MUST log a warning when `PULUMICOST_TEST_MODE` contains an
+  invalid value (not "true" or "false")
+
+### Key Entities
+
+- **Environment Variable Constants**: Named constants providing the canonical variable names:
+  - `EnvPort` = `PULUMICOST_PLUGIN_PORT`
+  - `EnvLogLevel` = `PULUMICOST_LOG_LEVEL`
+  - `EnvLogLevelFallback` = `LOG_LEVEL`
+  - `EnvLogFormat` = `PULUMICOST_LOG_FORMAT`
+  - `EnvLogFile` = `PULUMICOST_LOG_FILE`
+  - `EnvTraceID` = `PULUMICOST_TRACE_ID`
+  - `EnvTestMode` = `PULUMICOST_TEST_MODE`
+- **Port Configuration**: Numeric port value with validation (no fallback)
+- **Logging Configuration**: String-based log level (with fallback), format, and file path
+- **Trace Context**: Optional trace ID string for distributed tracing
+- **Test Mode**: Boolean flag for enabling test-specific plugin behavior
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: All plugins using `pluginsdk.GetPort()` correctly bind to the port set via
+  `PULUMICOST_PLUGIN_PORT` on first attempt
+- **SC-002**: Plugin developers can configure all standard environment variables by
+  referencing a single source of truth in `pluginsdk/env.go`
+- **SC-003**: E2E tests between pulumicost-core and plugins pass when core sets
+  `PULUMICOST_PLUGIN_PORT` (fixing the original issue)
+- **SC-004**: Documentation clearly shows plugin developers how to use environment
+  configuration functions
+- **SC-005**: Existing plugins using `LOG_LEVEL` can migrate to `PULUMICOST_LOG_LEVEL` with
+  a clear deprecation path (logging fallback only)
+
+## Assumptions
+
+- The `pluginsdk` package already exists and is the appropriate location for this
+  functionality
+- Plugins are responsible for their own default values when environment variables are not set
+- Port validation beyond positive integer check is delegated to the network layer
+- Log level and format values are passed through as strings; semantic validation is the
+  plugin's responsibility
+- Test mode validation (strict "true"/"false") follows the pattern in pulumicost-plugin-
+  aws-public
+
+## Cross-Repository Consistency Notes
+
+Based on analysis of pulumicost-core, pulumicost-plugin-aws-public, and pulumicost-plugin-
+aws-ce:
+
+### Variables Used Consistently
+
+- `PULUMICOST_PLUGIN_PORT` - Core sets this, plugins should read via `GetPort()`
+- `PULUMICOST_TRACE_ID` - Core and plugins use for distributed tracing
+- `PULUMICOST_LOG_LEVEL` - Core uses this; plugins should adopt
+- `PULUMICOST_LOG_FORMAT` - Core uses this; plugins should adopt
+
+### Variables Requiring Migration
+
+- `LOG_LEVEL` in pulumicost-plugin-aws-public should migrate to `PULUMICOST_LOG_LEVEL`
+  (fallback supported for backward compatibility)
+- `PORT` usage must be replaced with `PULUMICOST_PLUGIN_PORT` (no fallback - breaking change)
+
+### Core-Only Variables (Not in Plugin SDK)
+
+The following are used by pulumicost-core only and should NOT be in the plugin SDK:
+
+- `PULUMICOST_OUTPUT_FORMAT` - CLI output formatting
+- `PULUMICOST_OUTPUT_PRECISION` - Decimal precision for CLI output
+- `PULUMICOST_CONFIG_STRICT` - Config file error handling
+- `PULUMICOST_CONFIG` - Config file path
+- `PULUMICOST_PLUGIN_<NAME>_<KEY>` - Plugin-specific config (passed by core)
+- `GITHUB_TOKEN` - Registry authentication

--- a/specs/013-pluginsdk-env/tasks.md
+++ b/specs/013-pluginsdk-env/tasks.md
@@ -1,0 +1,279 @@
+# Tasks: Centralized Environment Variable Handling
+
+**Input**: Design documents from `/specs/013-pluginsdk-env/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: TDD is mandatory per Constitution. Tests are included for each user story.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and
+testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **SDK package**: `sdk/go/pluginsdk/`
+- Tests co-located with implementation: `sdk/go/pluginsdk/env_test.go`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create env.go file structure and define all environment variable constants
+
+- [x] T001 Create env.go with package declaration and imports in sdk/go/pluginsdk/env.go
+- [x] T002 [P] Define EnvPort constant as "PULUMICOST_PLUGIN_PORT" in sdk/go/pluginsdk/env.go
+- [x] T003 [P] Define EnvLogLevel constant as "PULUMICOST_LOG_LEVEL" in sdk/go/pluginsdk/env.go
+- [x] T004 [P] Define EnvLogLevelFallback constant as "LOG_LEVEL" in sdk/go/pluginsdk/env.go
+- [x] T005 [P] Define EnvLogFormat constant as "PULUMICOST_LOG_FORMAT" in sdk/go/pluginsdk/env.go
+- [x] T006 [P] Define EnvLogFile constant as "PULUMICOST_LOG_FILE" in sdk/go/pluginsdk/env.go
+- [x] T007 [P] Define EnvTraceID constant as "PULUMICOST_TRACE_ID" in sdk/go/pluginsdk/env.go
+- [x] T008 [P] Define EnvTestMode constant as "PULUMICOST_TEST_MODE" in sdk/go/pluginsdk/env.go
+- [x] T009 Create env_test.go with package declaration in sdk/go/pluginsdk/env_test.go
+
+**Checkpoint**: All constants defined. Ready for function implementation.
+
+---
+
+## Phase 2: User Story 1 - Standard Port Configuration (Priority: P1) MVP
+
+**Goal**: Plugin developers use `PULUMICOST_PLUGIN_PORT` exclusively (no fallback)
+
+**Independent Test**: Set `PULUMICOST_PLUGIN_PORT=8080`, call `GetPort()`, verify returns 8080
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T010 [US1] Write test TestGetPort_Set in sdk/go/pluginsdk/env_test.go
+- [x] T011 [US1] Write test TestGetPort_NotSet_ReturnsZero in sdk/go/pluginsdk/env_test.go
+- [x] T012 [US1] Write test TestGetPort_InvalidValue_ReturnsZero in sdk/go/pluginsdk/env_test.go
+- [x] T013 [US1] Write test TestGetPort_NonPositive_ReturnsZero in sdk/go/pluginsdk/env_test.go
+
+### Implementation for User Story 1
+
+- [x] T014 [US1] Implement GetPort() function (no fallback) in sdk/go/pluginsdk/env.go
+- [x] T015 [US1] Run tests to verify GetPort() passes all test cases
+- [x] T016 [US1] Modify resolvePort() in sdk/go/pluginsdk/sdk.go to use GetPort()
+- [x] T017 [US1] Update error message in sdk.go to mention PULUMICOST_PLUGIN_PORT only
+
+**Checkpoint**: User Story 1 complete. Port configuration works with canonical variable only.
+
+---
+
+## Phase 3: User Story 2 - Logging Configuration (Priority: P2)
+
+**Goal**: Plugin developers can configure logging via PULUMICOST_LOG_LEVEL, LOG_FORMAT, LOG_FILE
+
+**Independent Test**: Set `PULUMICOST_LOG_LEVEL=debug`, call `GetLogLevel()`, verify returns
+"debug"
+
+### Tests for User Story 2
+
+- [x] T018 [P] [US2] Write test TestGetLogLevel_CanonicalVariable in sdk/go/pluginsdk/env_test.go
+- [x] T019 [P] [US2] Write test TestGetLogLevel_FallbackVariable in sdk/go/pluginsdk/env_test.go
+- [x] T020 [P] [US2] Write test TestGetLogLevel_CanonicalTakesPrecedence in sdk/go/pluginsdk/env_test.go
+- [x] T021 [P] [US2] Write test TestGetLogLevel_NeitherSet_ReturnsEmpty in sdk/go/pluginsdk/env_test.go
+- [x] T022 [P] [US2] Write test TestGetLogFormat in sdk/go/pluginsdk/env_test.go
+- [x] T023 [P] [US2] Write test TestGetLogFile in sdk/go/pluginsdk/env_test.go
+
+### Implementation for User Story 2
+
+- [x] T024 [US2] Implement GetLogLevel() with canonical-first fallback in sdk/go/pluginsdk/env.go
+- [x] T025 [P] [US2] Implement GetLogFormat() in sdk/go/pluginsdk/env.go
+- [x] T026 [P] [US2] Implement GetLogFile() in sdk/go/pluginsdk/env.go
+- [x] T027 [US2] Run tests to verify all logging functions pass
+
+**Checkpoint**: User Story 2 complete. Logging configuration works independently.
+
+---
+
+## Phase 4: User Story 3 - Trace ID Configuration (Priority: P2)
+
+**Goal**: Operations team can inject PULUMICOST_TRACE_ID for distributed tracing
+
+**Independent Test**: Set `PULUMICOST_TRACE_ID=abc123`, call `GetTraceID()`, verify returns
+"abc123"
+
+### Tests for User Story 3
+
+- [x] T028 [P] [US3] Write test TestGetTraceID_Set in sdk/go/pluginsdk/env_test.go
+- [x] T029 [P] [US3] Write test TestGetTraceID_NotSet_ReturnsEmpty in sdk/go/pluginsdk/env_test.go
+
+### Implementation for User Story 3
+
+- [x] T030 [US3] Implement GetTraceID() in sdk/go/pluginsdk/env.go
+- [x] T031 [US3] Run tests to verify GetTraceID() passes
+
+**Checkpoint**: User Story 3 complete. Trace ID configuration works independently.
+
+---
+
+## Phase 5: User Story 4 - Test Mode Configuration (Priority: P2)
+
+**Goal**: Plugin developers can enable test mode via PULUMICOST_TEST_MODE=true
+
+**Independent Test**: Set `PULUMICOST_TEST_MODE=true`, call `IsTestMode()`, verify returns true
+
+### Tests for User Story 4
+
+- [x] T032 [P] [US4] Write test TestGetTestMode_True in sdk/go/pluginsdk/env_test.go
+- [x] T033 [P] [US4] Write test TestGetTestMode_False in sdk/go/pluginsdk/env_test.go
+- [x] T034 [P] [US4] Write test TestGetTestMode_NotSet_ReturnsFalse in sdk/go/pluginsdk/env_test.go
+- [x] T035 [P] [US4] Write test TestGetTestMode_InvalidValue_ReturnsFalse in sdk/go/pluginsdk/env_test.go
+- [x] T036 [P] [US4] Write test TestIsTestMode_NoWarning in sdk/go/pluginsdk/env_test.go
+
+### Implementation for User Story 4
+
+- [x] T037 [US4] Implement GetTestMode() with warning logging in sdk/go/pluginsdk/env.go
+- [x] T038 [US4] Implement IsTestMode() without warning in sdk/go/pluginsdk/env.go
+- [x] T039 [US4] Run tests to verify test mode functions pass
+
+**Checkpoint**: User Story 4 complete. Test mode configuration works independently.
+
+---
+
+## Phase 6: User Story 5 - Migration Support (Priority: P3)
+
+**Goal**: Verify Serve() integration and LOG_LEVEL backward compatibility
+
+**Independent Test**: Set `LOG_LEVEL=debug`, call `GetLogLevel()`, verify returns "debug"
+
+### Tests for User Story 5
+
+- [x] T040 [P] [US5] Write integration test verifying Serve() uses GetPort() in sdk/go/pluginsdk/sdk_test.go
+- [x] T041 [P] [US5] Write test verifying LOG_LEVEL fallback works in sdk/go/pluginsdk/env_test.go
+
+### Implementation for User Story 5
+
+- [x] T042 [US5] Verify resolvePort() modification from T016 properly integrates with Serve()
+- [x] T043 [US5] Run integration tests to verify LOG_LEVEL backward compatibility
+
+**Checkpoint**: User Story 5 complete. Serve() integration verified, LOG_LEVEL fallback works.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, validation, and cleanup
+
+- [x] T044 [P] Add godoc comments for all constants in sdk/go/pluginsdk/env.go
+- [x] T045 [P] Add godoc comments for all functions in sdk/go/pluginsdk/env.go
+- [x] T046 Run `make lint` to verify code quality
+- [x] T047 Run `make test` to verify all tests pass
+- [x] T048 Verify quickstart.md examples work by manual testing
+- [x] T049 Update sdk/go/CLAUDE.md with env.go documentation
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **US1 (Phase 2)**: Depends on Setup - MVP priority
+- **US2 (Phase 3)**: Depends on Setup only - can run parallel to US1
+- **US3 (Phase 4)**: Depends on Setup only - can run parallel to US1/US2
+- **US4 (Phase 5)**: Depends on Setup only - can run parallel to US1/US2/US3
+- **US5 (Phase 6)**: Depends on US1 and US2 (needs GetPort() and GetLogLevel() for integration)
+- **Polish (Phase 7)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+```text
+Setup ──┬──► US1 (P1) ───┬──► US5 (P3) ──► Polish
+        │                │
+        ├──► US2 (P2) ───┘
+        │
+        ├──► US3 (P2) ──────────────────► Polish
+        │
+        └──► US4 (P2) ──────────────────► Polish
+```
+
+### Within Each User Story
+
+1. Tests MUST be written and FAIL before implementation
+2. Implementation to make tests pass
+3. Verify all tests pass before checkpoint
+
+### Parallel Opportunities
+
+- All constant definitions (T002-T008) can run in parallel
+- All US2 tests (T018-T023) can run in parallel
+- All US2 implementations (T025-T026 for GetLogFormat/GetLogFile) can run in parallel
+- All US3 tests (T028-T029) can run in parallel
+- All US4 tests (T032-T036) can run in parallel
+- All US5 tests (T040-T041) can run in parallel
+- All Polish tasks (T044-T049) can run in parallel (except T047 depends on code completion)
+
+---
+
+## Parallel Example: Setup Phase
+
+```bash
+# Launch all constant definitions in parallel:
+Task: "Define EnvPort constant as 'PULUMICOST_PLUGIN_PORT'"
+Task: "Define EnvLogLevel constant as 'PULUMICOST_LOG_LEVEL'"
+Task: "Define EnvLogLevelFallback constant as 'LOG_LEVEL'"
+Task: "Define EnvLogFormat constant as 'PULUMICOST_LOG_FORMAT'"
+Task: "Define EnvLogFile constant as 'PULUMICOST_LOG_FILE'"
+Task: "Define EnvTraceID constant as 'PULUMICOST_TRACE_ID'"
+Task: "Define EnvTestMode constant as 'PULUMICOST_TEST_MODE'"
+```
+
+## Parallel Example: User Story 2 Tests
+
+```bash
+# Launch all logging tests in parallel:
+Task: "Write test TestGetLogLevel_CanonicalVariable"
+Task: "Write test TestGetLogLevel_FallbackVariable"
+Task: "Write test TestGetLogLevel_CanonicalTakesPrecedence"
+Task: "Write test TestGetLogLevel_NeitherSet_ReturnsEmpty"
+Task: "Write test TestGetLogFormat"
+Task: "Write test TestGetLogFile"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (constants)
+2. Complete Phase 2: User Story 1 (GetPort + Serve integration)
+3. **STOP and VALIDATE**: Test port configuration independently
+4. Deploy/demo if ready - fixes the original E2E testing failure
+
+### Incremental Delivery
+
+1. Setup → Constants ready
+2. US1 → Port configuration works → **MVP COMPLETE**
+3. US2 → Logging configuration works
+4. US3 → Trace ID works
+5. US4 → Test mode works
+6. US5 → Migration verified → Full backward compatibility
+7. Polish → Documentation complete
+
+### Solo Developer Strategy
+
+1. Complete Setup
+2. Complete US1 (MVP) - validates core functionality
+3. Complete US2, US3, US4 in any order (all P2)
+4. Complete US5 (integration verification)
+5. Complete Polish
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent code sections
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- TDD required: verify tests fail before implementing
+- Commit after each phase completion
+- Stop at any checkpoint to validate story independently
+- MVP (US1) can be deployed standalone to fix the original port mismatch issue


### PR DESCRIPTION
Standardize environment variable handling across all plugins by adding a centralized configuration module in `pluginsdk`. This change ensures consistency between `pulumicost-core` and plugins, specifically resolving a critical port mismatch issue.

## Description

- **New `env.go` module**: Added `sdk/go/pluginsdk/env.go` with exported constants and getter functions for standard environment variables.
- **Port Configuration Fix**: Updated `sdk.go` to use `GetPort()` which strictly reads `PULUMICOST_PLUGIN_PORT`. This aligns plugin behavior with the core orchestrator, removing the legacy fallback to `PORT`.
- **Logging Standardization**: Added `GetLogLevel()` with backward compatibility (checks `PULUMICOST_LOG_LEVEL` first, then falls back to `LOG_LEVEL`), along with support for `PULUMICOST_LOG_FORMAT` and `PULUMICOST_LOG_FILE`.
- **Trace & Test Support**: Added accessors for `PULUMICOST_TRACE_ID` and `PULUMICOST_TEST_MODE`.
- **Comprehensive Testing**: Added `env_test.go` with 100% test coverage for all new configuration logic.

## Motivation

This change addresses a critical integration issue where `pulumicost-core` sets `PULUMICOST_PLUGIN_PORT` when launching plugins, but plugins were listening on `PORT` (or defaulting to 0/random). This caused E2E test failures and orchestration breakdowns.

Additionally, this centralizes configuration logic, ensuring all plugins respect the same environment variable contract for logging and tracing, promoting a unified developer experience.

## Verification

- **Unit Tests**: Added comprehensive unit tests in `env_test.go` covering all getter functions, fallback logic, and edge cases (invalid values, empty strings).
- **Integration Check**: Verified `sdk.go` correctly integrates `GetPort()` in the server startup flow.
- **Test Suite**: Ran `go test ./sdk/go/pluginsdk/...` - **Passed (100%)**.
- **Lint**: Ran `golangci-lint run ./sdk/go/pluginsdk/...` - **Passed (0 issues)**.

Fixes #127