### PR TITLE
fix(sdk): correct strict weak ordering violation in sort recommendations

### DIFF
--- a/sdk/go/pluginsdk/helpers.go
+++ b/sdk/go/pluginsdk/helpers.go
@@ -654,11 +654,12 @@ func SortRecommendations(
 	ascending := determineSortOrder(sortBy, sortOrder)
 
 	sort.SliceStable(sorted, func(i, j int) bool {
-		less := compareRecommendations(sorted[i], sorted[j], sortBy)
 		if ascending {
-			return less
+			return compareRecommendations(sorted[i], sorted[j], sortBy)
 		}
-		return !less
+		// Swap arguments for descending order to maintain strict weak ordering.
+		// Using !less would break the sort contract for equal elements.
+		return compareRecommendations(sorted[j], sorted[i], sortBy)
 	})
 
 	return sorted


### PR DESCRIPTION
## Summary

- The `SortRecommendations` function used `!less` for descending order, which breaks the sort contract when elements are equal (both directions return true, violating asymmetry)
- Fixed by swapping comparison arguments instead of negating the result, ensuring equal elements correctly return false for both directions
- Added comprehensive test coverage for sorting functionality including a regression test specifically for equal-value stability

## Test plan

- [x] `make test` passes - all existing and new tests pass
- [x] `make lint` passes for Go code (0 issues)
- [x] New `TestSortRecommendationsWithEqualValues` verifies stable sorting
- [x] New `TestSortRecommendationsStrictWeakOrdering` stress tests with 100 elements containing duplicate values

## Changes

### Modified files

- `sdk/go/pluginsdk/helpers.go` - Fixed comparison logic in `SortRecommendations` to swap arguments for descending order instead of negating the result
- `sdk/go/pluginsdk/helpers_test.go` - Added 6 new test functions: `TestSortRecommendations`, `TestSortRecommendationsDoesNotModifyOriginal`, `TestSortRecommendationsWithEqualValues`, `TestSortRecommendationsByPriority`, `TestSortRecommendationsStrictWeakOrdering`

Closes #167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recommendation sorting logic to properly handle ascending and descending order requests with correct and consistent ordering.

* **Tests**
  * Added extensive test coverage for recommendation sorting, including ascending/descending modes, edge cases, empty inputs, priority sorting, and stress tests to ensure reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->