### PR TITLE
chore(pluginsdk): use package-level error variables for consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          version: '1.32.1'
+
       - name: Buf lint
-        run: make buf-lint
+        run: buf lint
 
       - name: Buf breaking change detection
         run: |
-          bin/buf breaking --against \
+          buf breaking --against \
             'https://github.com/rshade/pulumicost-spec.git#branch=main'
         if: github.event_name == 'pull_request'
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,18 @@ generate: $(BUF_BIN)
 $(BUF_BIN):
 	@mkdir -p bin
 	@echo "Installing buf $(BUF_VERSION) locally..."
-	@curl -sSL "https://github.com/bufbuild/buf/releases/download/v$(BUF_VERSION)/buf-$$(uname -s)-$$(uname -m)" -o $(BUF_BIN)
+	@BUF_URL="https://github.com/bufbuild/buf/releases/download/v$(BUF_VERSION)/buf-$$(uname -s)-$$(uname -m)"; \
+	curl -fsSL "$$BUF_URL" -o $(BUF_BIN) || { \
+		echo "Failed to download buf from $$BUF_URL"; \
+		exit 1; \
+	}
 	@chmod +x $(BUF_BIN)
+	@if ! file $(BUF_BIN) | grep -q 'ELF\|Mach-O'; then \
+		echo "Error: Downloaded file is not a valid binary"; \
+		head -5 $(BUF_BIN); \
+		rm -f $(BUF_BIN); \
+		exit 1; \
+	fi
 	@echo "buf installed to $(BUF_BIN)"
 
 tidy:

--- a/proto/pulumicost/v1/costsource.proto
+++ b/proto/pulumicost/v1/costsource.proto
@@ -162,7 +162,15 @@ message GetActualCostResponse {
 message GetProjectedCostRequest {
   // resource contains the resource descriptor for cost projection
   ResourceDescriptor resource = 1;
-  // utilization_percentage is the global default utilization for all resources in request (0.0 to 1.0)
+  // utilization_percentage is the global default utilization for all resources in request.
+  // Valid range: 0.0 to 1.0 (representing 0% to 100% utilization).
+  //
+  // NOTE: Due to proto3 semantics, 0.0 cannot be distinguished from "not set".
+  // When this field is 0.0 (proto3 default for unset double), the SDK applies
+  // a baseline default of 0.5 (50% utilization).
+  //
+  // To explicitly request 0% utilization, use the resource-level override:
+  //   resource.utilization_percentage = proto.Float64(0.0)
   double utilization_percentage = 2;
 }
 

--- a/sdk/go/pluginsdk/validation.go
+++ b/sdk/go/pluginsdk/validation.go
@@ -46,6 +46,11 @@ var (
 	ErrMetricKindInvalid              = errors.New("invalid metric kind")
 )
 
+// Validation error messages for SupportsResponse.
+var (
+	ErrSupportsResponseNil = errors.New("response is required")
+)
+
 // Validation error messages for GetActualCostRequest.
 var (
 	ErrActualCostRequestNil       = errors.New("request is required")
@@ -125,7 +130,7 @@ func ValidateProjectedCostRequest(req *pbc.GetProjectedCostRequest) error {
 // Returns nil if the response is valid, or an error describing the failure.
 func ValidateSupportsResponse(res *pbc.SupportsResponse) error {
 	if res == nil {
-		return errors.New("response is required")
+		return ErrSupportsResponseNil
 	}
 
 	for _, kind := range res.GetSupportedMetrics() {

--- a/sdk/go/pluginsdk/validation_test.go
+++ b/sdk/go/pluginsdk/validation_test.go
@@ -274,8 +274,7 @@ func TestValidateSupportsResponse(t *testing.T) {
 		{
 			name:    "nil response returns error",
 			res:     nil,
-			wantErr: nil, // Note: ValidateSupportsResponse currently returns errors.New("response is required")
-			// I should use errors.Is or check message for generic error
+			wantErr: pluginsdk.ErrSupportsResponseNil,
 		},
 		{
 			name: "valid response with metrics returns nil",
@@ -312,12 +311,6 @@ func TestValidateSupportsResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := pluginsdk.ValidateSupportsResponse(tt.res)
-			if tt.name == "nil response returns error" {
-				if err == nil {
-					t.Error("expected error for nil response, got nil")
-				}
-				return
-			}
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("ValidateSupportsResponse() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/sdk/go/proto/pulumicost/v1/costsource.pb.go
+++ b/sdk/go/proto/pulumicost/v1/costsource.pb.go
@@ -1241,7 +1241,16 @@ type GetProjectedCostRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// resource contains the resource descriptor for cost projection
 	Resource *ResourceDescriptor `protobuf:"bytes,1,opt,name=resource,proto3" json:"resource,omitempty"`
-	// utilization_percentage is the global default utilization for all resources in request (0.0 to 1.0)
+	// utilization_percentage is the global default utilization for all resources in request.
+	// Valid range: 0.0 to 1.0 (representing 0% to 100% utilization).
+	//
+	// NOTE: Due to proto3 semantics, 0.0 cannot be distinguished from "not set".
+	// When this field is 0.0 (proto3 default for unset double), the SDK applies
+	// a baseline default of 0.5 (50% utilization).
+	//
+	// To explicitly request 0% utilization, use the resource-level override:
+	//
+	//	resource.utilization_percentage = proto.Float64(0.0)
 	UtilizationPercentage float64 `protobuf:"fixed64,2,opt,name=utilization_percentage,json=utilizationPercentage,proto3" json:"utilization_percentage,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache


### PR DESCRIPTION
## Summary

- Add `ErrSupportsResponseNil` to enable `errors.Is()` comparisons for callers who need to handle nil response errors specifically
- Remove special-case test logic that was needed because inline errors couldn't be compared with `errors.Is()`
- Update proto documentation for `utilization_percentage` in `GetProjectedCostRequest` to explain proto3 zero-value semantics

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] `make generate` regenerates Go code without errors
- [x] `buf lint` passes
- [x] Tests now use `errors.Is()` consistently

## Changes

### Modified files

- `sdk/go/pluginsdk/validation.go` - Add `ErrSupportsResponseNil` package-level error variable and update `ValidateSupportsResponse()` to use it
- `sdk/go/pluginsdk/validation_test.go` - Update test to use `errors.Is()` with the new error variable, remove workaround logic
- `proto/pulumicost/v1/costsource.proto` - Add multi-line documentation for `utilization_percentage` field explaining proto3 limitations and SDK default behavior

Closes #177
Closed #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for utilization-percentage parameter, clarifying valid range, default semantics, and override behavior.

* **New Features**
  * Added a distinct error for nil-response validation to improve error clarity.

* **Tests**
  * Updated validation tests to assert the new nil-response error behavior.

* **Chores**
  * Updated CI lint/breaking-change steps and added guarded download and validation steps to local tooling setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->