### PR TITLE
bug: fixing test issues and mockplugin

### DIFF
--- a/sdk/go/testing/benchmark_test.go
+++ b/sdk/go/testing/benchmark_test.go
@@ -557,10 +557,8 @@ func BenchmarkGetRecommendations_LargeResultSet(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		_, err := client.GetRecommendations(ctx, &pbc.GetRecommendationsRequest{
-			// Request the full configured set in a single response for SC-005.
-			PageSize: largeResultSetRecommendationCount,
-		})
+		// PageSize=0 returns all results without pagination for SC-005 large result set testing.
+		_, err := client.GetRecommendations(ctx, &pbc.GetRecommendationsRequest{})
 		if err != nil {
 			b.Fatalf("GetRecommendations() failed: %v", err)
 		}
@@ -617,10 +615,9 @@ func TestGetRecommendations_LargeResultSetLatency(t *testing.T) {
 	ctx := context.Background()
 
 	// Measure single request latency for the full result set
+	// PageSize=0 returns all results without pagination for SC-005 large result set testing.
 	start := time.Now()
-	_, err := client.GetRecommendations(ctx, &pbc.GetRecommendationsRequest{
-		PageSize: largeResultSetRecommendationCount,
-	})
+	_, err := client.GetRecommendations(ctx, &pbc.GetRecommendationsRequest{})
 	duration := time.Since(start)
 
 	if err != nil {

--- a/sdk/go/testing/mock_plugin.go
+++ b/sdk/go/testing/mock_plugin.go
@@ -621,6 +621,11 @@ func (m *MockPlugin) GetRecommendations(
 		return nil, status.Error(codes.Unavailable, msg)
 	}
 
+	// Validate request contract constraints (including MaxTargetResources limit)
+	if err := ValidateGetRecommendationsRequest(req); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "request validation failed: %v", err)
+	}
+
 	// Return configured recommendations or empty list
 	recs := m.RecommendationsConfig.Recommendations
 	if recs == nil {


### PR DESCRIPTION
This pull request enhances the test coverage and validation logic for the `GetRecommendations` API, focusing on request validation, pagination handling, and robustness under concurrent and edge-case scenarios. The main improvements include stricter enforcement of request parameter limits, updates to test cases to reflect contract changes, and the addition of new tests for concurrency and limit enforcement.

**Test and validation improvements:**

* Added validation for the `MaxTargetResources` limit (100) in the `MockPlugin.GetRecommendations` method by invoking `ValidateGetRecommendationsRequest`, ensuring that requests exceeding this limit are rejected with an appropriate error code.
* Added a new test `TestTargetResourcesFiltering_ExceedsLimit` to verify that requests with more than 100 target resources are correctly rejected with an `InvalidArgument` gRPC error.
* Added a new test `TestTargetResourcesFiltering_Concurrent` to ensure that concurrent requests with different `target_resources` are handled safely and correctly, validating thread-safety of the filtering logic.

**Test updates for request parameters:**

* Updated the `TestGetRecommendations_SummaryValidation` test to use a valid projection period value (`"monthly"` instead of the invalid `"30d"`), and adjusted assertions accordingly. [[1]](diffhunk://#diff-1a7094b191576dc02d2356628716e9eafc1c20d432b20afed843ab0ac9f52222R2537-R2539) [[2]](diffhunk://#diff-1a7094b191576dc02d2356628716e9eafc1c20d432b20afed843ab0ac9f52222L2547-R2549)
* Added clarifying comments and minor adjustments to tests for large result sets and batch queries, including using `PageSize=0` to explicitly request all results in benchmark and latency tests. [[1]](diffhunk://#diff-0e2efe4abc3e1dd027b2ff1c7e32362f44ce25e9b81e5a41dc3e8c6df50fb434L560-R561) [[2]](diffhunk://#diff-0e2efe4abc3e1dd027b2ff1c7e32362f44ce25e9b81e5a41dc3e8c6df50fb434R618-R620) [[3]](diffhunk://#diff-1a7094b191576dc02d2356628716e9eafc1c20d432b20afed843ab0ac9f52222R3188)