### PR TITLE
fix: updating small bugs in spec

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -40,6 +40,7 @@ module.exports = {
         'ci', // CI/CD pipeline
         'deps', // Dependencies
         'docs', // Documentation
+        'main', // Main repository/release changes
       ],
     ],
 

--- a/sdk/go/pluginsdk/validation.go
+++ b/sdk/go/pluginsdk/validation.go
@@ -40,8 +40,8 @@ var (
 	ErrProjectedCostResourceNil       = errors.New("resource is required")
 	ErrProjectedCostProviderEmpty     = errors.New("resource.provider is required")
 	ErrProjectedCostResourceTypeEmpty = errors.New("resource.resource_type is required")
-	ErrProjectedCostSkuEmpty          = errors.New("resource.sku is required (use mapping.ExtractSKU)")
-	ErrProjectedCostRegionEmpty       = errors.New("resource.region is required (use mapping.ExtractRegion)")
+	ErrProjectedCostSkuEmpty          = errors.New("resource.sku is required (use mapping helpers)")
+	ErrProjectedCostRegionEmpty       = errors.New("resource.region is required (use mapping helpers)")
 )
 
 // Validation error messages for GetActualCostRequest.

--- a/specs/017-pluginsdk-validation/spec.md
+++ b/specs/017-pluginsdk-validation/spec.md
@@ -98,7 +98,7 @@ keys to check.
 - How does validation handle zero timestamps vs nil timestamps? Nil timestamps
   fail validation; zero timestamps (Unix epoch) are technically valid but may
   warn
-- What if start and end times are equal? Valid - represents an instant query
+- What if start and end times are equal? Invalid - end_time must be strictly after start_time.
 
 ## Requirements _(mandatory)_
 


### PR DESCRIPTION
This pull request updates validation logic and related tests for projected and actual cost requests in the pluginsdk, clarifies error messages, and improves test coverage and documentation. The main changes focus on making error messages more generic, refining time range validation, and enhancing benchmarks for invalid cases.

**Validation and Error Message Improvements:**
* Updated error messages for missing `sku` and `region` fields in `validation.go` to reference "mapping helpers" instead of specific function names, making guidance more general.
* Adjusted corresponding tests in `validation_test.go` to check for the new "mapping helpers" guidance in error messages. [[1]](diffhunk://#diff-9e4d876cc94ac929a98126ddec9f56f2ab9d41ae526e8b85619ed7a19c44aeeeL122-R122) [[2]](diffhunk://#diff-9e4d876cc94ac929a98126ddec9f56f2ab9d41ae526e8b85619ed7a19c44aeeeL141-R141)

**Validation Logic and Test Coverage:**
* Added a new test to ensure that an end time even one nanosecond before the start time is considered invalid for actual cost requests, enforcing that `end_time` must be strictly after `start_time`.
* Updated the specification to clarify that equal start and end times are invalid, aligning documentation with validation logic.

**Benchmark Improvements:**
* Split benchmarks for invalid projected and actual cost requests into more specific cases (`Invalid_EmptyProvider` and `Invalid_EmptyResourceID`) for clearer performance analysis. [[1]](diffhunk://#diff-9e4d876cc94ac929a98126ddec9f56f2ab9d41ae526e8b85619ed7a19c44aeeeL273-R286) [[2]](diffhunk://#diff-9e4d876cc94ac929a98126ddec9f56f2ab9d41ae526e8b85619ed7a19c44aeeeL303-R316)