### PR TITLE
feat(proto): add focus 1.3 columns and contract commitment dataset

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,56 +2,110 @@
 
 ## Vision
 
-To provide the definitive, high-performance gRPC specification and Go SDK for cloud cost observability, centered around the FinOps Foundation's FOCUS standard.
+To provide the definitive, high-performance gRPC specification and Go SDK for cloud cost observability,
+centered around the FinOps Foundation's FOCUS standard.
 
 ---
 
 ## [Past Milestones]
 
 ### Protocol & Modeling
-- [x] **GreenOps Standardization** ([#176](https://github.com/rshade/pulumicost-spec/issues/176)) - Sustainability metrics (carbon footprint, energy utilization) integrated into the core protocol.
-- [x] **Recommendation Enhancements** ([#173](https://github.com/rshade/pulumicost-spec/issues/173), [#171](https://github.com/rshade/pulumicost-spec/issues/171), [#166](https://github.com/rshade/pulumicost-spec/issues/166)) - Added resource-scoped targets, filtering, and extended action types.
-- [x] **FOCUS 1.2 Integration** ([#100](https://github.com/rshade/pulumicost-spec/issues/100), [#99](https://github.com/rshade/pulumicost-spec/issues/99)) - Full schema coverage and builder API for FOCUS 1.2.
-- [x] **RPC Expansion** ([#125](https://github.com/rshade/pulumicost-spec/issues/125), [#123](https://github.com/rshade/pulumicost-spec/issues/123), [#90](https://github.com/rshade/pulumicost-spec/issues/90)) - Implemented `EstimateCost`, `GetBudgets`, and `GetRecommendations`.
-- [x] **Zero-Allocation Enums** ([#63](https://github.com/rshade/pulumicost-spec/issues/63), [#33](https://github.com/rshade/pulumicost-spec/issues/33)) - High-performance validation for domain enums.
+
+- [x] **GreenOps Standardization** ([#176](https://github.com/rshade/pulumicost-spec/issues/176)) -
+  Sustainability metrics (carbon footprint, energy utilization) integrated into the core protocol.
+- [x] **Recommendation Enhancements**
+  ([#173](https://github.com/rshade/pulumicost-spec/issues/173),
+  [#171](https://github.com/rshade/pulumicost-spec/issues/171),
+  [#166](https://github.com/rshade/pulumicost-spec/issues/166)) -
+  Added resource-scoped targets, filtering, and extended action types.
+- [x] **FOCUS 1.2 Integration**
+  ([#100](https://github.com/rshade/pulumicost-spec/issues/100),
+  [#99](https://github.com/rshade/pulumicost-spec/issues/99)) -
+  Full schema coverage and builder API for FOCUS 1.2.
+- [x] **RPC Expansion**
+  ([#125](https://github.com/rshade/pulumicost-spec/issues/125),
+  [#123](https://github.com/rshade/pulumicost-spec/issues/123),
+  [#90](https://github.com/rshade/pulumicost-spec/issues/90)) -
+  Implemented `EstimateCost`, `GetBudgets`, and `GetRecommendations`.
+- [x] **Zero-Allocation Enums**
+  ([#63](https://github.com/rshade/pulumicost-spec/issues/63),
+  [#33](https://github.com/rshade/pulumicost-spec/issues/33)) -
+  High-performance validation for domain enums.
 
 ### SDK & Tooling
-- [x] **Plugin Conformance Suite** ([#109](https://github.com/rshade/pulumicost-spec/issues/109)) - Automated testing for plugin implementers to ensure spec compliance.
-- [x] **SDK Foundation** ([#151](https://github.com/rshade/pulumicost-spec/issues/151), [#148](https://github.com/rshade/pulumicost-spec/issues/148), [#145](https://github.com/rshade/pulumicost-spec/issues/145), [#139](https://github.com/rshade/pulumicost-spec/issues/139)) - Centralized environment handling, Prometheus metrics, and unified file-based logging.
-- [x] **Orchestration Support** ([#181](https://github.com/rshade/pulumicost-spec/issues/181), [#143](https://github.com/rshade/pulumicost-spec/issues/143), [#126](https://github.com/rshade/pulumicost-spec/issues/126)) - Added reflection, `--port` flags, and `fallback-hints`.
+
+- [x] **Plugin Conformance Suite** ([#109](https://github.com/rshade/pulumicost-spec/issues/109)) -
+  Automated testing for plugin implementers to ensure spec compliance.
+- [x] **SDK Foundation**
+  ([#151](https://github.com/rshade/pulumicost-spec/issues/151),
+  [#148](https://github.com/rshade/pulumicost-spec/issues/148),
+  [#145](https://github.com/rshade/pulumicost-spec/issues/145),
+  [#139](https://github.com/rshade/pulumicost-spec/issues/139)) -
+  Centralized environment handling, Prometheus metrics, and unified file-based logging.
+- [x] **Orchestration Support**
+  ([#181](https://github.com/rshade/pulumicost-spec/issues/181),
+  [#143](https://github.com/rshade/pulumicost-spec/issues/143),
+  [#126](https://github.com/rshade/pulumicost-spec/issues/126)) -
+  Added reflection, `--port` flags, and `fallback-hints`.
 
 ---
 
 ## [Immediate Focus] (Q1 2026)
 
 ### High Priority Research
-- [ ] **Plugin Capability Discovery (Feature Flagging)** ([#194](https://github.com/rshade/pulumicost-spec/issues/194)) - Implementing a discovery protocol for advertisement of supported RPCs.
+
+- [ ] **Plugin Capability Discovery (Feature Flagging)**
+  ([#194](https://github.com/rshade/pulumicost-spec/issues/194)) -
+  Implementing a discovery protocol for advertisement of supported RPCs.
 
 ### Stability & Maintenance
-- [ ] **Dependency Management** ([#13](https://github.com/rshade/pulumicost-spec/issues/13)) - Automated tracking and updating of core proto and SDK dependencies.
+
+- [ ] **Dependency Management** ([#13](https://github.com/rshade/pulumicost-spec/issues/13)) -
+  Automated tracking and updating of core proto and SDK dependencies.
 
 ### Planned Features
-- [ ] **FOCUS 1.3 Migration** ([#183](https://github.com/rshade/pulumicost-spec/issues/183)) - Audit new columns and entities in FOCUS 1.3 and update builder APIs.
-- [ ] **Contextual FinOps Validation** ([#184](https://github.com/rshade/pulumicost-spec/issues/184)) - Extend `pluginsdk/validation` to include contextual checks (e.g., ensuring `ListPrice` is not less than `BilledCost`).
-- [ ] **Advanced SDK Patterns** ([#185](https://github.com/rshade/pulumicost-spec/issues/185)) - Implementation examples for complex tiered pricing and multi-provider mapping.
-- [ ] **SDK Documentation Overhaul** - Comprehensive Godoc and implementation examples for the new `mapping` and `validation` packages.
+
+- [ ] **FOCUS 1.3 Migration** ([#183](https://github.com/rshade/pulumicost-spec/issues/183)) -
+  Audit new columns and entities in FOCUS 1.3 and update builder APIs.
+- [ ] **Contextual FinOps Validation** ([#184](https://github.com/rshade/pulumicost-spec/issues/184)) -
+  Extend `pluginsdk/validation` to include contextual checks
+  (e.g., ensuring `ListPrice` is not less than `BilledCost`).
+- [ ] **Advanced SDK Patterns** ([#185](https://github.com/rshade/pulumicost-spec/issues/185)) -
+  Implementation examples for complex tiered pricing and multi-provider mapping.
+- [ ] **SDK Documentation Overhaul** -
+  Comprehensive Godoc and implementation examples for the new `mapping` and `validation` packages.
 
 ### In Progress
-- [/] **Standardized Benchmark Suite** ([#113](https://github.com/rshade/pulumicost-spec/issues/113), [#142](https://github.com/rshade/pulumicost-spec/issues/142)) - Formalizing "Time to First Byte" and memory allocation benchmarks for plugins.
+
+- [/] **Standardized Benchmark Suite**
+  ([#113](https://github.com/rshade/pulumicost-spec/issues/113),
+  [#142](https://github.com/rshade/pulumicost-spec/issues/142)) -
+  Formalizing "Time to First Byte" and memory allocation benchmarks for plugins.
 
 ---
 
 ## [Future Vision] (Long-Term)
 
 ### Active Research
-- [ ] **Standardized Cost Allocation Lineage Metadata** ([#191](https://github.com/rshade/pulumicost-spec/issues/191))
-- [ ] **Standardized Recommendation Reasoning Metadata** ([#192](https://github.com/rshade/pulumicost-spec/issues/192))
-- [ ] **Distributed Tracing Propagation (Contextual Visibility)** ([#193](https://github.com/rshade/pulumicost-spec/issues/193))
-- [ ] **Authorization Middleware (OIDC/IAM)** ([#195](https://github.com/rshade/pulumicost-spec/issues/195)) - Standardizing how plugins receive and validate identity without violating "Stateless" boundaries.
-- [ ] **Cross-Language SDKs (Python/TS)** ([#196](https://github.com/rshade/pulumicost-spec/issues/196)) - To be initiated after Go SDK reaches v1.0 stability and a critical mass of plugins exist.
-- [ ] **Streaming Actual Cost (Streaming RPCs)** ([#197](https://github.com/rshade/pulumicost-spec/issues/197)) - Evaluating the need for `StreamActualCost` for real-time anomaly detection.
+
+- [ ] **Standardized Cost Allocation Lineage Metadata**
+  ([#191](https://github.com/rshade/pulumicost-spec/issues/191))
+- [ ] **Standardized Recommendation Reasoning Metadata**
+  ([#192](https://github.com/rshade/pulumicost-spec/issues/192))
+- [ ] **Distributed Tracing Propagation (Contextual Visibility)**
+  ([#193](https://github.com/rshade/pulumicost-spec/issues/193))
+- [ ] **Authorization Middleware (OIDC/IAM)**
+  ([#195](https://github.com/rshade/pulumicost-spec/issues/195)) -
+  Standardizing how plugins receive and validate identity without violating "Stateless" boundaries.
+- [ ] **Cross-Language SDKs (Python/TS)**
+  ([#196](https://github.com/rshade/pulumicost-spec/issues/196)) -
+  To be initiated after Go SDK reaches v1.0 stability and a critical mass of plugins exist.
+- [ ] **Streaming Actual Cost (Streaming RPCs)**
+  ([#197](https://github.com/rshade/pulumicost-spec/issues/197)) -
+  Evaluating the need for `StreamActualCost` for real-time anomaly detection.
 
 ### Proposed for Discussion (Discovery)
+
 - [ ] **Plugin Capability Dry Run Mode** ([#186](https://github.com/rshade/pulumicost-spec/issues/186))
 - [ ] **JSON-LD / Schema.org Serialization** ([#187](https://github.com/rshade/pulumicost-spec/issues/187))
 - [ ] **Standardized Recommendation Reasoning** ([#188](https://github.com/rshade/pulumicost-spec/issues/188))
@@ -64,4 +118,5 @@ To provide the definitive, high-performance gRPC specification and Go SDK for cl
 
 - **No Orchestration Logic**: Multi-plugin aggregation and "Muxing" logic will stay in `pulumicost-core`.
 - **No Persistence**: The SDK will not provide built-in database support; it remains stateless.
-- **No Native Math Engines**: The SDK will not perform financial amortization; it will only define the fields to store the results of such calculations.
+- **No Native Math Engines**: The SDK will not perform financial amortization;
+  it will only define the fields to store the results of such calculations.

--- a/examples/plugins/focus_example.go
+++ b/examples/plugins/focus_example.go
@@ -40,6 +40,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	//nolint:staticcheck // SA1019: Demonstrating deprecated provider_name access for backward compatibility example
 	logger.Info("Generated Complete FOCUS 1.2 Record",
 		"provider", record.GetProviderName(),
 		"service", record.GetServiceName(),
@@ -132,6 +133,7 @@ func setConditionalColumns(builder *pluginsdk.FocusRecordBuilder) {
 	builder.WithUsage(exampleConsumedQuantity, "Hours")
 
 	// Service - Conditional Fields
+	//nolint:staticcheck // SA1019: Demonstrating deprecated WithPublisher for backward compatibility example
 	builder.WithPublisher("Amazon Web Services")
 	builder.WithServiceSubcategory("Virtual Machine")
 

--- a/proto/pulumicost/v1/focus.proto
+++ b/proto/pulumicost/v1/focus.proto
@@ -7,8 +7,26 @@ import "pulumicost/v1/enums.proto";
 
 option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto;pbc";
 
+// =============================================================================
+// FOCUS 1.3 Contract Commitment Category Enum
+// =============================================================================
+
+// FocusContractCommitmentCategory represents the type of commitment in the
+// FOCUS 1.3 Contract Commitment Dataset.
+// Reference: FOCUS 1.3 Contract Commitment Category
+enum FocusContractCommitmentCategory {
+  // Default/unspecified value.
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED = 0;
+  // Monetary spend commitment (e.g., $10,000/month minimum).
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND = 1;
+  // Usage quantity commitment (e.g., 1000 compute hours).
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE = 2;
+}
+
 // FocusCostRecord represents a single cost line item normalized to the
-// FinOps FOCUS 1.2 specification. All field names follow FOCUS naming conventions.
+// FinOps FOCUS specification (1.2 and 1.3). All field names follow FOCUS naming conventions.
+// Includes FOCUS 1.3 additions: allocation fields, contract commitment linking,
+// and service/host provider disambiguation.
 // Reference: https://focus.finops.org
 message FocusCostRecord {
   // ==========================================================================
@@ -16,7 +34,9 @@ message FocusCostRecord {
   // ==========================================================================
 
   // ProviderName: The name of the cloud provider (e.g., "AWS", "Azure", "GCP").
-  string provider_name = 1;
+  // DEPRECATED in FOCUS 1.3: Use service_provider_name instead.
+  // Will be removed in FOCUS 1.4.
+  string provider_name = 1 [deprecated = true];
 
   // BillingAccountId: The identifier for the billing account.
   string billing_account_id = 2;
@@ -128,7 +148,9 @@ message FocusCostRecord {
 
   // Publisher: Entity that published the service or product.
   // FOCUS 1.2 Section 3.39: Publisher (CONDITIONAL).
-  string publisher = 55;
+  // DEPRECATED in FOCUS 1.3: Use host_provider_name instead.
+  // Will be removed in FOCUS 1.4.
+  string publisher = 55 [deprecated = true];
 
   // ==========================================================================
   // Resource Details (FOCUS 1.2 Section 2.7)
@@ -270,4 +292,162 @@ message FocusCostRecord {
   // ExtendedColumns: The "Backpack" - supports future FOCUS columns or
   // provider-specific extensions without requiring a schema update.
   map<string, string> extended_columns = 23;
+
+  // ==========================================================================
+  // FOCUS 1.3 Additions (Field Numbers 59-66)
+  // ==========================================================================
+  //
+  // Field Numbering Strategy:
+  // - Fields 1-58: FOCUS 1.2 columns (established baseline)
+  // - Fields 59-66: Reserved for FOCUS 1.3 additions
+  //
+  // This separation enables clear version tracking - you can identify which
+  // FOCUS version introduced each field by its number. Future FOCUS versions
+  // should continue this pattern (e.g., FOCUS 1.4 could use 67+).
+  //
+  // ==========================================================================
+  // FOCUS 1.3 Provider Identification
+  // ==========================================================================
+
+  // ServiceProviderName: The entity that makes the service available for purchase.
+  // In reseller/marketplace scenarios, this is the ISV or reseller.
+  // Replaces deprecated provider_name field.
+  // FOCUS 1.3 Section: Service Provider Name (CONDITIONAL)
+  string service_provider_name = 59;
+
+  // HostProviderName: The entity that hosts the underlying resource or service.
+  // This is where the workload actually runs (e.g., AWS, Azure, GCP).
+  // Replaces deprecated publisher field.
+  // FOCUS 1.3 Section: Host Provider Name (CONDITIONAL)
+  string host_provider_name = 60;
+
+  // ==========================================================================
+  // FOCUS 1.3 Split Cost Allocation (NEW)
+  // ==========================================================================
+
+  // AllocatedMethodId: Identifier for the cost allocation methodology used.
+  // Links to a documented allocation method.
+  // Validation: If populated, allocated_resource_id MUST also be populated.
+  // FOCUS 1.3 Section: Allocated Method ID (CONDITIONAL)
+  string allocated_method_id = 61;
+
+  // AllocatedMethodDetails: Human-readable description of the allocation method.
+  // Provides transparency into how costs were split.
+  // FOCUS 1.3 Section: Allocated Method Details (RECOMMENDED)
+  string allocated_method_details = 62;
+
+  // AllocatedResourceId: Identifier of the resource receiving the allocated cost.
+  // This is the target of the cost allocation.
+  // FOCUS 1.3 Section: Allocated Resource ID (CONDITIONAL)
+  string allocated_resource_id = 63;
+
+  // AllocatedResourceName: Display name of the resource receiving allocated cost.
+  // FOCUS 1.3 Section: Allocated Resource Name (CONDITIONAL)
+  string allocated_resource_name = 64;
+
+  // AllocatedTags: Tags associated with the allocated resource.
+  // Follows same map<string, string> pattern as existing tags field.
+  // FOCUS 1.3 Section: Allocated Tags (CONDITIONAL)
+  map<string, string> allocated_tags = 65;
+
+  // ==========================================================================
+  // FOCUS 1.3 Contract Commitment Link (NEW)
+  // ==========================================================================
+
+  // ContractApplied: Reference to a ContractCommitmentId in the Contract
+  // Commitment dataset. Treated as opaque reference (no cross-dataset validation).
+  // FOCUS 1.3 Section: Contract Applied (CONDITIONAL)
+  string contract_applied = 66;
+}
+
+// =============================================================================
+// FOCUS 1.3 Contract Commitment Dataset
+// =============================================================================
+
+// ContractCommitment represents a contractual commitment record in the
+// FOCUS 1.3 Contract Commitment supplemental dataset.
+//
+// This is a separate dataset from Cost and Usage data, allowing practitioners
+// to query contract terms independently from individual cost line items.
+//
+// Reference: FOCUS 1.3 Contract Commitment Dataset
+message ContractCommitment {
+  // ==========================================================================
+  // Identity Fields
+  // ==========================================================================
+
+  // ContractCommitmentId: Unique identifier for this specific commitment.
+  // REQUIRED. Primary key for the commitment record.
+  // FOCUS 1.3 Section: Contract Commitment ID
+  string contract_commitment_id = 1;
+
+  // ContractId: Identifier of the parent contract containing this commitment.
+  // REQUIRED. Links to the broader contract agreement.
+  // FOCUS 1.3 Section: Contract ID
+  string contract_id = 2;
+
+  // ==========================================================================
+  // Classification Fields
+  // ==========================================================================
+
+  // ContractCommitmentCategory: Category of commitment (SPEND or USAGE).
+  // FOCUS 1.3 Contract Commitment Category (CONDITIONAL).
+  FocusContractCommitmentCategory contract_commitment_category = 3;
+
+  // ContractCommitmentType: Provider-specific type of commitment.
+  // Free-form string (e.g., "Reserved Instance", "Savings Plan", "CUD").
+  // FOCUS 1.3 Contract Commitment Type (CONDITIONAL).
+  string contract_commitment_type = 4;
+
+  // ==========================================================================
+  // Commitment Period Fields
+  // ==========================================================================
+
+  // ContractCommitmentPeriodStart: Start of the commitment period.
+  // When the specific commitment obligations begin.
+  // FOCUS 1.3 Contract Commitment Period Start (CONDITIONAL).
+  google.protobuf.Timestamp contract_commitment_period_start = 5;
+
+  // ContractCommitmentPeriodEnd: End of the commitment period.
+  // When the specific commitment obligations end.
+  // FOCUS 1.3 Contract Commitment Period End (CONDITIONAL).
+  google.protobuf.Timestamp contract_commitment_period_end = 6;
+
+  // ==========================================================================
+  // Contract Period Fields
+  // ==========================================================================
+
+  // ContractPeriodStart: Start of the overall contract.
+  // When the parent contract agreement begins.
+  // FOCUS 1.3 Contract Period Start (CONDITIONAL).
+  google.protobuf.Timestamp contract_period_start = 7;
+
+  // ContractPeriodEnd: End of the overall contract.
+  // When the parent contract agreement ends.
+  // FOCUS 1.3 Contract Period End (CONDITIONAL).
+  google.protobuf.Timestamp contract_period_end = 8;
+
+  // ==========================================================================
+  // Financial Fields
+  // ==========================================================================
+
+  // ContractCommitmentCost: Monetary amount of the commitment.
+  // For SPEND category, this is the dollar/currency amount committed.
+  // FOCUS 1.3 Contract Commitment Cost (CONDITIONAL).
+  double contract_commitment_cost = 9;
+
+  // ContractCommitmentQuantity: Quantity amount of the commitment.
+  // For USAGE category, this is the unit quantity committed.
+  // FOCUS 1.3 Contract Commitment Quantity (CONDITIONAL).
+  double contract_commitment_quantity = 10;
+
+  // ContractCommitmentUnit: Unit of measure for quantity.
+  // Examples: "Hours", "GB", "vCPU-Hours", "Requests".
+  // FOCUS 1.3 Contract Commitment Unit (CONDITIONAL).
+  string contract_commitment_unit = 11;
+
+  // BillingCurrency: ISO 4217 currency code for monetary values.
+  // REQUIRED. Format: 3-letter currency code (e.g., "USD", "EUR").
+  // FOCUS 1.3 Billing Currency
+  string billing_currency = 12;
 }

--- a/sdk/go/pluginsdk/contract_commitment_builder.go
+++ b/sdk/go/pluginsdk/contract_commitment_builder.go
@@ -1,0 +1,206 @@
+package pluginsdk
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/currency"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ContractCommitmentBuilder handles the construction of FOCUS 1.3 ContractCommitment records.
+// This builder creates records for the Contract Commitment supplemental dataset,
+// which tracks contractual obligations separately from cost line items.
+//
+// Reference: FOCUS 1.3 Contract Commitment Dataset.
+type ContractCommitmentBuilder struct {
+	record *pbc.ContractCommitment
+}
+
+// NewContractCommitmentBuilder creates a new builder instance for ContractCommitment records.
+func NewContractCommitmentBuilder() *ContractCommitmentBuilder {
+	return &ContractCommitmentBuilder{
+		record: &pbc.ContractCommitment{},
+	}
+}
+
+// WithIdentity sets the identity fields for the contract commitment.
+// ContractCommitmentId is the unique identifier for this specific commitment (REQUIRED).
+// ContractId is the identifier of the parent contract containing this commitment (REQUIRED).
+// FOCUS 1.3 Section: Contract Commitment ID, Contract ID.
+func (b *ContractCommitmentBuilder) WithIdentity(
+	commitmentID, contractID string,
+) *ContractCommitmentBuilder {
+	b.record.ContractCommitmentId = commitmentID
+	b.record.ContractId = contractID
+	return b
+}
+
+// WithCategory sets the commitment category.
+// Category indicates whether this is a SPEND or USAGE commitment.
+// FOCUS 1.3 Section: Contract Commitment Category.
+func (b *ContractCommitmentBuilder) WithCategory(
+	category pbc.FocusContractCommitmentCategory,
+) *ContractCommitmentBuilder {
+	b.record.ContractCommitmentCategory = category
+	return b
+}
+
+// WithType sets the provider-specific commitment type.
+// Examples: "Reserved Instance", "Savings Plan", "Committed Use Discount", "Enterprise Agreement"
+// FOCUS 1.3 Section: Contract Commitment Type.
+func (b *ContractCommitmentBuilder) WithType(
+	commitmentType string,
+) *ContractCommitmentBuilder {
+	b.record.ContractCommitmentType = commitmentType
+	return b
+}
+
+// WithCommitmentPeriod sets the start and end of the commitment period.
+// This is when the specific commitment obligations are active.
+// FOCUS 1.3 Section: Contract Commitment Period Start/End.
+func (b *ContractCommitmentBuilder) WithCommitmentPeriod(
+	start, end time.Time,
+) *ContractCommitmentBuilder {
+	b.record.ContractCommitmentPeriodStart = timestamppb.New(start)
+	b.record.ContractCommitmentPeriodEnd = timestamppb.New(end)
+	return b
+}
+
+// WithContractPeriod sets the start and end of the overall contract period.
+// This is when the parent contract agreement is active.
+// FOCUS 1.3 Section: Contract Period Start/End.
+func (b *ContractCommitmentBuilder) WithContractPeriod(
+	start, end time.Time,
+) *ContractCommitmentBuilder {
+	b.record.ContractPeriodStart = timestamppb.New(start)
+	b.record.ContractPeriodEnd = timestamppb.New(end)
+	return b
+}
+
+// WithFinancials sets all financial fields for the commitment.
+// - cost: Monetary amount of the commitment (for SPEND category)
+// - quantity: Quantity amount of the commitment (for USAGE category)
+// - unit: Unit of measure for quantity (e.g., "Hours", "GB", "vCPU-Hours")
+// - currencyCode: ISO 4217 currency code for monetary values (REQUIRED)
+//
+// For granular control, use WithCost(), WithQuantity(), and WithCurrency() instead.
+// FOCUS 1.3 Section: Contract Commitment Cost, Quantity, Unit, Billing Currency.
+func (b *ContractCommitmentBuilder) WithFinancials(
+	cost, quantity float64, unit, currencyCode string,
+) *ContractCommitmentBuilder {
+	b.record.ContractCommitmentCost = cost
+	b.record.ContractCommitmentQuantity = quantity
+	b.record.ContractCommitmentUnit = unit
+	b.record.BillingCurrency = currencyCode
+	return b
+}
+
+// WithCost sets the monetary commitment amount for SPEND category commitments.
+// Use this for commitments based on spend thresholds (e.g., "$100,000/year").
+// FOCUS 1.3 Section: Contract Commitment Cost.
+func (b *ContractCommitmentBuilder) WithCost(cost float64) *ContractCommitmentBuilder {
+	b.record.ContractCommitmentCost = cost
+	return b
+}
+
+// WithQuantity sets the quantity and unit for USAGE category commitments.
+// Use this for commitments based on consumption (e.g., "1000 vCPU-Hours").
+// FOCUS 1.3 Section: Contract Commitment Quantity, Contract Commitment Unit.
+func (b *ContractCommitmentBuilder) WithQuantity(quantity float64, unit string) *ContractCommitmentBuilder {
+	b.record.ContractCommitmentQuantity = quantity
+	b.record.ContractCommitmentUnit = unit
+	return b
+}
+
+// WithCurrency sets the ISO 4217 currency code for the commitment.
+// This field is REQUIRED for all commitments.
+// FOCUS 1.3 Section: Billing Currency.
+func (b *ContractCommitmentBuilder) WithCurrency(currencyCode string) *ContractCommitmentBuilder {
+	b.record.BillingCurrency = currencyCode
+	return b
+}
+
+// Build validates and returns the constructed ContractCommitment record.
+// Returns an error if required fields are missing or validation rules are violated.
+func (b *ContractCommitmentBuilder) Build() (*pbc.ContractCommitment, error) {
+	if err := b.validate(); err != nil {
+		return nil, err
+	}
+	return b.record, nil
+}
+
+// validate checks all validation rules for the ContractCommitment record.
+func (b *ContractCommitmentBuilder) validate() error {
+	// Required fields validation
+	if b.record.GetContractCommitmentId() == "" {
+		return errors.New("contract_commitment_id is required")
+	}
+	if b.record.GetContractId() == "" {
+		return errors.New("contract_id is required")
+	}
+	if b.record.GetBillingCurrency() == "" {
+		return errors.New("billing_currency is required")
+	}
+
+	// Category validation - must be explicitly set to SPEND or USAGE
+	category := b.record.GetContractCommitmentCategory()
+	if category != pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND &&
+		category != pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE {
+		return fmt.Errorf("contract_commitment_category must be SPEND or USAGE, got %v", category)
+	}
+
+	// Currency validation using existing ISO 4217 validator
+	if !currency.IsValid(b.record.GetBillingCurrency()) {
+		return fmt.Errorf(
+			"billing_currency must be a valid ISO 4217 currency code, got %q",
+			b.record.GetBillingCurrency(),
+		)
+	}
+
+	// Period consistency validation
+	if err := b.validatePeriods(); err != nil {
+		return err
+	}
+
+	// Non-negative value validation
+	if b.record.GetContractCommitmentCost() < 0 {
+		return errors.New("contract_commitment_cost must be non-negative")
+	}
+	if b.record.GetContractCommitmentQuantity() < 0 {
+		return errors.New("contract_commitment_quantity must be non-negative")
+	}
+
+	return nil
+}
+
+// validatePeriods ensures period end >= period start for both commitment and contract periods.
+func (b *ContractCommitmentBuilder) validatePeriods() error {
+	// Validate commitment period if both are set
+	if b.record.GetContractCommitmentPeriodStart() != nil && b.record.GetContractCommitmentPeriodEnd() != nil {
+		start := b.record.GetContractCommitmentPeriodStart().AsTime()
+		end := b.record.GetContractCommitmentPeriodEnd().AsTime()
+		if end.Before(start) {
+			return fmt.Errorf(
+				"contract_commitment_period_end (%s) must be >= contract_commitment_period_start (%s)",
+				end.Format(time.RFC3339), start.Format(time.RFC3339),
+			)
+		}
+	}
+
+	// Validate contract period if both are set
+	if b.record.GetContractPeriodStart() != nil && b.record.GetContractPeriodEnd() != nil {
+		start := b.record.GetContractPeriodStart().AsTime()
+		end := b.record.GetContractPeriodEnd().AsTime()
+		if end.Before(start) {
+			return fmt.Errorf(
+				"contract_period_end (%s) must be >= contract_period_start (%s)",
+				end.Format(time.RFC3339), start.Format(time.RFC3339),
+			)
+		}
+	}
+
+	return nil
+}

--- a/sdk/go/pluginsdk/contract_commitment_builder_test.go
+++ b/sdk/go/pluginsdk/contract_commitment_builder_test.go
@@ -1,0 +1,488 @@
+package pluginsdk_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// =============================================================================
+// ContractCommitmentBuilder Tests (Phase 5 - User Story 3)
+// =============================================================================
+
+// TestContractCommitmentBuilder_Build_HappyPath tests a complete valid contract commitment.
+func TestContractCommitmentBuilder_Build_HappyPath(t *testing.T) {
+	now := time.Now()
+	commitmentStart := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	commitmentEnd := commitmentStart.AddDate(1, 0, 0)
+	contractStart := commitmentStart.AddDate(-1, 0, 0)
+	contractEnd := commitmentEnd.AddDate(2, 0, 0)
+
+	record, err := pluginsdk.NewContractCommitmentBuilder().
+		WithIdentity("commitment-ri-123456", "contract-enterprise-2024").
+		WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+		WithType("3-Year Reserved Instance").
+		WithCommitmentPeriod(commitmentStart, commitmentEnd).
+		WithContractPeriod(contractStart, contractEnd).
+		WithFinancials(120000.00, 0, "", "USD").
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Verify identity fields
+	if record.GetContractCommitmentId() != "commitment-ri-123456" {
+		t.Errorf("Expected ContractCommitmentId %q, got %q", "commitment-ri-123456", record.GetContractCommitmentId())
+	}
+	if record.GetContractId() != "contract-enterprise-2024" {
+		t.Errorf("Expected ContractId %q, got %q", "contract-enterprise-2024", record.GetContractId())
+	}
+
+	// Verify classification fields
+	if record.GetContractCommitmentCategory() != pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND {
+		t.Errorf("Expected SPEND category, got %v", record.GetContractCommitmentCategory())
+	}
+	if record.GetContractCommitmentType() != "3-Year Reserved Instance" {
+		t.Errorf("Expected CommitmentType %q, got %q", "3-Year Reserved Instance", record.GetContractCommitmentType())
+	}
+
+	// Verify financial fields
+	if record.GetContractCommitmentCost() != 120000.00 {
+		t.Errorf("Expected Cost 120000.00, got %f", record.GetContractCommitmentCost())
+	}
+	if record.GetBillingCurrency() != "USD" {
+		t.Errorf("Expected BillingCurrency %q, got %q", "USD", record.GetBillingCurrency())
+	}
+}
+
+// TestContractCommitmentBuilder_WithIdentity tests the WithIdentity builder method.
+func TestContractCommitmentBuilder_WithIdentity(t *testing.T) {
+	tests := []struct {
+		name         string
+		commitmentID string
+		contractID   string
+	}{
+		{"ri commitment", "ri-123", "contract-456"},
+		{"savings plan", "sp-abc", "contract-xyz"},
+		{"cud commitment", "cud-def", "contract-ghi"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidCommitmentBuilder()
+			builder.WithIdentity(tt.commitmentID, tt.contractID)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetContractCommitmentId() != tt.commitmentID {
+				t.Errorf("Expected CommitmentId %q, got %q", tt.commitmentID, record.GetContractCommitmentId())
+			}
+			if record.GetContractId() != tt.contractID {
+				t.Errorf("Expected ContractId %q, got %q", tt.contractID, record.GetContractId())
+			}
+		})
+	}
+}
+
+// TestContractCommitmentBuilder_WithCategory tests the WithCategory builder method.
+func TestContractCommitmentBuilder_WithCategory(t *testing.T) {
+	tests := []struct {
+		name        string
+		category    pbc.FocusContractCommitmentCategory
+		expectError bool
+	}{
+		{"spend", pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND, false},
+		{"usage", pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE, false},
+		{
+			"unspecified rejects",
+			pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Note: createValidCommitmentBuilder sets SPEND category, so we start with minimal builder
+			builder := pluginsdk.NewContractCommitmentBuilder().
+				WithIdentity("commitment-123", "contract-456").
+				WithCategory(tt.category).
+				WithFinancials(100, 0, "", "USD")
+			record, err := builder.Build()
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error for UNSPECIFIED category, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Build failed: %v", err)
+				}
+				if record.GetContractCommitmentCategory() != tt.category {
+					t.Errorf("Expected Category %v, got %v", tt.category, record.GetContractCommitmentCategory())
+				}
+			}
+		})
+	}
+}
+
+// TestContractCommitmentBuilder_WithType tests the WithType builder method.
+func TestContractCommitmentBuilder_WithType(t *testing.T) {
+	tests := []struct {
+		name           string
+		commitmentType string
+	}{
+		{"reserved instance", "Reserved Instance"},
+		{"savings plan", "Savings Plan"},
+		{"committed use discount", "Committed Use Discount"},
+		{"enterprise agreement", "Enterprise Agreement"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidCommitmentBuilder()
+			builder.WithType(tt.commitmentType)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetContractCommitmentType() != tt.commitmentType {
+				t.Errorf("Expected Type %q, got %q", tt.commitmentType, record.GetContractCommitmentType())
+			}
+		})
+	}
+}
+
+// TestContractCommitmentBuilder_WithFinancials tests the WithFinancials builder method.
+func TestContractCommitmentBuilder_WithFinancials(t *testing.T) {
+	tests := []struct {
+		name     string
+		cost     float64
+		quantity float64
+		unit     string
+		currency string
+	}{
+		{"spend commitment", 10000.00, 0, "", "USD"},
+		{"usage commitment", 0, 1000, "Hours", "EUR"},
+		{"combined commitment", 5000.00, 500, "vCPU-Hours", "GBP"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := createValidCommitmentBuilder()
+			builder.WithFinancials(tt.cost, tt.quantity, tt.unit, tt.currency)
+			record, err := builder.Build()
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			if record.GetContractCommitmentCost() != tt.cost {
+				t.Errorf("Expected Cost %f, got %f", tt.cost, record.GetContractCommitmentCost())
+			}
+			if record.GetContractCommitmentQuantity() != tt.quantity {
+				t.Errorf("Expected Quantity %f, got %f", tt.quantity, record.GetContractCommitmentQuantity())
+			}
+			if record.GetContractCommitmentUnit() != tt.unit {
+				t.Errorf("Expected Unit %q, got %q", tt.unit, record.GetContractCommitmentUnit())
+			}
+			if record.GetBillingCurrency() != tt.currency {
+				t.Errorf("Expected Currency %q, got %q", tt.currency, record.GetBillingCurrency())
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Validation Tests
+// =============================================================================
+
+// TestContractCommitmentBuilder_Validation_RequiredFields tests required field validation.
+func TestContractCommitmentBuilder_Validation_RequiredFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		builder     func() *pluginsdk.ContractCommitmentBuilder
+		expectError bool
+		errContains string
+	}{
+		{
+			name: "missing commitment id",
+			builder: func() *pluginsdk.ContractCommitmentBuilder {
+				return pluginsdk.NewContractCommitmentBuilder().
+					WithIdentity("", "contract-123").
+					WithFinancials(100, 0, "", "USD")
+			},
+			expectError: true,
+			errContains: "contract_commitment_id",
+		},
+		{
+			name: "missing contract id",
+			builder: func() *pluginsdk.ContractCommitmentBuilder {
+				return pluginsdk.NewContractCommitmentBuilder().
+					WithIdentity("commitment-123", "").
+					WithFinancials(100, 0, "", "USD")
+			},
+			expectError: true,
+			errContains: "contract_id",
+		},
+		{
+			name: "missing billing currency",
+			builder: func() *pluginsdk.ContractCommitmentBuilder {
+				return pluginsdk.NewContractCommitmentBuilder().
+					WithIdentity("commitment-123", "contract-456").
+					WithFinancials(100, 0, "", "")
+			},
+			expectError: true,
+			errContains: "billing_currency",
+		},
+		{
+			name: "valid minimal",
+			builder: func() *pluginsdk.ContractCommitmentBuilder {
+				return pluginsdk.NewContractCommitmentBuilder().
+					WithIdentity("commitment-123", "contract-456").
+					WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+					WithFinancials(100, 0, "", "USD")
+			},
+			expectError: false,
+			errContains: "",
+		},
+		{
+			name: "missing category (UNSPECIFIED)",
+			builder: func() *pluginsdk.ContractCommitmentBuilder {
+				return pluginsdk.NewContractCommitmentBuilder().
+					WithIdentity("commitment-123", "contract-456").
+					WithFinancials(100, 0, "", "USD")
+			},
+			expectError: true,
+			errContains: "contract_commitment_category",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.builder().Build()
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got nil")
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestContractCommitmentBuilder_Validation_PeriodConsistency tests period validation.
+func TestContractCommitmentBuilder_Validation_PeriodConsistency(t *testing.T) {
+	now := time.Now()
+	validStart := now
+	validEnd := now.AddDate(1, 0, 0)
+	invalidEnd := now.AddDate(-1, 0, 0) // End before start
+
+	tests := []struct {
+		name        string
+		start       time.Time
+		end         time.Time
+		expectError bool
+	}{
+		{"valid period", validStart, validEnd, false},
+		{"same start and end", validStart, validStart, false}, // Edge case: allowed
+		{"end before start", validStart, invalidEnd, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := pluginsdk.NewContractCommitmentBuilder().
+				WithIdentity("commitment-123", "contract-456").
+				WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+				WithCommitmentPeriod(tt.start, tt.end).
+				WithFinancials(100, 0, "", "USD")
+
+			_, err := builder.Build()
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error for invalid period but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestContractCommitmentBuilder_Validation_NonNegativeValues tests non-negative validation.
+func TestContractCommitmentBuilder_Validation_NonNegativeValues(t *testing.T) {
+	tests := []struct {
+		name        string
+		cost        float64
+		quantity    float64
+		expectError bool
+	}{
+		{"positive cost", 100.00, 0, false},
+		{"positive quantity", 0, 100, false},
+		{"zero cost and quantity", 0, 0, false},
+		{"negative cost", -100.00, 0, true},
+		{"negative quantity", 0, -100, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := pluginsdk.NewContractCommitmentBuilder().
+				WithIdentity("commitment-123", "contract-456").
+				WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+				WithFinancials(tt.cost, tt.quantity, "Units", "USD")
+
+			_, err := builder.Build()
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error for negative values but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestContractCommitmentBuilder_Validation_Currency tests currency validation.
+func TestContractCommitmentBuilder_Validation_Currency(t *testing.T) {
+	tests := []struct {
+		name        string
+		currency    string
+		expectError bool
+	}{
+		{"valid USD", "USD", false},
+		{"valid EUR", "EUR", false},
+		{"valid JPY", "JPY", false},
+		{"valid XXX no currency", "XXX", false}, // XXX is valid ISO 4217 for "no currency"
+		{"invalid currency", "ZZZ", true},       // ZZZ is not a valid ISO 4217 code
+		{"lowercase", "usd", true},              // Must be uppercase
+		{"empty", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := pluginsdk.NewContractCommitmentBuilder().
+				WithIdentity("commitment-123", "contract-456").
+				WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+				WithFinancials(100, 0, "", tt.currency)
+
+			_, err := builder.Build()
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for currency %q but got nil", tt.currency)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for currency %q: %v", tt.currency, err)
+				}
+			}
+		})
+	}
+}
+
+// TestContractCommitmentBuilder_ChainMethods tests method chaining.
+func TestContractCommitmentBuilder_ChainMethods(t *testing.T) {
+	now := time.Now()
+	commitmentStart := now
+	commitmentEnd := now.AddDate(1, 0, 0)
+	contractStart := now.AddDate(-1, 0, 0)
+	contractEnd := now.AddDate(2, 0, 0)
+
+	record, err := pluginsdk.NewContractCommitmentBuilder().
+		WithIdentity("commitment-123", "contract-456").
+		WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE).
+		WithType("Compute Engine CUD").
+		WithCommitmentPeriod(commitmentStart, commitmentEnd).
+		WithContractPeriod(contractStart, contractEnd).
+		WithFinancials(0, 1000, "vCPU-Hours", "USD").
+		Build()
+
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	// Verify all fields
+	if record.GetContractCommitmentId() != "commitment-123" {
+		t.Errorf("Wrong CommitmentId")
+	}
+	if record.GetContractId() != "contract-456" {
+		t.Errorf("Wrong ContractId")
+	}
+	if record.GetContractCommitmentCategory() != pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE {
+		t.Errorf("Wrong Category")
+	}
+	if record.GetContractCommitmentType() != "Compute Engine CUD" {
+		t.Errorf("Wrong Type")
+	}
+	if record.GetContractCommitmentQuantity() != 1000 {
+		t.Errorf("Wrong Quantity")
+	}
+	if record.GetContractCommitmentUnit() != "vCPU-Hours" {
+		t.Errorf("Wrong Unit")
+	}
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+// createValidCommitmentBuilder creates a builder with minimal valid data.
+func createValidCommitmentBuilder() *pluginsdk.ContractCommitmentBuilder {
+	return pluginsdk.NewContractCommitmentBuilder().
+		WithIdentity("commitment-123", "contract-456").
+		WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+		WithFinancials(100, 0, "", "USD")
+}
+
+// =============================================================================
+// Benchmarks
+// =============================================================================
+
+// BenchmarkContractCommitmentBuilder_Build measures build performance.
+func BenchmarkContractCommitmentBuilder_Build(b *testing.B) {
+	now := time.Now()
+	start := now
+	end := now.AddDate(1, 0, 0)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_, _ = pluginsdk.NewContractCommitmentBuilder().
+			WithIdentity("commitment-123", "contract-456").
+			WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+			WithType("Reserved Instance").
+			WithCommitmentPeriod(start, end).
+			WithFinancials(10000, 0, "", "USD").
+			Build()
+	}
+}
+
+// BenchmarkContractCommitmentBuilder_WithIdentity measures identity method performance.
+func BenchmarkContractCommitmentBuilder_WithIdentity(b *testing.B) {
+	builder := pluginsdk.NewContractCommitmentBuilder()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		builder.WithIdentity("commitment-123", "contract-456")
+	}
+}
+
+// BenchmarkContractCommitmentBuilder_WithFinancials measures financials method performance.
+func BenchmarkContractCommitmentBuilder_WithFinancials(b *testing.B) {
+	builder := pluginsdk.NewContractCommitmentBuilder()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		builder.WithFinancials(10000, 100, "Hours", "USD")
+	}
+}

--- a/sdk/go/proto/pulumicost/v1/focus.pb.go
+++ b/sdk/go/proto/pulumicost/v1/focus.pb.go
@@ -22,12 +22,73 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// FocusContractCommitmentCategory represents the type of commitment in the
+// FOCUS 1.3 Contract Commitment Dataset.
+// Reference: FOCUS 1.3 Contract Commitment Category
+type FocusContractCommitmentCategory int32
+
+const (
+	// Default/unspecified value.
+	FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED FocusContractCommitmentCategory = 0
+	// Monetary spend commitment (e.g., $10,000/month minimum).
+	FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND FocusContractCommitmentCategory = 1
+	// Usage quantity commitment (e.g., 1000 compute hours).
+	FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE FocusContractCommitmentCategory = 2
+)
+
+// Enum value maps for FocusContractCommitmentCategory.
+var (
+	FocusContractCommitmentCategory_name = map[int32]string{
+		0: "FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED",
+		1: "FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND",
+		2: "FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE",
+	}
+	FocusContractCommitmentCategory_value = map[string]int32{
+		"FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED": 0,
+		"FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND":       1,
+		"FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE":       2,
+	}
+)
+
+func (x FocusContractCommitmentCategory) Enum() *FocusContractCommitmentCategory {
+	p := new(FocusContractCommitmentCategory)
+	*p = x
+	return p
+}
+
+func (x FocusContractCommitmentCategory) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (FocusContractCommitmentCategory) Descriptor() protoreflect.EnumDescriptor {
+	return file_pulumicost_v1_focus_proto_enumTypes[0].Descriptor()
+}
+
+func (FocusContractCommitmentCategory) Type() protoreflect.EnumType {
+	return &file_pulumicost_v1_focus_proto_enumTypes[0]
+}
+
+func (x FocusContractCommitmentCategory) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use FocusContractCommitmentCategory.Descriptor instead.
+func (FocusContractCommitmentCategory) EnumDescriptor() ([]byte, []int) {
+	return file_pulumicost_v1_focus_proto_rawDescGZIP(), []int{0}
+}
+
 // FocusCostRecord represents a single cost line item normalized to the
-// FinOps FOCUS 1.2 specification. All field names follow FOCUS naming conventions.
+// FinOps FOCUS specification (1.2 and 1.3). All field names follow FOCUS naming conventions.
+// Includes FOCUS 1.3 additions: allocation fields, contract commitment linking,
+// and service/host provider disambiguation.
 // Reference: https://focus.finops.org
 type FocusCostRecord struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// ProviderName: The name of the cloud provider (e.g., "AWS", "Azure", "GCP").
+	// DEPRECATED in FOCUS 1.3: Use service_provider_name instead.
+	// Will be removed in FOCUS 1.4.
+	//
+	// Deprecated: Marked as deprecated in pulumicost/v1/focus.proto.
 	ProviderName string `protobuf:"bytes,1,opt,name=provider_name,json=providerName,proto3" json:"provider_name,omitempty"`
 	// BillingAccountId: The identifier for the billing account.
 	BillingAccountId string `protobuf:"bytes,2,opt,name=billing_account_id,json=billingAccountId,proto3" json:"billing_account_id,omitempty"`
@@ -93,6 +154,10 @@ type FocusCostRecord struct {
 	ServiceSubcategory string `protobuf:"bytes,56,opt,name=service_subcategory,json=serviceSubcategory,proto3" json:"service_subcategory,omitempty"`
 	// Publisher: Entity that published the service or product.
 	// FOCUS 1.2 Section 3.39: Publisher (CONDITIONAL).
+	// DEPRECATED in FOCUS 1.3: Use host_provider_name instead.
+	// Will be removed in FOCUS 1.4.
+	//
+	// Deprecated: Marked as deprecated in pulumicost/v1/focus.proto.
 	Publisher string `protobuf:"bytes,55,opt,name=publisher,proto3" json:"publisher,omitempty"`
 	// ResourceId: The unique identifier for the resource.
 	ResourceId string `protobuf:"bytes,12,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
@@ -169,6 +234,40 @@ type FocusCostRecord struct {
 	// ExtendedColumns: The "Backpack" - supports future FOCUS columns or
 	// provider-specific extensions without requiring a schema update.
 	ExtendedColumns map[string]string `protobuf:"bytes,23,rep,name=extended_columns,json=extendedColumns,proto3" json:"extended_columns,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// ServiceProviderName: The entity that makes the service available for purchase.
+	// In reseller/marketplace scenarios, this is the ISV or reseller.
+	// Replaces deprecated provider_name field.
+	// FOCUS 1.3 Section: Service Provider Name (CONDITIONAL)
+	ServiceProviderName string `protobuf:"bytes,59,opt,name=service_provider_name,json=serviceProviderName,proto3" json:"service_provider_name,omitempty"`
+	// HostProviderName: The entity that hosts the underlying resource or service.
+	// This is where the workload actually runs (e.g., AWS, Azure, GCP).
+	// Replaces deprecated publisher field.
+	// FOCUS 1.3 Section: Host Provider Name (CONDITIONAL)
+	HostProviderName string `protobuf:"bytes,60,opt,name=host_provider_name,json=hostProviderName,proto3" json:"host_provider_name,omitempty"`
+	// AllocatedMethodId: Identifier for the cost allocation methodology used.
+	// Links to a documented allocation method.
+	// Validation: If populated, allocated_resource_id MUST also be populated.
+	// FOCUS 1.3 Section: Allocated Method ID (CONDITIONAL)
+	AllocatedMethodId string `protobuf:"bytes,61,opt,name=allocated_method_id,json=allocatedMethodId,proto3" json:"allocated_method_id,omitempty"`
+	// AllocatedMethodDetails: Human-readable description of the allocation method.
+	// Provides transparency into how costs were split.
+	// FOCUS 1.3 Section: Allocated Method Details (RECOMMENDED)
+	AllocatedMethodDetails string `protobuf:"bytes,62,opt,name=allocated_method_details,json=allocatedMethodDetails,proto3" json:"allocated_method_details,omitempty"`
+	// AllocatedResourceId: Identifier of the resource receiving the allocated cost.
+	// This is the target of the cost allocation.
+	// FOCUS 1.3 Section: Allocated Resource ID (CONDITIONAL)
+	AllocatedResourceId string `protobuf:"bytes,63,opt,name=allocated_resource_id,json=allocatedResourceId,proto3" json:"allocated_resource_id,omitempty"`
+	// AllocatedResourceName: Display name of the resource receiving allocated cost.
+	// FOCUS 1.3 Section: Allocated Resource Name (CONDITIONAL)
+	AllocatedResourceName string `protobuf:"bytes,64,opt,name=allocated_resource_name,json=allocatedResourceName,proto3" json:"allocated_resource_name,omitempty"`
+	// AllocatedTags: Tags associated with the allocated resource.
+	// Follows same map<string, string> pattern as existing tags field.
+	// FOCUS 1.3 Section: Allocated Tags (CONDITIONAL)
+	AllocatedTags map[string]string `protobuf:"bytes,65,rep,name=allocated_tags,json=allocatedTags,proto3" json:"allocated_tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// ContractApplied: Reference to a ContractCommitmentId in the Contract
+	// Commitment dataset. Treated as opaque reference (no cross-dataset validation).
+	// FOCUS 1.3 Section: Contract Applied (CONDITIONAL)
+	ContractApplied string `protobuf:"bytes,66,opt,name=contract_applied,json=contractApplied,proto3" json:"contract_applied,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -203,6 +302,7 @@ func (*FocusCostRecord) Descriptor() ([]byte, []int) {
 	return file_pulumicost_v1_focus_proto_rawDescGZIP(), []int{0}
 }
 
+// Deprecated: Marked as deprecated in pulumicost/v1/focus.proto.
 func (x *FocusCostRecord) GetProviderName() string {
 	if x != nil {
 		return x.ProviderName
@@ -392,6 +492,7 @@ func (x *FocusCostRecord) GetServiceSubcategory() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in pulumicost/v1/focus.proto.
 func (x *FocusCostRecord) GetPublisher() string {
 	if x != nil {
 		return x.Publisher
@@ -609,13 +710,243 @@ func (x *FocusCostRecord) GetExtendedColumns() map[string]string {
 	return nil
 }
 
+func (x *FocusCostRecord) GetServiceProviderName() string {
+	if x != nil {
+		return x.ServiceProviderName
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetHostProviderName() string {
+	if x != nil {
+		return x.HostProviderName
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetAllocatedMethodId() string {
+	if x != nil {
+		return x.AllocatedMethodId
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetAllocatedMethodDetails() string {
+	if x != nil {
+		return x.AllocatedMethodDetails
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetAllocatedResourceId() string {
+	if x != nil {
+		return x.AllocatedResourceId
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetAllocatedResourceName() string {
+	if x != nil {
+		return x.AllocatedResourceName
+	}
+	return ""
+}
+
+func (x *FocusCostRecord) GetAllocatedTags() map[string]string {
+	if x != nil {
+		return x.AllocatedTags
+	}
+	return nil
+}
+
+func (x *FocusCostRecord) GetContractApplied() string {
+	if x != nil {
+		return x.ContractApplied
+	}
+	return ""
+}
+
+// ContractCommitment represents a contractual commitment record in the
+// FOCUS 1.3 Contract Commitment supplemental dataset.
+//
+// This is a separate dataset from Cost and Usage data, allowing practitioners
+// to query contract terms independently from individual cost line items.
+//
+// Reference: FOCUS 1.3 Contract Commitment Dataset
+type ContractCommitment struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ContractCommitmentId: Unique identifier for this specific commitment.
+	// REQUIRED. Primary key for the commitment record.
+	// FOCUS 1.3 Section: Contract Commitment ID
+	ContractCommitmentId string `protobuf:"bytes,1,opt,name=contract_commitment_id,json=contractCommitmentId,proto3" json:"contract_commitment_id,omitempty"`
+	// ContractId: Identifier of the parent contract containing this commitment.
+	// REQUIRED. Links to the broader contract agreement.
+	// FOCUS 1.3 Section: Contract ID
+	ContractId string `protobuf:"bytes,2,opt,name=contract_id,json=contractId,proto3" json:"contract_id,omitempty"`
+	// ContractCommitmentCategory: Category of commitment (SPEND or USAGE).
+	// FOCUS 1.3 Contract Commitment Category (CONDITIONAL).
+	ContractCommitmentCategory FocusContractCommitmentCategory `protobuf:"varint,3,opt,name=contract_commitment_category,json=contractCommitmentCategory,proto3,enum=pulumicost.v1.FocusContractCommitmentCategory" json:"contract_commitment_category,omitempty"`
+	// ContractCommitmentType: Provider-specific type of commitment.
+	// Free-form string (e.g., "Reserved Instance", "Savings Plan", "CUD").
+	// FOCUS 1.3 Contract Commitment Type (CONDITIONAL).
+	ContractCommitmentType string `protobuf:"bytes,4,opt,name=contract_commitment_type,json=contractCommitmentType,proto3" json:"contract_commitment_type,omitempty"`
+	// ContractCommitmentPeriodStart: Start of the commitment period.
+	// When the specific commitment obligations begin.
+	// FOCUS 1.3 Contract Commitment Period Start (CONDITIONAL).
+	ContractCommitmentPeriodStart *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=contract_commitment_period_start,json=contractCommitmentPeriodStart,proto3" json:"contract_commitment_period_start,omitempty"`
+	// ContractCommitmentPeriodEnd: End of the commitment period.
+	// When the specific commitment obligations end.
+	// FOCUS 1.3 Contract Commitment Period End (CONDITIONAL).
+	ContractCommitmentPeriodEnd *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=contract_commitment_period_end,json=contractCommitmentPeriodEnd,proto3" json:"contract_commitment_period_end,omitempty"`
+	// ContractPeriodStart: Start of the overall contract.
+	// When the parent contract agreement begins.
+	// FOCUS 1.3 Contract Period Start (CONDITIONAL).
+	ContractPeriodStart *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=contract_period_start,json=contractPeriodStart,proto3" json:"contract_period_start,omitempty"`
+	// ContractPeriodEnd: End of the overall contract.
+	// When the parent contract agreement ends.
+	// FOCUS 1.3 Contract Period End (CONDITIONAL).
+	ContractPeriodEnd *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=contract_period_end,json=contractPeriodEnd,proto3" json:"contract_period_end,omitempty"`
+	// ContractCommitmentCost: Monetary amount of the commitment.
+	// For SPEND category, this is the dollar/currency amount committed.
+	// FOCUS 1.3 Contract Commitment Cost (CONDITIONAL).
+	ContractCommitmentCost float64 `protobuf:"fixed64,9,opt,name=contract_commitment_cost,json=contractCommitmentCost,proto3" json:"contract_commitment_cost,omitempty"`
+	// ContractCommitmentQuantity: Quantity amount of the commitment.
+	// For USAGE category, this is the unit quantity committed.
+	// FOCUS 1.3 Contract Commitment Quantity (CONDITIONAL).
+	ContractCommitmentQuantity float64 `protobuf:"fixed64,10,opt,name=contract_commitment_quantity,json=contractCommitmentQuantity,proto3" json:"contract_commitment_quantity,omitempty"`
+	// ContractCommitmentUnit: Unit of measure for quantity.
+	// Examples: "Hours", "GB", "vCPU-Hours", "Requests".
+	// FOCUS 1.3 Contract Commitment Unit (CONDITIONAL).
+	ContractCommitmentUnit string `protobuf:"bytes,11,opt,name=contract_commitment_unit,json=contractCommitmentUnit,proto3" json:"contract_commitment_unit,omitempty"`
+	// BillingCurrency: ISO 4217 currency code for monetary values.
+	// REQUIRED. Format: 3-letter currency code (e.g., "USD", "EUR").
+	// FOCUS 1.3 Billing Currency
+	BillingCurrency string `protobuf:"bytes,12,opt,name=billing_currency,json=billingCurrency,proto3" json:"billing_currency,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ContractCommitment) Reset() {
+	*x = ContractCommitment{}
+	mi := &file_pulumicost_v1_focus_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContractCommitment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContractCommitment) ProtoMessage() {}
+
+func (x *ContractCommitment) ProtoReflect() protoreflect.Message {
+	mi := &file_pulumicost_v1_focus_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContractCommitment.ProtoReflect.Descriptor instead.
+func (*ContractCommitment) Descriptor() ([]byte, []int) {
+	return file_pulumicost_v1_focus_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ContractCommitment) GetContractCommitmentId() string {
+	if x != nil {
+		return x.ContractCommitmentId
+	}
+	return ""
+}
+
+func (x *ContractCommitment) GetContractId() string {
+	if x != nil {
+		return x.ContractId
+	}
+	return ""
+}
+
+func (x *ContractCommitment) GetContractCommitmentCategory() FocusContractCommitmentCategory {
+	if x != nil {
+		return x.ContractCommitmentCategory
+	}
+	return FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED
+}
+
+func (x *ContractCommitment) GetContractCommitmentType() string {
+	if x != nil {
+		return x.ContractCommitmentType
+	}
+	return ""
+}
+
+func (x *ContractCommitment) GetContractCommitmentPeriodStart() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ContractCommitmentPeriodStart
+	}
+	return nil
+}
+
+func (x *ContractCommitment) GetContractCommitmentPeriodEnd() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ContractCommitmentPeriodEnd
+	}
+	return nil
+}
+
+func (x *ContractCommitment) GetContractPeriodStart() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ContractPeriodStart
+	}
+	return nil
+}
+
+func (x *ContractCommitment) GetContractPeriodEnd() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ContractPeriodEnd
+	}
+	return nil
+}
+
+func (x *ContractCommitment) GetContractCommitmentCost() float64 {
+	if x != nil {
+		return x.ContractCommitmentCost
+	}
+	return 0
+}
+
+func (x *ContractCommitment) GetContractCommitmentQuantity() float64 {
+	if x != nil {
+		return x.ContractCommitmentQuantity
+	}
+	return 0
+}
+
+func (x *ContractCommitment) GetContractCommitmentUnit() string {
+	if x != nil {
+		return x.ContractCommitmentUnit
+	}
+	return ""
+}
+
+func (x *ContractCommitment) GetBillingCurrency() string {
+	if x != nil {
+		return x.BillingCurrency
+	}
+	return ""
+}
+
 var File_pulumicost_v1_focus_proto protoreflect.FileDescriptor
 
 const file_pulumicost_v1_focus_proto_rawDesc = "" +
 	"\n" +
-	"\x19pulumicost/v1/focus.proto\x12\rpulumicost.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x19pulumicost/v1/enums.proto\"\xb7\x19\n" +
-	"\x0fFocusCostRecord\x12#\n" +
-	"\rprovider_name\x18\x01 \x01(\tR\fproviderName\x12,\n" +
+	"\x19pulumicost/v1/focus.proto\x12\rpulumicost.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x19pulumicost/v1/enums.proto\"\xbe\x1d\n" +
+	"\x0fFocusCostRecord\x12'\n" +
+	"\rprovider_name\x18\x01 \x01(\tB\x02\x18\x01R\fproviderName\x12,\n" +
 	"\x12billing_account_id\x18\x02 \x01(\tR\x10billingAccountId\x120\n" +
 	"\x14billing_account_name\x18\x03 \x01(\tR\x12billingAccountName\x12$\n" +
 	"\x0esub_account_id\x18\x18 \x01(\tR\fsubAccountId\x12(\n" +
@@ -641,8 +972,8 @@ const file_pulumicost_v1_focus_proto_rawDesc = "" +
 	" pricing_currency_list_unit_price\x186 \x01(\x01R\x1cpricingCurrencyListUnitPrice\x12N\n" +
 	"\x10service_category\x18\x06 \x01(\x0e2#.pulumicost.v1.FocusServiceCategoryR\x0fserviceCategory\x12!\n" +
 	"\fservice_name\x18\a \x01(\tR\vserviceName\x12/\n" +
-	"\x13service_subcategory\x188 \x01(\tR\x12serviceSubcategory\x12\x1c\n" +
-	"\tpublisher\x187 \x01(\tR\tpublisher\x12\x1f\n" +
+	"\x13service_subcategory\x188 \x01(\tR\x12serviceSubcategory\x12 \n" +
+	"\tpublisher\x187 \x01(\tB\x02\x18\x01R\tpublisher\x12\x1f\n" +
 	"\vresource_id\x18\f \x01(\tR\n" +
 	"resourceId\x12#\n" +
 	"\rresource_name\x18\r \x01(\tR\fresourceName\x12#\n" +
@@ -678,13 +1009,43 @@ const file_pulumicost_v1_focus_proto_rawDesc = "" +
 	"invoice_id\x18\x13 \x01(\tR\tinvoiceId\x12%\n" +
 	"\x0einvoice_issuer\x18( \x01(\tR\rinvoiceIssuer\x12<\n" +
 	"\x04tags\x18\x16 \x03(\v2(.pulumicost.v1.FocusCostRecord.TagsEntryR\x04tags\x12^\n" +
-	"\x10extended_columns\x18\x17 \x03(\v23.pulumicost.v1.FocusCostRecord.ExtendedColumnsEntryR\x0fextendedColumns\x1a7\n" +
+	"\x10extended_columns\x18\x17 \x03(\v23.pulumicost.v1.FocusCostRecord.ExtendedColumnsEntryR\x0fextendedColumns\x122\n" +
+	"\x15service_provider_name\x18; \x01(\tR\x13serviceProviderName\x12,\n" +
+	"\x12host_provider_name\x18< \x01(\tR\x10hostProviderName\x12.\n" +
+	"\x13allocated_method_id\x18= \x01(\tR\x11allocatedMethodId\x128\n" +
+	"\x18allocated_method_details\x18> \x01(\tR\x16allocatedMethodDetails\x122\n" +
+	"\x15allocated_resource_id\x18? \x01(\tR\x13allocatedResourceId\x126\n" +
+	"\x17allocated_resource_name\x18@ \x01(\tR\x15allocatedResourceName\x12X\n" +
+	"\x0eallocated_tags\x18A \x03(\v21.pulumicost.v1.FocusCostRecord.AllocatedTagsEntryR\rallocatedTags\x12)\n" +
+	"\x10contract_applied\x18B \x01(\tR\x0fcontractApplied\x1a7\n" +
 	"\tTagsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1aB\n" +
 	"\x14ExtendedColumnsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B4Z2github.com/rshade/pulumicost-spec/sdk/go/proto;pbcb\x06proto3"
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a@\n" +
+	"\x12AllocatedTagsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xda\x06\n" +
+	"\x12ContractCommitment\x124\n" +
+	"\x16contract_commitment_id\x18\x01 \x01(\tR\x14contractCommitmentId\x12\x1f\n" +
+	"\vcontract_id\x18\x02 \x01(\tR\n" +
+	"contractId\x12p\n" +
+	"\x1ccontract_commitment_category\x18\x03 \x01(\x0e2..pulumicost.v1.FocusContractCommitmentCategoryR\x1acontractCommitmentCategory\x128\n" +
+	"\x18contract_commitment_type\x18\x04 \x01(\tR\x16contractCommitmentType\x12c\n" +
+	" contract_commitment_period_start\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\x1dcontractCommitmentPeriodStart\x12_\n" +
+	"\x1econtract_commitment_period_end\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x1bcontractCommitmentPeriodEnd\x12N\n" +
+	"\x15contract_period_start\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x13contractPeriodStart\x12J\n" +
+	"\x13contract_period_end\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\x11contractPeriodEnd\x128\n" +
+	"\x18contract_commitment_cost\x18\t \x01(\x01R\x16contractCommitmentCost\x12@\n" +
+	"\x1ccontract_commitment_quantity\x18\n" +
+	" \x01(\x01R\x1acontractCommitmentQuantity\x128\n" +
+	"\x18contract_commitment_unit\x18\v \x01(\tR\x16contractCommitmentUnit\x12)\n" +
+	"\x10billing_currency\x18\f \x01(\tR\x0fbillingCurrency*\xb1\x01\n" +
+	"\x1fFocusContractCommitmentCategory\x122\n" +
+	".FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED\x10\x00\x12,\n" +
+	"(FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND\x10\x01\x12,\n" +
+	"(FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE\x10\x02B4Z2github.com/rshade/pulumicost-spec/sdk/go/proto;pbcb\x06proto3"
 
 var (
 	file_pulumicost_v1_focus_proto_rawDescOnce sync.Once
@@ -698,41 +1059,51 @@ func file_pulumicost_v1_focus_proto_rawDescGZIP() []byte {
 	return file_pulumicost_v1_focus_proto_rawDescData
 }
 
-var file_pulumicost_v1_focus_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_pulumicost_v1_focus_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_pulumicost_v1_focus_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_pulumicost_v1_focus_proto_goTypes = []any{
-	(*FocusCostRecord)(nil),              // 0: pulumicost.v1.FocusCostRecord
-	nil,                                  // 1: pulumicost.v1.FocusCostRecord.TagsEntry
-	nil,                                  // 2: pulumicost.v1.FocusCostRecord.ExtendedColumnsEntry
-	(*timestamppb.Timestamp)(nil),        // 3: google.protobuf.Timestamp
-	(FocusChargeCategory)(0),             // 4: pulumicost.v1.FocusChargeCategory
-	(FocusChargeClass)(0),                // 5: pulumicost.v1.FocusChargeClass
-	(FocusChargeFrequency)(0),            // 6: pulumicost.v1.FocusChargeFrequency
-	(FocusPricingCategory)(0),            // 7: pulumicost.v1.FocusPricingCategory
-	(FocusServiceCategory)(0),            // 8: pulumicost.v1.FocusServiceCategory
-	(FocusCommitmentDiscountCategory)(0), // 9: pulumicost.v1.FocusCommitmentDiscountCategory
-	(FocusCommitmentDiscountStatus)(0),   // 10: pulumicost.v1.FocusCommitmentDiscountStatus
-	(FocusCapacityReservationStatus)(0),  // 11: pulumicost.v1.FocusCapacityReservationStatus
+	(FocusContractCommitmentCategory)(0), // 0: pulumicost.v1.FocusContractCommitmentCategory
+	(*FocusCostRecord)(nil),              // 1: pulumicost.v1.FocusCostRecord
+	(*ContractCommitment)(nil),           // 2: pulumicost.v1.ContractCommitment
+	nil,                                  // 3: pulumicost.v1.FocusCostRecord.TagsEntry
+	nil,                                  // 4: pulumicost.v1.FocusCostRecord.ExtendedColumnsEntry
+	nil,                                  // 5: pulumicost.v1.FocusCostRecord.AllocatedTagsEntry
+	(*timestamppb.Timestamp)(nil),        // 6: google.protobuf.Timestamp
+	(FocusChargeCategory)(0),             // 7: pulumicost.v1.FocusChargeCategory
+	(FocusChargeClass)(0),                // 8: pulumicost.v1.FocusChargeClass
+	(FocusChargeFrequency)(0),            // 9: pulumicost.v1.FocusChargeFrequency
+	(FocusPricingCategory)(0),            // 10: pulumicost.v1.FocusPricingCategory
+	(FocusServiceCategory)(0),            // 11: pulumicost.v1.FocusServiceCategory
+	(FocusCommitmentDiscountCategory)(0), // 12: pulumicost.v1.FocusCommitmentDiscountCategory
+	(FocusCommitmentDiscountStatus)(0),   // 13: pulumicost.v1.FocusCommitmentDiscountStatus
+	(FocusCapacityReservationStatus)(0),  // 14: pulumicost.v1.FocusCapacityReservationStatus
 }
 var file_pulumicost_v1_focus_proto_depIdxs = []int32{
-	3,  // 0: pulumicost.v1.FocusCostRecord.billing_period_start:type_name -> google.protobuf.Timestamp
-	3,  // 1: pulumicost.v1.FocusCostRecord.billing_period_end:type_name -> google.protobuf.Timestamp
-	3,  // 2: pulumicost.v1.FocusCostRecord.charge_period_start:type_name -> google.protobuf.Timestamp
-	3,  // 3: pulumicost.v1.FocusCostRecord.charge_period_end:type_name -> google.protobuf.Timestamp
-	4,  // 4: pulumicost.v1.FocusCostRecord.charge_category:type_name -> pulumicost.v1.FocusChargeCategory
-	5,  // 5: pulumicost.v1.FocusCostRecord.charge_class:type_name -> pulumicost.v1.FocusChargeClass
-	6,  // 6: pulumicost.v1.FocusCostRecord.charge_frequency:type_name -> pulumicost.v1.FocusChargeFrequency
-	7,  // 7: pulumicost.v1.FocusCostRecord.pricing_category:type_name -> pulumicost.v1.FocusPricingCategory
-	8,  // 8: pulumicost.v1.FocusCostRecord.service_category:type_name -> pulumicost.v1.FocusServiceCategory
-	9,  // 9: pulumicost.v1.FocusCostRecord.commitment_discount_category:type_name -> pulumicost.v1.FocusCommitmentDiscountCategory
-	10, // 10: pulumicost.v1.FocusCostRecord.commitment_discount_status:type_name -> pulumicost.v1.FocusCommitmentDiscountStatus
-	11, // 11: pulumicost.v1.FocusCostRecord.capacity_reservation_status:type_name -> pulumicost.v1.FocusCapacityReservationStatus
-	1,  // 12: pulumicost.v1.FocusCostRecord.tags:type_name -> pulumicost.v1.FocusCostRecord.TagsEntry
-	2,  // 13: pulumicost.v1.FocusCostRecord.extended_columns:type_name -> pulumicost.v1.FocusCostRecord.ExtendedColumnsEntry
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	6,  // 0: pulumicost.v1.FocusCostRecord.billing_period_start:type_name -> google.protobuf.Timestamp
+	6,  // 1: pulumicost.v1.FocusCostRecord.billing_period_end:type_name -> google.protobuf.Timestamp
+	6,  // 2: pulumicost.v1.FocusCostRecord.charge_period_start:type_name -> google.protobuf.Timestamp
+	6,  // 3: pulumicost.v1.FocusCostRecord.charge_period_end:type_name -> google.protobuf.Timestamp
+	7,  // 4: pulumicost.v1.FocusCostRecord.charge_category:type_name -> pulumicost.v1.FocusChargeCategory
+	8,  // 5: pulumicost.v1.FocusCostRecord.charge_class:type_name -> pulumicost.v1.FocusChargeClass
+	9,  // 6: pulumicost.v1.FocusCostRecord.charge_frequency:type_name -> pulumicost.v1.FocusChargeFrequency
+	10, // 7: pulumicost.v1.FocusCostRecord.pricing_category:type_name -> pulumicost.v1.FocusPricingCategory
+	11, // 8: pulumicost.v1.FocusCostRecord.service_category:type_name -> pulumicost.v1.FocusServiceCategory
+	12, // 9: pulumicost.v1.FocusCostRecord.commitment_discount_category:type_name -> pulumicost.v1.FocusCommitmentDiscountCategory
+	13, // 10: pulumicost.v1.FocusCostRecord.commitment_discount_status:type_name -> pulumicost.v1.FocusCommitmentDiscountStatus
+	14, // 11: pulumicost.v1.FocusCostRecord.capacity_reservation_status:type_name -> pulumicost.v1.FocusCapacityReservationStatus
+	3,  // 12: pulumicost.v1.FocusCostRecord.tags:type_name -> pulumicost.v1.FocusCostRecord.TagsEntry
+	4,  // 13: pulumicost.v1.FocusCostRecord.extended_columns:type_name -> pulumicost.v1.FocusCostRecord.ExtendedColumnsEntry
+	5,  // 14: pulumicost.v1.FocusCostRecord.allocated_tags:type_name -> pulumicost.v1.FocusCostRecord.AllocatedTagsEntry
+	0,  // 15: pulumicost.v1.ContractCommitment.contract_commitment_category:type_name -> pulumicost.v1.FocusContractCommitmentCategory
+	6,  // 16: pulumicost.v1.ContractCommitment.contract_commitment_period_start:type_name -> google.protobuf.Timestamp
+	6,  // 17: pulumicost.v1.ContractCommitment.contract_commitment_period_end:type_name -> google.protobuf.Timestamp
+	6,  // 18: pulumicost.v1.ContractCommitment.contract_period_start:type_name -> google.protobuf.Timestamp
+	6,  // 19: pulumicost.v1.ContractCommitment.contract_period_end:type_name -> google.protobuf.Timestamp
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_pulumicost_v1_focus_proto_init() }
@@ -746,13 +1117,14 @@ func file_pulumicost_v1_focus_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pulumicost_v1_focus_proto_rawDesc), len(file_pulumicost_v1_focus_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   3,
+			NumEnums:      1,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_pulumicost_v1_focus_proto_goTypes,
 		DependencyIndexes: file_pulumicost_v1_focus_proto_depIdxs,
+		EnumInfos:         file_pulumicost_v1_focus_proto_enumTypes,
 		MessageInfos:      file_pulumicost_v1_focus_proto_msgTypes,
 	}.Build()
 	File_pulumicost_v1_focus_proto = out.File

--- a/sdk/go/testing/focus13_conformance_test.go
+++ b/sdk/go/testing/focus13_conformance_test.go
@@ -1,0 +1,455 @@
+package testing_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// =============================================================================
+// FOCUS 1.3 Conformance Tests
+// =============================================================================
+//
+// These tests validate backward compatibility and correct behavior of
+// FOCUS 1.3 extensions in the pluginsdk package.
+
+// buildValidFocusRecord creates a minimal valid FOCUS record with all required fields.
+// This helper ensures tests focus on FOCUS 1.3 specific behavior.
+func buildValidFocusRecord() *pluginsdk.FocusRecordBuilder {
+	now := time.Now()
+	billingStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	billingEnd := billingStart.AddDate(0, 1, 0)
+	chargeStart := now.Add(-24 * time.Hour)
+	chargeEnd := now
+
+	return pluginsdk.NewFocusRecordBuilder().
+		WithIdentity("AWS", "123456789012", "Production").
+		WithBillingPeriod(billingStart, billingEnd, "USD").
+		WithChargePeriod(chargeStart, chargeEnd).
+		WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE, "Amazon EC2").
+		WithChargeDetails(
+			pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+			pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD,
+		).
+		WithChargeClassification(
+			pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+			"EC2 usage",
+			pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED,
+		).
+		WithUsage(100, "Hours").
+		WithFinancials(100.00, 100.00, 95.00, "USD", "INV-2024-001").
+		WithContractedCost(95.00)
+}
+
+// TestFocus13_BackwardCompatibility_FOCUS12OnlyRecords validates that plugins
+// can create valid FOCUS 1.2 records without any FOCUS 1.3 fields (T060, T061).
+func TestFocus13_BackwardCompatibility_FOCUS12OnlyRecords(t *testing.T) {
+	// Create a pure FOCUS 1.2 record with no FOCUS 1.3 fields
+	record, err := buildValidFocusRecord().Build()
+
+	if err != nil {
+		t.Fatalf("FOCUS 1.2 record creation failed: %v", err)
+	}
+
+	// Verify FOCUS 1.3 fields are empty/zero (default values)
+	if record.GetServiceProviderName() != "" {
+		t.Errorf("Expected empty service_provider_name, got %q", record.GetServiceProviderName())
+	}
+	if record.GetHostProviderName() != "" {
+		t.Errorf("Expected empty host_provider_name, got %q", record.GetHostProviderName())
+	}
+	if record.GetAllocatedMethodId() != "" {
+		t.Errorf("Expected empty allocated_method_id, got %q", record.GetAllocatedMethodId())
+	}
+	if record.GetAllocatedResourceId() != "" {
+		t.Errorf("Expected empty allocated_resource_id, got %q", record.GetAllocatedResourceId())
+	}
+	if record.GetContractApplied() != "" {
+		t.Errorf("Expected empty contract_applied, got %q", record.GetContractApplied())
+	}
+	if len(record.GetAllocatedTags()) != 0 {
+		t.Errorf("Expected empty allocated_tags, got %v", record.GetAllocatedTags())
+	}
+
+	// Verify FOCUS 1.2 fields are correctly populated
+	//nolint:staticcheck // SA1019: Testing deprecated provider_name backward compatibility
+	if record.GetProviderName() != "AWS" {
+		//nolint:staticcheck // SA1019: Testing deprecated provider_name backward compatibility
+		t.Errorf("Expected provider_name='AWS', got %q", record.GetProviderName())
+	}
+	if record.GetBillingAccountId() != "123456789012" {
+		t.Errorf("Expected billing_account_id='123456789012', got %q", record.GetBillingAccountId())
+	}
+}
+
+// TestFocus13_BackwardCompatibility_DeprecatedFieldsWork validates that
+// deprecated fields (provider_name, publisher) continue to function (T062).
+func TestFocus13_BackwardCompatibility_DeprecatedFieldsWork(t *testing.T) {
+	t.Run("provider_name continues to work", func(t *testing.T) {
+		record, err := buildValidFocusRecord().Build()
+
+		if err != nil {
+			t.Fatalf("Record creation failed: %v", err)
+		}
+
+		//nolint:staticcheck // SA1019: Testing deprecated provider_name backward compatibility
+		if record.GetProviderName() != "AWS" {
+			//nolint:staticcheck // SA1019: Testing deprecated provider_name backward compatibility
+			t.Errorf("Expected provider_name='AWS', got %q", record.GetProviderName())
+		}
+	})
+
+	t.Run("publisher continues to work", func(t *testing.T) {
+		//nolint:staticcheck // SA1019: Testing deprecated WithPublisher backward compatibility
+		record, err := buildValidFocusRecord().
+			WithPublisher("AWS Inc.").
+			Build()
+
+		if err != nil {
+			t.Fatalf("Record creation failed: %v", err)
+		}
+
+		//nolint:staticcheck // SA1019: Testing deprecated publisher backward compatibility
+		if record.GetPublisher() != "AWS Inc." {
+			//nolint:staticcheck // SA1019: Testing deprecated publisher backward compatibility
+			t.Errorf("Expected publisher='AWS Inc.', got %q", record.GetPublisher())
+		}
+	})
+}
+
+// TestFocus13_NewFieldsDefaultValues validates that all new FOCUS 1.3 fields
+// have sensible default values that don't affect existing behavior (T063).
+func TestFocus13_NewFieldsDefaultValues(t *testing.T) {
+	record, err := buildValidFocusRecord().Build()
+
+	if err != nil {
+		t.Fatalf("Record creation with defaults failed: %v", err)
+	}
+
+	// All FOCUS 1.3 string fields should default to empty string
+	focus13StringFields := map[string]string{
+		"service_provider_name":    record.GetServiceProviderName(),
+		"host_provider_name":       record.GetHostProviderName(),
+		"allocated_method_id":      record.GetAllocatedMethodId(),
+		"allocated_method_details": record.GetAllocatedMethodDetails(),
+		"allocated_resource_id":    record.GetAllocatedResourceId(),
+		"allocated_resource_name":  record.GetAllocatedResourceName(),
+		"contract_applied":         record.GetContractApplied(),
+	}
+
+	for fieldName, value := range focus13StringFields {
+		if value != "" {
+			t.Errorf("FOCUS 1.3 field %s should default to empty, got %q", fieldName, value)
+		}
+	}
+
+	// AllocatedTags should default to nil or empty map
+	if tags := record.GetAllocatedTags(); len(tags) > 0 {
+		t.Errorf("allocated_tags should be empty by default, got %v", tags)
+	}
+}
+
+// TestFocus13_AllocationFields validates the new cost allocation builder methods.
+func TestFocus13_AllocationFields(t *testing.T) {
+	t.Run("allocation fields set correctly", func(t *testing.T) {
+		record, err := buildValidFocusRecord().
+			WithAllocation("proportional-cpu", "Allocated by CPU usage percentage").
+			WithAllocatedResource("workload-frontend", "Frontend Application").
+			WithAllocatedTags(map[string]string{
+				"team":        "frontend",
+				"environment": "production",
+			}).
+			Build()
+
+		if err != nil {
+			t.Fatalf("Record creation failed: %v", err)
+		}
+
+		if record.GetAllocatedMethodId() != "proportional-cpu" {
+			t.Errorf("Expected allocated_method_id='proportional-cpu', got %q",
+				record.GetAllocatedMethodId())
+		}
+		if record.GetAllocatedMethodDetails() != "Allocated by CPU usage percentage" {
+			t.Errorf("Expected allocated_method_details='Allocated by CPU usage percentage', got %q",
+				record.GetAllocatedMethodDetails())
+		}
+		if record.GetAllocatedResourceId() != "workload-frontend" {
+			t.Errorf("Expected allocated_resource_id='workload-frontend', got %q",
+				record.GetAllocatedResourceId())
+		}
+		if record.GetAllocatedResourceName() != "Frontend Application" {
+			t.Errorf("Expected allocated_resource_name='Frontend Application', got %q",
+				record.GetAllocatedResourceName())
+		}
+
+		tags := record.GetAllocatedTags()
+		if tags["team"] != "frontend" {
+			t.Errorf("Expected allocated_tags['team']='frontend', got %q", tags["team"])
+		}
+		if tags["environment"] != "production" {
+			t.Errorf("Expected allocated_tags['environment']='production', got %q", tags["environment"])
+		}
+	})
+}
+
+// TestFocus13_ProviderFields validates service_provider_name and host_provider_name.
+func TestFocus13_ProviderFields(t *testing.T) {
+	t.Run("marketplace scenario", func(t *testing.T) {
+		record, err := buildValidFocusRecord().
+			WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_MANAGEMENT, "Datadog APM").
+			WithServiceProvider("Datadog"). // ISV selling via marketplace
+			WithHostProvider("AWS").        // Cloud platform hosting
+			Build()
+
+		if err != nil {
+			t.Fatalf("Marketplace record creation failed: %v", err)
+		}
+
+		if record.GetServiceProviderName() != "Datadog" {
+			t.Errorf("Expected service_provider_name='Datadog', got %q",
+				record.GetServiceProviderName())
+		}
+		if record.GetHostProviderName() != "AWS" {
+			t.Errorf("Expected host_provider_name='AWS', got %q",
+				record.GetHostProviderName())
+		}
+	})
+
+	t.Run("same provider scenario", func(t *testing.T) {
+		record, err := buildValidFocusRecord().
+			WithServiceProvider("AWS"). // AWS is both service and host provider
+			WithHostProvider("AWS").
+			Build()
+
+		if err != nil {
+			t.Fatalf("Same provider record creation failed: %v", err)
+		}
+
+		if record.GetServiceProviderName() != "AWS" {
+			t.Errorf("Expected service_provider_name='AWS', got %q",
+				record.GetServiceProviderName())
+		}
+		if record.GetHostProviderName() != "AWS" {
+			t.Errorf("Expected host_provider_name='AWS', got %q",
+				record.GetHostProviderName())
+		}
+	})
+}
+
+// TestFocus13_ContractApplied validates the ContractApplied field linking.
+func TestFocus13_ContractApplied(t *testing.T) {
+	t.Run("links to contract commitment", func(t *testing.T) {
+		// First create a contract commitment
+		commitment, err := pluginsdk.NewContractCommitmentBuilder().
+			WithIdentity("commit-ri-001", "contract-ea-2025").
+			WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+			WithType("Reserved Instance").
+			WithFinancials(10000.00, 0, "", "USD").
+			Build()
+
+		if err != nil {
+			t.Fatalf("Contract commitment creation failed: %v", err)
+		}
+
+		// Then link a cost record to it
+		record, err := buildValidFocusRecord().
+			WithContractApplied(commitment.GetContractCommitmentId()). // Link to commitment
+			Build()
+
+		if err != nil {
+			t.Fatalf("Record with contract applied failed: %v", err)
+		}
+
+		if record.GetContractApplied() != "commit-ri-001" {
+			t.Errorf("Expected contract_applied='commit-ri-001', got %q",
+				record.GetContractApplied())
+		}
+	})
+
+	t.Run("accepts any string as opaque reference", func(t *testing.T) {
+		// ContractApplied accepts any string - no validation against commitment dataset
+		record, err := buildValidFocusRecord().
+			WithContractApplied("any-arbitrary-commitment-id"). // No validation
+			Build()
+
+		if err != nil {
+			t.Fatalf("Record with arbitrary contract_applied failed: %v", err)
+		}
+
+		if record.GetContractApplied() != "any-arbitrary-commitment-id" {
+			t.Errorf("Expected contract_applied='any-arbitrary-commitment-id', got %q",
+				record.GetContractApplied())
+		}
+	})
+}
+
+// TestFocus13_ContractCommitmentBuilder_SPEND validates SPEND category commitments.
+func TestFocus13_ContractCommitmentBuilder_SPEND(t *testing.T) {
+	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	commitment, err := pluginsdk.NewContractCommitmentBuilder().
+		WithIdentity("commit-sp-001", "aws-ea-2025").
+		WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+		WithType("Savings Plan").
+		WithCommitmentPeriod(start, end).
+		WithContractPeriod(start, end.AddDate(2, 0, 0)).
+		WithFinancials(100000.00, 0, "", "USD").
+		Build()
+
+	if err != nil {
+		t.Fatalf("SPEND commitment creation failed: %v", err)
+	}
+
+	if commitment.GetContractCommitmentId() != "commit-sp-001" {
+		t.Errorf("Expected contract_commitment_id='commit-sp-001', got %q",
+			commitment.GetContractCommitmentId())
+	}
+	if commitment.GetContractId() != "aws-ea-2025" {
+		t.Errorf("Expected contract_id='aws-ea-2025', got %q",
+			commitment.GetContractId())
+	}
+	if commitment.GetContractCommitmentCategory() !=
+		pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND {
+		t.Errorf("Expected SPEND category, got %v",
+			commitment.GetContractCommitmentCategory())
+	}
+	if commitment.GetContractCommitmentCost() != 100000.00 {
+		t.Errorf("Expected cost=100000.00, got %f",
+			commitment.GetContractCommitmentCost())
+	}
+}
+
+// TestFocus13_ContractCommitmentBuilder_USAGE validates USAGE category commitments.
+func TestFocus13_ContractCommitmentBuilder_USAGE(t *testing.T) {
+	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	commitment, err := pluginsdk.NewContractCommitmentBuilder().
+		WithIdentity("commit-cud-001", "gcp-cud-2025").
+		WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE).
+		WithType("Committed Use Discount").
+		WithCommitmentPeriod(start, end).
+		WithFinancials(0, 10000, "vCPU-Hours", "USD").
+		Build()
+
+	if err != nil {
+		t.Fatalf("USAGE commitment creation failed: %v", err)
+	}
+
+	if commitment.GetContractCommitmentCategory() !=
+		pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE {
+		t.Errorf("Expected USAGE category, got %v",
+			commitment.GetContractCommitmentCategory())
+	}
+	if commitment.GetContractCommitmentQuantity() != 10000 {
+		t.Errorf("Expected quantity=10000, got %f",
+			commitment.GetContractCommitmentQuantity())
+	}
+	if commitment.GetContractCommitmentUnit() != "vCPU-Hours" {
+		t.Errorf("Expected unit='vCPU-Hours', got %q",
+			commitment.GetContractCommitmentUnit())
+	}
+}
+
+// TestFocus13_ContractCommitmentBuilder_Validation validates builder error handling.
+func TestFocus13_ContractCommitmentBuilder_Validation(t *testing.T) {
+	t.Run("missing required fields", func(t *testing.T) {
+		_, err := pluginsdk.NewContractCommitmentBuilder().
+			WithFinancials(100.0, 0, "", "USD").
+			Build()
+
+		if err == nil {
+			t.Error("Expected error for missing contract_commitment_id")
+		}
+	})
+
+	t.Run("invalid currency", func(t *testing.T) {
+		_, err := pluginsdk.NewContractCommitmentBuilder().
+			WithIdentity("commit-001", "contract-001").
+			WithFinancials(100.0, 0, "", "ZZZ"). // Invalid currency
+			Build()
+
+		if err == nil {
+			t.Error("Expected error for invalid currency")
+		}
+	})
+
+	t.Run("invalid period", func(t *testing.T) {
+		start := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+		_, err := pluginsdk.NewContractCommitmentBuilder().
+			WithIdentity("commit-001", "contract-001").
+			WithCommitmentPeriod(start, end). // End before start
+			WithFinancials(100.0, 0, "", "USD").
+			Build()
+
+		if err == nil {
+			t.Error("Expected error for invalid commitment period")
+		}
+	})
+
+	t.Run("negative cost", func(t *testing.T) {
+		_, err := pluginsdk.NewContractCommitmentBuilder().
+			WithIdentity("commit-001", "contract-001").
+			WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+			WithFinancials(-100.0, 0, "", "USD"). // Negative cost
+			Build()
+
+		if err == nil {
+			t.Error("Expected error for negative cost")
+		}
+	})
+
+	t.Run("negative quantity", func(t *testing.T) {
+		_, err := pluginsdk.NewContractCommitmentBuilder().
+			WithIdentity("commit-001", "contract-001").
+			WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE).
+			WithFinancials(0, -100.0, "vCPU-Hours", "USD"). // Negative quantity
+			Build()
+
+		if err == nil {
+			t.Error("Expected error for negative quantity")
+		}
+	})
+}
+
+// TestFocus13_MixedVersionRecords validates records with both FOCUS 1.2 and 1.3 fields.
+func TestFocus13_MixedVersionRecords(t *testing.T) {
+	t.Run("all FOCUS 1.3 fields populated", func(t *testing.T) {
+		record, err := buildValidFocusRecord().
+			// FOCUS 1.3 fields
+			WithServiceProvider("AWS").
+			WithHostProvider("AWS").
+			WithAllocation("proportional-cost", "Cost split by resource usage").
+			WithAllocatedResource("app-backend", "Backend Service").
+			WithAllocatedTags(map[string]string{
+				"cost-center": "engineering",
+				"project":     "infrastructure",
+			}).
+			WithContractApplied("commit-ri-backend-001").
+			Build()
+
+		if err != nil {
+			t.Fatalf("Mixed version record creation failed: %v", err)
+		}
+
+		// Verify both 1.2 and 1.3 fields are populated
+		//nolint:staticcheck // SA1019: Testing deprecated provider_name backward compatibility
+		if record.GetProviderName() != "AWS" {
+			t.Error("FOCUS 1.2 provider_name not set")
+		}
+		if record.GetServiceProviderName() != "AWS" {
+			t.Error("FOCUS 1.3 service_provider_name not set")
+		}
+		if record.GetAllocatedMethodId() != "proportional-cost" {
+			t.Error("FOCUS 1.3 allocated_method_id not set")
+		}
+		if record.GetContractApplied() != "commit-ri-backend-001" {
+			t.Error("FOCUS 1.3 contract_applied not set")
+		}
+	})
+}

--- a/specs/026-focus-1-3-migration/checklists/requirements.md
+++ b/specs/026-focus-1-3-migration/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: FOCUS 1.3 Migration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- 19 functional requirements covering proto, SDK, validation, testing, and documentation
+- 5 user stories with clear acceptance scenarios
+- 8 measurable success criteria
+- Assumptions and out-of-scope items clearly documented

--- a/specs/026-focus-1-3-migration/contracts/contract_commitment.proto
+++ b/specs/026-focus-1-3-migration/contracts/contract_commitment.proto
@@ -1,0 +1,115 @@
+// Contract Commitment Dataset Contract
+// This file documents the new ContractCommitment proto message.
+// Actual implementation goes in proto/pulumicost/v1/focus.proto (or separate file)
+
+syntax = "proto3";
+
+package pulumicost.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto;pbc";
+
+// =============================================================================
+// NEW ENUM: FocusContractCommitmentCategory
+// =============================================================================
+
+// FocusContractCommitmentCategory represents the type of commitment.
+// FOCUS 1.3 Contract Commitment Dataset specification.
+enum FocusContractCommitmentCategory {
+  // Default/unspecified value.
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED = 0;
+  // Monetary spend commitment (e.g., $10,000/month minimum).
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND = 1;
+  // Usage quantity commitment (e.g., 1000 compute hours).
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE = 2;
+}
+
+// =============================================================================
+// NEW MESSAGE: ContractCommitment
+// =============================================================================
+
+// ContractCommitment represents a contractual commitment record in the
+// FOCUS 1.3 Contract Commitment supplemental dataset.
+//
+// This is a separate dataset from Cost and Usage data, allowing practitioners
+// to query contract terms independently from individual cost line items.
+//
+// Reference: FOCUS 1.3 Contract Commitment Dataset
+message ContractCommitment {
+  // ==========================================================================
+  // Identity Fields
+  // ==========================================================================
+
+  // ContractCommitmentId: Unique identifier for this specific commitment.
+  // REQUIRED. Primary key for the commitment record.
+  string contract_commitment_id = 1;
+
+  // ContractId: Identifier of the parent contract containing this commitment.
+  // REQUIRED. Links to the broader contract agreement.
+  string contract_id = 2;
+
+  // ==========================================================================
+  // Classification Fields
+  // ==========================================================================
+
+  // ContractCommitmentCategory: Category of commitment (SPEND or USAGE).
+  // FOCUS 1.3 Contract Commitment Category (CONDITIONAL).
+  FocusContractCommitmentCategory contract_commitment_category = 3;
+
+  // ContractCommitmentType: Provider-specific type of commitment.
+  // Free-form string (e.g., "Reserved Instance", "Savings Plan", "CUD").
+  // FOCUS 1.3 Contract Commitment Type (CONDITIONAL).
+  string contract_commitment_type = 4;
+
+  // ==========================================================================
+  // Commitment Period Fields
+  // ==========================================================================
+
+  // ContractCommitmentPeriodStart: Start of the commitment period.
+  // When the specific commitment obligations begin.
+  // FOCUS 1.3 Contract Commitment Period Start (CONDITIONAL).
+  google.protobuf.Timestamp contract_commitment_period_start = 5;
+
+  // ContractCommitmentPeriodEnd: End of the commitment period.
+  // When the specific commitment obligations end.
+  // FOCUS 1.3 Contract Commitment Period End (CONDITIONAL).
+  google.protobuf.Timestamp contract_commitment_period_end = 6;
+
+  // ==========================================================================
+  // Contract Period Fields
+  // ==========================================================================
+
+  // ContractPeriodStart: Start of the overall contract.
+  // When the parent contract agreement begins.
+  // FOCUS 1.3 Contract Period Start (CONDITIONAL).
+  google.protobuf.Timestamp contract_period_start = 7;
+
+  // ContractPeriodEnd: End of the overall contract.
+  // When the parent contract agreement ends.
+  // FOCUS 1.3 Contract Period End (CONDITIONAL).
+  google.protobuf.Timestamp contract_period_end = 8;
+
+  // ==========================================================================
+  // Financial Fields
+  // ==========================================================================
+
+  // ContractCommitmentCost: Monetary amount of the commitment.
+  // For SPEND category, this is the dollar/currency amount committed.
+  // FOCUS 1.3 Contract Commitment Cost (CONDITIONAL).
+  double contract_commitment_cost = 9;
+
+  // ContractCommitmentQuantity: Quantity amount of the commitment.
+  // For USAGE category, this is the unit quantity committed.
+  // FOCUS 1.3 Contract Commitment Quantity (CONDITIONAL).
+  double contract_commitment_quantity = 10;
+
+  // ContractCommitmentUnit: Unit of measure for quantity.
+  // Examples: "Hours", "GB", "vCPU-Hours", "Requests".
+  // FOCUS 1.3 Contract Commitment Unit (CONDITIONAL).
+  string contract_commitment_unit = 11;
+
+  // BillingCurrency: ISO 4217 currency code for monetary values.
+  // REQUIRED. Format: 3-letter currency code (e.g., "USD", "EUR").
+  string billing_currency = 12;
+}

--- a/specs/026-focus-1-3-migration/contracts/focus_1_3_fields.proto
+++ b/specs/026-focus-1-3-migration/contracts/focus_1_3_fields.proto
@@ -1,0 +1,72 @@
+// FOCUS 1.3 Field Extensions Contract
+// This file documents the proto field additions to FocusCostRecord.
+// Actual implementation goes in proto/pulumicost/v1/focus.proto
+
+syntax = "proto3";
+
+package pulumicost.v1;
+
+// NOTE: This is a CONTRACT DEFINITION showing the new fields.
+// These fields will be ADDED to the existing FocusCostRecord message.
+
+// =============================================================================
+// NEW FOCUS 1.3 FIELDS TO ADD TO FocusCostRecord
+// =============================================================================
+
+// Provider Identification (replacing deprecated ProviderName/Publisher)
+//
+// ServiceProviderName: The entity that makes the service available for purchase.
+// In reseller/marketplace scenarios, this is the ISV or reseller.
+// FOCUS 1.3 Section: Service Provider Name (CONDITIONAL)
+// string service_provider_name = 59;
+//
+// HostProviderName: The entity that hosts the underlying resource or service.
+// This is where the workload actually runs (e.g., AWS, Azure, GCP).
+// FOCUS 1.3 Section: Host Provider Name (CONDITIONAL)
+// string host_provider_name = 60;
+
+// Split Cost Allocation
+//
+// AllocatedMethodId: Identifier for the cost allocation methodology used.
+// Links to a documented allocation method.
+// FOCUS 1.3 Section: Allocated Method ID (CONDITIONAL)
+// Validation: If populated, allocated_resource_id MUST also be populated.
+// string allocated_method_id = 61;
+//
+// AllocatedMethodDetails: Human-readable description of the allocation method.
+// Provides transparency into how costs were split.
+// FOCUS 1.3 Section: Allocated Method Details (RECOMMENDED)
+// string allocated_method_details = 62;
+//
+// AllocatedResourceId: Identifier of the resource receiving the allocated cost.
+// This is the target of the cost allocation.
+// FOCUS 1.3 Section: Allocated Resource ID (CONDITIONAL)
+// string allocated_resource_id = 63;
+//
+// AllocatedResourceName: Display name of the resource receiving allocated cost.
+// FOCUS 1.3 Section: Allocated Resource Name (CONDITIONAL)
+// string allocated_resource_name = 64;
+//
+// AllocatedTags: Tags associated with the allocated resource.
+// Follows same map<string, string> pattern as existing tags field.
+// FOCUS 1.3 Section: Allocated Tags (CONDITIONAL)
+// map<string, string> allocated_tags = 65;
+
+// Contract Commitment Link
+//
+// ContractApplied: Reference to a ContractCommitmentId in the Contract
+// Commitment dataset. Treated as opaque reference (no cross-dataset validation).
+// FOCUS 1.3 Section: Contract Applied (CONDITIONAL)
+// string contract_applied = 66;
+
+// =============================================================================
+// DEPRECATED FIELDS (mark with deprecated option)
+// =============================================================================
+
+// The following existing fields should be marked deprecated:
+//
+// string provider_name = 1 [deprecated = true];
+//   Deprecated: Use service_provider_name instead. Will be removed in FOCUS 1.4.
+//
+// string publisher = 55 [deprecated = true];
+//   Deprecated: Use host_provider_name instead. Will be removed in FOCUS 1.4.

--- a/specs/026-focus-1-3-migration/data-model.md
+++ b/specs/026-focus-1-3-migration/data-model.md
@@ -1,0 +1,200 @@
+# Data Model: FOCUS 1.3 Migration
+
+**Branch**: `026-focus-1-3-migration` | **Date**: 2025-12-23
+
+## Entity Overview
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           FocusCostRecord                                    │
+│  (Extended with 8 new FOCUS 1.3 columns)                                     │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ EXISTING FIELDS (1-58)                                                       │
+│ ├── provider_name [1] ⚠️ DEPRECATED                                          │
+│ ├── publisher [55] ⚠️ DEPRECATED                                             │
+│ └── ... (56 other existing fields)                                          │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ NEW FOCUS 1.3 FIELDS (59-66)                                                │
+│ ├── service_provider_name [59] - string                                     │
+│ ├── host_provider_name [60] - string                                        │
+│ ├── allocated_method_id [61] - string                                       │
+│ ├── allocated_method_details [62] - string                                  │
+│ ├── allocated_resource_id [63] - string                                     │
+│ ├── allocated_resource_name [64] - string                                   │
+│ ├── allocated_tags [65] - map<string, string>                               │
+│ └── contract_applied [66] - string                                          │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    │ Links via contract_applied
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         ContractCommitment                                   │
+│  (NEW supplemental dataset - 12 fields)                                      │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ IDENTITY                                                                     │
+│ ├── contract_commitment_id [1] - string (primary identifier)                │
+│ └── contract_id [2] - string (parent contract)                              │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ CLASSIFICATION                                                               │
+│ ├── contract_commitment_category [3] - enum                                 │
+│ └── contract_commitment_type [4] - string                                   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ COMMITMENT PERIOD                                                            │
+│ ├── contract_commitment_period_start [5] - timestamp                        │
+│ └── contract_commitment_period_end [6] - timestamp                          │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ CONTRACT PERIOD                                                              │
+│ ├── contract_period_start [7] - timestamp                                   │
+│ └── contract_period_end [8] - timestamp                                     │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ FINANCIAL                                                                    │
+│ ├── contract_commitment_cost [9] - double                                   │
+│ ├── contract_commitment_quantity [10] - double                              │
+│ ├── contract_commitment_unit [11] - string                                  │
+│ └── billing_currency [12] - string (ISO 4217)                               │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## FocusCostRecord Extensions
+
+### New Fields (FOCUS 1.3)
+
+| Field | Number | Type | Requirement | Description |
+|-------|--------|------|-------------|-------------|
+| service_provider_name | 59 | string | Conditional | Provider making service available for purchase |
+| host_provider_name | 60 | string | Conditional | Provider hosting the underlying resource |
+| allocated_method_id | 61 | string | Conditional | Identifier for allocation methodology |
+| allocated_method_details | 62 | string | Recommended | Description of allocation methodology |
+| allocated_resource_id | 63 | string | Conditional | ID of resource receiving allocated cost |
+| allocated_resource_name | 64 | string | Conditional | Name of resource receiving allocated cost |
+| allocated_tags | 65 | map | Conditional | Tags associated with allocated resource |
+| contract_applied | 66 | string | Conditional | Reference to ContractCommitmentId |
+
+### Deprecated Fields
+
+| Field | Number | Replacement | Removal Version |
+|-------|--------|-------------|-----------------|
+| provider_name | 1 | service_provider_name | FOCUS 1.4 |
+| publisher | 55 | host_provider_name | FOCUS 1.4 |
+
+### Validation Rules
+
+1. **Allocation Field Dependency**: If `allocated_method_id` is populated, `allocated_resource_id`
+   MUST also be populated. Validation error otherwise.
+
+2. **Deprecated Field Handling**: If `provider_name` is populated AND `service_provider_name` is
+   populated with a different value, log deprecation warning and prefer `service_provider_name`.
+
+3. **Backward Compatibility**: All new fields are optional. FOCUS 1.2 records (without new
+   fields) MUST pass validation.
+
+## ContractCommitment Entity
+
+### Fields
+
+| Field | Number | Type | Description |
+|-------|--------|------|-------------|
+| contract_commitment_id | 1 | string | Unique identifier for this commitment |
+| contract_id | 2 | string | Parent contract identifier |
+| contract_commitment_category | 3 | enum | SPEND or USAGE |
+| contract_commitment_type | 4 | string | Provider-specific commitment type |
+| contract_commitment_period_start | 5 | timestamp | When commitment period begins |
+| contract_commitment_period_end | 6 | timestamp | When commitment period ends |
+| contract_period_start | 7 | timestamp | When contract begins |
+| contract_period_end | 8 | timestamp | When contract ends |
+| contract_commitment_cost | 9 | double | Monetary commitment amount |
+| contract_commitment_quantity | 10 | double | Committed quantity |
+| contract_commitment_unit | 11 | string | Unit for quantity measurement |
+| billing_currency | 12 | string | ISO 4217 currency code |
+
+### Enum: FocusContractCommitmentCategory
+
+| Value | Number | Description |
+|-------|--------|-------------|
+| UNSPECIFIED | 0 | Default/unknown |
+| SPEND | 1 | Monetary spend commitment |
+| USAGE | 2 | Usage quantity commitment |
+
+### Validation Rules
+
+1. **Required Fields**: contract_commitment_id, contract_id, billing_currency
+2. **Period Consistency**: contract_commitment_period_end >= contract_commitment_period_start
+3. **Currency Format**: billing_currency must be valid ISO 4217 code (reuse existing validation)
+4. **Non-negative Values**: contract_commitment_cost >= 0, contract_commitment_quantity >= 0
+
+## Relationships
+
+### FocusCostRecord → ContractCommitment
+
+- **Link Field**: `contract_applied` in FocusCostRecord
+- **Link Type**: Opaque reference (string containing ContractCommitmentId)
+- **Validation**: No cross-dataset validation (referential integrity is consumer's responsibility)
+- **Cardinality**: Many FocusCostRecords can reference one ContractCommitment
+
+### AllocatedResource (Conceptual)
+
+The allocated resource is not a separate entity but represented by fields within FocusCostRecord:
+
+- `allocated_resource_id` - Identifier
+- `allocated_resource_name` - Display name
+- `allocated_tags` - Associated metadata
+
+This follows FOCUS 1.3's design of embedded allocation data rather than a separate dataset.
+
+## State Transitions
+
+### FocusCostRecord Lifecycle
+
+```text
+┌──────────────┐
+│   Created    │ ─── All mandatory FOCUS 1.2 fields set
+└──────┬───────┘
+       │
+       ▼
+┌──────────────┐
+│   Extended   │ ─── Optional FOCUS 1.3 fields added
+└──────┬───────┘     (allocation, provider, contract)
+       │
+       ▼
+┌──────────────┐
+│  Validated   │ ─── Passes conformance checks
+└──────────────┘
+```
+
+### ContractCommitment Lifecycle
+
+```text
+┌──────────────┐
+│   Created    │ ─── Identity fields set (ids, category)
+└──────┬───────┘
+       │
+       ▼
+┌──────────────┐
+│   Bounded    │ ─── Period fields set (start/end dates)
+└──────┬───────┘
+       │
+       ▼
+┌──────────────┐
+│  Quantified  │ ─── Financial fields set (cost, quantity)
+└──────┬───────┘
+       │
+       ▼
+┌──────────────┐
+│  Validated   │ ─── Passes validation rules
+└──────────────┘
+```
+
+## Proto Wire Format Compatibility
+
+### Backward Compatibility Guarantee
+
+- Field numbers 59-66 are new and don't conflict with existing fields
+- Old clients reading new messages will ignore unknown field numbers
+- New clients reading old messages will see empty/default values for new fields
+- No `reserved` statements needed (no fields being removed)
+
+### Forward Compatibility
+
+- New messages can be read by old clients (unknown fields ignored)
+- Deprecated fields (1, 55) remain in proto for transition period
+- `deprecated = true` option warns at compile time

--- a/specs/026-focus-1-3-migration/plan.md
+++ b/specs/026-focus-1-3-migration/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: FOCUS 1.3 Migration
+
+**Branch**: `026-focus-1-3-migration` | **Date**: 2025-12-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/026-focus-1-3-migration/spec.md`
+
+## Summary
+
+Migrate the PulumiCost FOCUS implementation from version 1.2 to 1.3 by:
+
+1. Adding 8 new columns to FocusCostRecord proto message for split cost allocation and
+   provider identification
+2. Creating a new ContractCommitment proto message (12 fields) for the supplemental dataset
+3. Extending the Go SDK builder API with corresponding methods
+4. Adding deprecation handling for ProviderName and Publisher fields
+5. Maintaining full backward compatibility with existing FOCUS 1.2 implementations
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5 (per go.mod)
+**Primary Dependencies**: google.golang.org/protobuf, google.golang.org/grpc, buf v1.32.1
+**Storage**: N/A (stateless proto definitions and SDK)
+**Testing**: go test (conformance tests, integration tests, benchmarks)
+**Target Platform**: Multi-platform Go library (Linux, macOS, Windows)
+**Project Type**: gRPC proto specification + Go SDK library
+**Performance Goals**: Builder operations <100ns/op, 0 allocs/op for validation
+**Constraints**: Proto field numbers 59+ for backward compatibility, no breaking changes
+**Scale/Scope**: 8 new FocusCostRecord columns, 12-field ContractCommitment message
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. gRPC Proto Specification-First | ✅ PASS | Proto changes defined before SDK builder methods |
+| II. Multi-Provider gRPC Consistency | ✅ PASS | FOCUS 1.3 is provider-agnostic by design |
+| III. Test-First Protocol | ✅ PASS | Conformance tests will be written first (FR-013-016) |
+| IV. Protobuf Backward Compatibility | ✅ PASS | Field numbers 59+, no field removals |
+| V. Comprehensive Documentation | ✅ PASS | FR-017-019 require documentation updates |
+| VI. Performance as gRPC Requirement | ✅ PASS | SC-005 requires <100ns builder operations |
+| VII. Validation at Multiple Levels | ✅ PASS | FR-008-010a define validation requirements |
+
+**Gate Status**: ALL PASS - Proceed to Phase 0
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/026-focus-1-3-migration/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (proto contract definitions)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+proto/pulumicost/v1/
+├── focus.proto          # FocusCostRecord message (add 8 new fields)
+├── contract.proto       # NEW: ContractCommitment message (12 fields)
+└── enums.proto          # Add new enums if needed
+
+sdk/go/
+├── proto/               # Generated code (via buf generate)
+│   └── pulumicost/v1/
+│       ├── focus.pb.go
+│       └── contract.pb.go  # NEW
+├── pluginsdk/
+│   ├── focus_builder.go          # Add new builder methods
+│   ├── focus_conformance.go      # Add FOCUS 1.3 validation
+│   ├── contract_builder.go       # NEW: ContractCommitment builder
+│   └── contract_conformance.go   # NEW: Contract validation
+└── testing/
+    ├── focus_conformance_test.go # Add FOCUS 1.3 tests
+    ├── contract_test.go          # NEW: Contract commitment tests
+    └── benchmark_test.go         # Add new benchmarks
+
+docs/
+└── focus-columns.md     # Update with FOCUS 1.3 columns
+```
+
+**Structure Decision**: Follows existing repository structure with proto definitions in
+`proto/pulumicost/v1/`, generated code in `sdk/go/proto/`, and SDK implementation in
+`sdk/go/pluginsdk/`. New ContractCommitment proto may be added to existing focus.proto
+or as a separate contract.proto file.
+
+## Complexity Tracking
+
+> No constitutional violations - table not needed.

--- a/specs/026-focus-1-3-migration/quickstart.md
+++ b/specs/026-focus-1-3-migration/quickstart.md
@@ -1,0 +1,188 @@
+# Quickstart: FOCUS 1.3 Migration
+
+**Branch**: `026-focus-1-3-migration` | **Date**: 2025-12-23
+
+## Overview
+
+This guide covers implementing FOCUS 1.3 features in your PulumiCost plugin.
+
+## New Capabilities
+
+### 1. Split Cost Allocation
+
+Track how shared resource costs are allocated to specific workloads:
+
+```go
+record := pluginsdk.NewFocusRecordBuilder().
+    // ... existing FOCUS 1.2 fields ...
+    WithAllocation(
+        "proportional-cpu",           // AllocatedMethodId
+        "CPU-weighted proportional",  // AllocatedMethodDetails
+    ).
+    WithAllocatedResource(
+        "pod-frontend-abc123",        // AllocatedResourceId
+        "frontend-service",           // AllocatedResourceName
+    ).
+    WithAllocatedTags(map[string]string{
+        "team":        "platform",
+        "environment": "production",
+    }).
+    Build()
+```
+
+### 2. Service/Host Provider Distinction
+
+Clearly identify billing relationships in multi-vendor scenarios:
+
+```go
+record := pluginsdk.NewFocusRecordBuilder().
+    // For an Azure Marketplace ISV product:
+    WithServiceProvider("Datadog Inc").      // Who sells the service
+    WithHostProvider("Microsoft Azure").     // Where it runs
+    // ... other fields ...
+    Build()
+```
+
+### 3. Contract Commitment Linking
+
+Link cost records to contract commitment data:
+
+```go
+record := pluginsdk.NewFocusRecordBuilder().
+    // ... existing fields ...
+    WithContractApplied("commitment-ri-123456").  // Links to ContractCommitment
+    Build()
+```
+
+### 4. Contract Commitment Dataset
+
+Create standalone contract commitment records:
+
+```go
+commitment := pluginsdk.NewContractCommitmentBuilder().
+    WithIdentity(
+        "commitment-ri-123456",     // ContractCommitmentId
+        "contract-enterprise-2024", // ContractId
+    ).
+    WithCategory(pbc.FocusContractCommitmentCategory_FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND).
+    WithType("3-Year Reserved Instance").
+    WithCommitmentPeriod(startTime, endTime).
+    WithContractPeriod(contractStart, contractEnd).
+    WithFinancials(
+        120000.00,  // ContractCommitmentCost ($120k commitment)
+        0,          // ContractCommitmentQuantity (not applicable for SPEND)
+        "",         // ContractCommitmentUnit (not applicable for SPEND)
+        "USD",      // BillingCurrency
+    ).
+    Build()
+```
+
+## Migration from FOCUS 1.2
+
+### Backward Compatibility
+
+Your existing FOCUS 1.2 code continues to work unchanged:
+
+```go
+// This still works - all new fields are optional
+record := pluginsdk.NewFocusRecordBuilder().
+    WithIdentity("AWS", "123456789012", "Production").
+    WithBillingPeriod(start, end, "USD").
+    WithChargePeriod(chargeStart, chargeEnd).
+    WithService(pbc.FocusServiceCategory_FOCUS_SERVICE_CATEGORY_COMPUTE, "Amazon EC2").
+    WithChargeDetails(pbc.FocusChargeCategory_FOCUS_CHARGE_CATEGORY_USAGE,
+                      pbc.FocusPricingCategory_FOCUS_PRICING_CATEGORY_STANDARD).
+    WithChargeClassification(pbc.FocusChargeClass_FOCUS_CHARGE_CLASS_REGULAR,
+                             "EC2 m5.large usage",
+                             pbc.FocusChargeFrequency_FOCUS_CHARGE_FREQUENCY_USAGE_BASED).
+    WithFinancials(100.00, 100.00, 95.00, "USD", "INV-2024-001").
+    WithContractedCost(95.00).
+    Build()
+```
+
+### Deprecated Fields
+
+The following fields are deprecated but still work in FOCUS 1.3:
+
+| Deprecated | Use Instead | Warning |
+|------------|-------------|---------|
+| `WithIdentity()` sets `provider_name` | `WithServiceProvider()` | Deprecation warning logged |
+| `WithPublisher()` | `WithHostProvider()` | Deprecation warning logged |
+
+### Deprecation Handling
+
+When both old and new fields are set:
+
+```go
+record := pluginsdk.NewFocusRecordBuilder().
+    WithIdentity("AWS", "123", "Prod").            // Sets provider_name
+    WithServiceProvider("Amazon Web Services").    // Sets service_provider_name
+    Build()
+// Warning logged: "provider_name is deprecated, using service_provider_name"
+// service_provider_name value takes precedence
+```
+
+## Validation Rules
+
+### Allocation Field Dependency
+
+```go
+// VALID: Both method and resource set
+record.WithAllocation("method-id", "details").
+       WithAllocatedResource("resource-id", "resource-name")
+
+// INVALID: Method without resource (validation error)
+record.WithAllocation("method-id", "details")
+// Error: "allocated_method_id requires allocated_resource_id"
+```
+
+### Contract Reference (No Validation)
+
+```go
+// Contract references are not validated against ContractCommitment dataset
+record.WithContractApplied("any-commitment-id")  // Always passes
+```
+
+## Testing
+
+### Conformance Tests
+
+```go
+// Run FOCUS 1.3 conformance tests
+func TestFocus13Conformance(t *testing.T) {
+    plugin := &MyPlugin{}
+    result := plugintesting.RunFocus13ConformanceTests(t, plugin)
+    if result.FailedTests > 0 {
+        t.Errorf("FOCUS 1.3 conformance failed: %s", result.Summary)
+    }
+}
+```
+
+### Backward Compatibility Tests
+
+```go
+// Verify FOCUS 1.2 records still work
+func TestFocus12BackwardCompat(t *testing.T) {
+    // Build FOCUS 1.2-only record
+    record, err := pluginsdk.NewFocusRecordBuilder().
+        // Only FOCUS 1.2 fields...
+        Build()
+
+    require.NoError(t, err, "FOCUS 1.2 record should validate")
+}
+```
+
+## Performance
+
+Builder operations for new fields maintain existing performance:
+
+- Target: <100 nanoseconds per operation
+- Memory: 0 allocations for validation
+- Benchmark: `go test -bench=BenchmarkFocus13 -benchmem ./sdk/go/testing/`
+
+## Next Steps
+
+1. Update your plugin to use new provider columns (`WithServiceProvider`, `WithHostProvider`)
+2. Add allocation data for shared resources if applicable
+3. Implement ContractCommitment support if you have contract data
+4. Run conformance tests to verify FOCUS 1.3 compliance

--- a/specs/026-focus-1-3-migration/research.md
+++ b/specs/026-focus-1-3-migration/research.md
@@ -1,0 +1,193 @@
+# Research: FOCUS 1.3 Migration
+
+**Branch**: `026-focus-1-3-migration` | **Date**: 2025-12-23
+
+## Research Tasks
+
+### 1. FOCUS 1.3 Column Specifications
+
+**Task**: Research exact FOCUS 1.3 column definitions, data types, and requirements.
+
+**Decision**: Use official FOCUS 1.3 specification column definitions with these mappings:
+
+| FOCUS Column | Proto Type | FOCUS Requirement |
+|--------------|-----------|-------------------|
+| AllocatedMethodId | string | Conditional |
+| AllocatedMethodDetails | string | Recommended |
+| AllocatedResourceId | string | Conditional |
+| AllocatedResourceName | string | Conditional |
+| AllocatedTags | map<string, string> | Conditional |
+| ContractApplied | string | Conditional |
+| ServiceProviderName | string | Conditional |
+| HostProviderName | string | Conditional |
+
+**Rationale**: These match the official FOCUS 1.3 specification released December 2025. All new
+columns are conditional (not mandatory) to maintain backward compatibility.
+
+**Alternatives considered**:
+
+- Make some columns mandatory: Rejected - would break FOCUS 1.2 backward compatibility
+- Use different data types: Rejected - must follow FOCUS specification exactly
+
+### 2. ContractCommitment Dataset Schema
+
+**Task**: Research the 12-field ContractCommitment dataset structure.
+
+**Decision**: Implement as a separate proto message with these fields:
+
+| Field | Proto Type | Purpose |
+|-------|-----------|---------|
+| ContractCommitmentId | string | Unique identifier for commitment |
+| ContractId | string | Parent contract identifier |
+| ContractCommitmentCategory | enum | Category (e.g., Spend, Usage) |
+| ContractCommitmentType | string | Type of commitment |
+| ContractCommitmentPeriodStart | google.protobuf.Timestamp | Commitment period start |
+| ContractCommitmentPeriodEnd | google.protobuf.Timestamp | Commitment period end |
+| ContractPeriodStart | google.protobuf.Timestamp | Contract period start |
+| ContractPeriodEnd | google.protobuf.Timestamp | Contract period end |
+| ContractCommitmentCost | double | Financial commitment amount |
+| ContractCommitmentQuantity | double | Committed quantity |
+| ContractCommitmentUnit | string | Unit for quantity |
+| BillingCurrency | string | ISO 4217 currency code |
+
+**Rationale**: This structure matches the FOCUS 1.3 Contract Commitment dataset specification.
+Using a separate proto message (not embedded in FocusCostRecord) reflects FOCUS's design of
+decoupled datasets.
+
+**Alternatives considered**:
+
+- Embed in FocusCostRecord: Rejected - FOCUS 1.3 explicitly separates these datasets
+- Use nested messages: Rejected - simpler flat structure aligns with FOCUS patterns
+
+### 3. Deprecation Handling Pattern
+
+**Task**: Research best practices for protobuf field deprecation.
+
+**Decision**: Use protobuf `deprecated` option and application-level warnings:
+
+```protobuf
+// Deprecated: Use service_provider_name instead. Will be removed in FOCUS 1.4.
+string provider_name = 1 [deprecated = true];
+
+// Deprecated: Use host_provider_name instead. Will be removed in FOCUS 1.4.
+string publisher = 55 [deprecated = true];
+```
+
+**Rationale**: The `deprecated` option generates compiler warnings in generated code. Combined
+with application-level logging (FR-009), this gives developers clear migration signals.
+
+**Alternatives considered**:
+
+- Remove fields immediately: Rejected - breaks wire compatibility
+- Only add comments: Rejected - generated code wouldn't warn developers
+
+### 4. Proto Field Numbering Strategy
+
+**Task**: Determine field numbers for new FocusCostRecord columns.
+
+**Decision**: Use field numbers 59-66 for new columns:
+
+| Field | Number | Rationale |
+|-------|--------|-----------|
+| service_provider_name | 59 | First new field |
+| host_provider_name | 60 | Provider pair |
+| allocated_method_id | 61 | Allocation group start |
+| allocated_method_details | 62 | Allocation group |
+| allocated_resource_id | 63 | Allocation group |
+| allocated_resource_name | 64 | Allocation group |
+| allocated_tags | 65 | Allocation metadata |
+| contract_applied | 66 | Contract link |
+
+**Rationale**: Current highest field number is 58 (sku_price_details). Using 59+ maintains
+backward compatibility - existing serialized messages remain valid.
+
+**Alternatives considered**:
+
+- Use gaps in existing numbering: Rejected - existing gaps may have semantic meaning
+- Reserve large range: Not needed - FOCUS spec is stable
+
+### 5. AllocatedTags Data Structure
+
+**Task**: Research whether AllocatedTags should match existing Tags structure.
+
+**Decision**: Use `map<string, string>` matching the existing Tags field pattern.
+
+**Rationale**: Consistency with existing `tags` field (field 22) in FocusCostRecord. Same
+pattern used throughout the codebase for key-value metadata.
+
+**Alternatives considered**:
+
+- Use repeated TagEntry message: Rejected - inconsistent with existing pattern
+- Use JSON string: Rejected - loses type safety
+
+### 6. ContractApplied Data Format
+
+**Task**: Research the ContractApplied column format for linking datasets.
+
+**Decision**: Use a simple string containing the ContractCommitmentId value.
+
+**Rationale**: Per clarification session, ContractApplied is treated as an opaque reference
+with no cross-dataset validation. A string ID is sufficient for linking and follows FOCUS's
+approach of decoupled datasets where referential integrity is the consumer's responsibility.
+
+**Alternatives considered**:
+
+- JSON object with multiple IDs: Rejected - overcomplicated for opaque reference
+- Repeated field for multiple contracts: Rejected - FOCUS spec uses singular
+
+### 7. Enum Requirements
+
+**Task**: Research whether new enums are needed for FOCUS 1.3.
+
+**Decision**: Add one new enum for ContractCommitmentCategory:
+
+```protobuf
+enum FocusContractCommitmentCategory {
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_UNSPECIFIED = 0;
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_SPEND = 1;
+  FOCUS_CONTRACT_COMMITMENT_CATEGORY_USAGE = 2;
+}
+```
+
+**Rationale**: ContractCommitmentCategory is explicitly enumerated in FOCUS 1.3 with Spend
+and Usage as the defined values. ContractCommitmentType is a free-form string per spec.
+
+**Alternatives considered**:
+
+- Use string for category: Rejected - FOCUS explicitly enumerates values
+- Add ContractCommitmentType enum: Rejected - spec allows free-form strings
+
+### 8. Validation Rule Dependencies
+
+**Task**: Research validation dependencies between new fields.
+
+**Decision**: Implement one validation dependency per clarification session:
+
+- **AllocatedMethodId requires AllocatedResourceId**: When AllocatedMethodId is populated,
+  AllocatedResourceId MUST also be populated. Rationale: An allocation method without an
+  allocation target is meaningless.
+
+No other field dependencies identified - all other new fields are independently optional.
+
+**Rationale**: This was clarified during spec development. The dependency is logical -
+you can't describe HOW costs are allocated without identifying WHAT they're allocated to.
+
+**Alternatives considered**:
+
+- Require all allocation fields together: Rejected - too restrictive
+- No dependencies: Rejected - allows nonsensical data
+
+## Summary
+
+All technical unknowns have been resolved:
+
+1. **Column definitions**: 8 new FocusCostRecord columns mapped with types and requirements
+2. **ContractCommitment**: 12-field separate proto message structure defined
+3. **Deprecation**: Use protobuf `deprecated` option + application warnings
+4. **Field numbers**: 59-66 for new columns, preserving backward compatibility
+5. **AllocatedTags**: map<string, string> matching existing Tags pattern
+6. **ContractApplied**: Simple string reference (opaque, no validation)
+7. **Enums**: One new enum (FocusContractCommitmentCategory)
+8. **Validation**: AllocatedMethodId requires AllocatedResourceId
+
+Ready to proceed to Phase 1: Design & Contracts.

--- a/specs/026-focus-1-3-migration/spec.md
+++ b/specs/026-focus-1-3-migration/spec.md
@@ -1,0 +1,264 @@
+# Feature Specification: FOCUS 1.3 Migration
+
+**Feature Branch**: `026-focus-1-3-migration`
+**Created**: 2025-12-23
+**Status**: Draft
+**Input**: GitHub Issue #183 - feat(focus): migrate to FOCUS 1.3 specification
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Add FOCUS 1.3 Cost Allocation Columns (Priority: P1)
+
+As a plugin developer implementing cost data for shared resources (Kubernetes pods, database
+instances), I need to populate allocation-specific columns so that FinOps practitioners can
+understand how costs are split across workloads and see the methodology, not just the final
+allocated amounts.
+
+**Why this priority**: Split cost allocation is the primary pain point FOCUS 1.3 addresses.
+Without these columns, practitioners must build custom allocation logic. This is the core value
+proposition of FOCUS 1.3.
+
+**Independent Test**: Can be fully tested by building a FocusCostRecord with allocation columns
+and validating all fields are correctly populated and accessible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plugin returning cost data for a shared Kubernetes cluster, **When** the plugin
+   sets allocated resource details, **Then** the record contains AllocatedResourceId,
+   AllocatedResourceName, AllocatedMethodId, AllocatedMethodDetails, and AllocatedTags fields.
+2. **Given** a FocusRecordBuilder instance, **When** the developer calls allocation-related
+   builder methods, **Then** all allocation fields are correctly populated in the resulting
+   proto message.
+3. **Given** a cost record with allocation columns populated, **When** validation runs, **Then**
+   the record passes FOCUS 1.3 conformance checks.
+
+---
+
+### User Story 2 - Add Service/Host Provider Columns (Priority: P1)
+
+As a plugin developer working with multi-vendor billing (resellers, marketplace purchases), I
+need to distinguish between the service provider (who sells the service) and the host provider
+(where it runs) so that practitioners can accurately identify billing relationships and support
+contacts.
+
+**Why this priority**: The deprecated Provider/Publisher columns caused confusion in multi-vendor
+scenarios. These new columns resolve definitional conflicts and are mandatory replacements.
+
+**Independent Test**: Can be fully tested by building a FocusCostRecord with ServiceProviderName
+and HostProviderName and verifying correct population and validation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cost record for an Azure Marketplace service running on Azure, **When** the
+   plugin populates provider columns, **Then** ServiceProviderName reflects the ISV vendor and
+   HostProviderName reflects "Azure".
+2. **Given** a FocusRecordBuilder instance, **When** the developer calls WithServiceProvider()
+   and WithHostProvider(), **Then** both fields are correctly populated.
+3. **Given** the deprecated ProviderName field is populated, **When** validation runs with
+   FOCUS 1.3 mode, **Then** a deprecation warning is logged but the record still validates
+   (backward compatibility).
+
+---
+
+### User Story 3 - Support Contract Commitment Dataset (Priority: P2)
+
+As a FinOps practitioner, I need to query contract commitment data separately from cost/usage
+data so that I can see all active commitments, their terms, remaining units, and expiration
+dates in a single query without parsing cost records.
+
+**Why this priority**: Contract commitments were previously embedded in cost rows, making
+analysis difficult. This is the first supplemental dataset in FOCUS, representing a significant
+architectural addition.
+
+**Independent Test**: Can be fully tested by creating a ContractCommitment message, populating
+all fields, and verifying round-trip serialization.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new ContractCommitment proto message, **When** the developer populates all 12
+   fields, **Then** all fields serialize correctly and are accessible via generated Go code.
+2. **Given** a contract commitment for a 3-year reserved instance, **When** the commitment is
+   created, **Then** ContractCommitmentId, ContractId, ContractPeriodStart, ContractPeriodEnd,
+   ContractCommitmentCost, and ContractCommitmentQuantity are all populated.
+3. **Given** a ContractCommitmentBuilder, **When** Build() is called with all required fields,
+   **Then** the commitment passes validation.
+
+---
+
+### User Story 4 - Add Contract Applied Column (Priority: P2)
+
+As a plugin developer returning cost records, I need to indicate whether a contract applies to
+a specific charge so that practitioners can link cost records to their contract commitment data.
+
+**Why this priority**: This column connects the Cost/Usage dataset to the new Contract
+Commitment dataset, enabling cross-dataset analysis.
+
+**Independent Test**: Can be fully tested by setting ContractApplied on a FocusCostRecord and
+verifying the link to contract data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a cost record covered by a reserved instance contract, **When** ContractApplied is
+   set, **Then** the field contains data linking to the Contract Commitment dataset.
+2. **Given** a FocusRecordBuilder, **When** WithContractApplied() is called, **Then** the
+   ContractApplied field is correctly populated.
+
+---
+
+### User Story 5 - Maintain Backward Compatibility (Priority: P3)
+
+As a plugin developer with existing FOCUS 1.2 implementations, I need my current code to
+continue working without modification so that I can adopt FOCUS 1.3 features incrementally.
+
+**Why this priority**: Breaking existing plugins would cause adoption friction. All new columns
+should be optional for backward compatibility.
+
+**Independent Test**: Can be fully tested by running existing FOCUS 1.2 conformance tests and
+verifying they still pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** a FocusCostRecord built using only FOCUS 1.2 fields, **When** validation runs,
+   **Then** the record passes validation (new FOCUS 1.3 fields are optional).
+2. **Given** existing FOCUS 1.2 builder code, **When** compiled against the updated SDK,
+   **Then** no compile errors occur and existing tests pass.
+3. **Given** the deprecated ProviderName field, **When** populated alongside new
+   ServiceProviderName/HostProviderName, **Then** both are accepted for transition period
+   compatibility.
+
+---
+
+### Edge Cases
+
+- When both deprecated ProviderName and new ServiceProviderName are populated with conflicting
+  values: Log deprecation warning and prefer ServiceProviderName (new field wins).
+- ContractApplied references to non-existent ContractCommitmentId: Accept as opaque reference
+  (no cross-dataset validation; referential integrity is consumer's responsibility).
+- AllocatedMethodId without AllocatedResourceId: Validation error (method requires resource).
+- FOCUS 1.2 records processed by FOCUS 1.3 code: Pass validation (all new fields optional).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+#### Proto Definition Updates
+
+- **FR-001**: System MUST add eight new columns to FocusCostRecord: AllocatedMethodId,
+  AllocatedMethodDetails, AllocatedResourceId, AllocatedResourceName, AllocatedTags,
+  ContractApplied, HostProviderName, ServiceProviderName.
+- **FR-002**: System MUST create a new ContractCommitment proto message with 12 fields:
+  ContractCommitmentId, ContractId, ContractCommitmentCategory, ContractCommitmentType,
+  ContractCommitmentPeriodStart, ContractCommitmentPeriodEnd, ContractPeriodStart,
+  ContractPeriodEnd, ContractCommitmentCost, ContractCommitmentQuantity, ContractCommitmentUnit,
+  BillingCurrency.
+- **FR-003**: System MUST add deprecation comments to ProviderName and Publisher fields in
+  FocusCostRecord proto.
+- **FR-004**: System MUST use proto field numbers 59+ for new FocusCostRecord columns to
+  maintain backward compatibility.
+
+#### Go SDK Builder Updates
+
+- **FR-005**: System MUST add builder methods for all new FocusCostRecord columns:
+  WithAllocation(), WithAllocatedResource(), WithAllocatedTags(), WithContractApplied(),
+  WithServiceProvider(), WithHostProvider().
+- **FR-006**: System MUST create a ContractCommitmentBuilder for constructing contract
+  commitment records.
+- **FR-007**: Builder methods MUST follow existing naming conventions and fluent API patterns.
+
+#### Validation Updates
+
+- **FR-008**: System MUST validate new FOCUS 1.3 columns according to specification
+  requirements (mandatory, recommended, conditional classifications).
+- **FR-009**: System MUST log deprecation warnings when deprecated fields (ProviderName,
+  Publisher) are populated.
+- **FR-010**: System MUST maintain validation compatibility for FOCUS 1.2 records (new columns
+  optional).
+- **FR-010a**: System MUST require AllocatedResourceId when AllocatedMethodId is populated
+  (allocation method requires an allocated resource target).
+
+#### Enum Additions
+
+- **FR-011**: System MUST add FocusContractCommitmentCategory enum if required by
+  specification.
+- **FR-012**: System MUST add FocusContractCommitmentType enum if required by specification.
+
+#### Testing Updates
+
+- **FR-013**: System MUST add conformance tests for all new FOCUS 1.3 columns.
+- **FR-014**: System MUST add integration tests for ContractCommitment dataset.
+- **FR-015**: System MUST verify existing FOCUS 1.2 conformance tests continue to pass.
+- **FR-016**: System MUST add benchmarks for new builder methods.
+
+#### Documentation Updates
+
+- **FR-017**: System MUST update focus-columns.md with FOCUS 1.3 column documentation.
+- **FR-018**: System MUST update FocusCostRecord proto comments to reference FOCUS 1.3
+  specification.
+- **FR-019**: System MUST document the new ContractCommitment dataset and its relationship
+  to FocusCostRecord.
+
+### Key Entities
+
+- **FocusCostRecord**: Extended with 8 new columns for allocation and provider identification.
+  Represents a single cost line item in the Cost and Usage dataset.
+- **ContractCommitment**: New entity representing contractual commitment terms. Contains 12
+  fields covering commitment identification, temporal bounds, and financial metrics. Links to
+  FocusCostRecord via ContractApplied column.
+- **AllocatedResource**: Conceptual entity representing the resource receiving an allocated
+  charge. Identified by AllocatedResourceId and AllocatedResourceName, with associated tags.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: All 8 new FocusCostRecord columns are accessible through the Go SDK builder API.
+- **SC-002**: ContractCommitment proto message compiles and generates valid Go code with all
+  12 fields.
+- **SC-003**: 100% of existing FOCUS 1.2 conformance tests pass without modification.
+- **SC-004**: New FOCUS 1.3 conformance tests achieve 100% coverage of new columns and
+  validation rules.
+- **SC-005**: Builder operations for new columns complete in under 100 nanoseconds per
+  operation (matching existing performance baselines).
+- **SC-006**: Documentation covers all new columns with examples matching the quality of
+  existing FOCUS 1.2 documentation.
+- **SC-007**: Deprecation warnings appear in logs when deprecated columns (ProviderName,
+  Publisher) are used.
+- **SC-008**: Plugin developers can incrementally adopt FOCUS 1.3 features without rewriting
+  existing FOCUS 1.2 code.
+
+## Assumptions
+
+- FOCUS 1.3 specification is finalized (ratified December 5, 2025) and column definitions are
+  stable.
+- New columns follow the same conditional/mandatory classification patterns as FOCUS 1.2.
+- The ContractCommitment dataset is queried separately (not embedded in cost RPC responses).
+- AllocatedTags follows the same map<string, string> pattern as existing Tags field.
+- ContractApplied column contains structured data (likely JSON) linking to ContractCommitmentId.
+- Deprecation period for ProviderName and Publisher extends through FOCUS 1.3 (removed in 1.4).
+
+## Out of Scope
+
+- Recency and completeness metadata (dataset-level, not record-level).
+- Changes to existing RPC definitions (GetActualCost, GetProjectedCost, etc.).
+- New RPC methods for querying ContractCommitment data (may be addressed in future spec).
+- Automatic migration of existing FOCUS 1.2 data to FOCUS 1.3 format.
+- UI/CLI changes for visualizing contract commitments.
+
+## Clarifications
+
+### Session 2025-12-23
+
+- Q: When both deprecated ProviderName and new ServiceProviderName are populated with conflicting
+  values, how should validation behave? → A: Warn and prefer ServiceProviderName (new field wins)
+- Q: How should the system handle a ContractApplied field that references a ContractCommitmentId
+  that doesn't exist? → A: Accept as opaque reference (no cross-dataset validation)
+- Q: When AllocatedMethodId is set but AllocatedResourceId is NOT set, how should validation
+  behave? → A: Require AllocatedResourceId when AllocatedMethodId is set (validation error)
+
+## References
+
+- [FOCUS 1.3 Announcement](https://www.finops.org/insights/introducing-focus-1-3/)
+- [FOCUS Specification](https://focus.finops.org/)
+- [FOCUS GitHub Repository](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec)
+- GitHub Issue #183: feat(focus): migrate to FOCUS 1.3 specification
+- Related PR: rshade/pulumicost-spec#99 - feat(focus): Implement FOCUS 1.2 integration [merged]

--- a/specs/026-focus-1-3-migration/tasks.md
+++ b/specs/026-focus-1-3-migration/tasks.md
@@ -1,0 +1,376 @@
+# Tasks: FOCUS 1.3 Migration
+
+**Input**: Design documents from `/specs/026-focus-1-3-migration/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+**Tests**: Test tasks are included as specified in FR-013 through FR-017 of the spec.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation
+and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Proto definitions**: `proto/pulumicost/v1/`
+- **Go SDK**: `sdk/go/`
+- **Testing framework**: `sdk/go/testing/`
+- **Plugin SDK**: `sdk/go/pluginsdk/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and verify existing infrastructure
+
+- [x] T001 Verify branch 026-focus-1-3-migration exists and is checked out
+- [x] T002 [P] Verify buf v1.32.1 is installed (`make generate` installs if needed)
+- [x] T003 [P] Verify Go 1.25.5+ and protobuf dependencies are available
+- [x] T004 Review existing `proto/pulumicost/v1/focus.proto` for field number conflicts
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core proto changes that MUST be complete before ANY user story can
+be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T005 Add `FocusContractCommitmentCategory` enum to `proto/pulumicost/v1/focus.proto`
+  with values: UNSPECIFIED(0), SPEND(1), USAGE(2)
+- [x] T006 Add `ContractCommitment` message to `proto/pulumicost/v1/focus.proto`
+  with 12 fields per contracts/contract_commitment.proto
+- [x] T006a Add FOCUS 1.3 specification reference comments to all new proto fields
+  in `proto/pulumicost/v1/focus.proto` (reference FOCUS 1.3 section numbers for
+  each column: AllocatedMethodId, ServiceProviderName, etc.)
+- [x] T007 Mark `provider_name` field (1) as deprecated with `[deprecated = true]`
+  option in FocusCostRecord
+- [x] T008 Mark `publisher` field (55) as deprecated with `[deprecated = true]`
+  option in FocusCostRecord
+- [x] T009 Run `make generate` to regenerate Go bindings from proto changes
+- [x] T010 Verify generated code compiles: `go build ./...`
+- [x] T011 Update `sdk/go/registry/` enums if ContractCommitmentCategory
+  needs registry exposure
+
+**Checkpoint**: Foundation ready - proto changes compiled, user story
+implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Cost Allocation Columns (Priority: P1) 🎯 MVP
+
+**Goal**: As a FinOps Practitioner, I can track split cost allocations to analyze
+how shared resource costs are distributed across workloads.
+
+**Independent Test**: Create FocusRecordBuilder with allocation fields, verify
+proto serialization and validation
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T012 [P] [US1] Unit test for allocation field validation in
+  `sdk/go/pluginsdk/focus_builder_test.go` - test AllocatedMethodId requires
+  AllocatedResourceId
+- [x] T013 [P] [US1] Unit test for allocation builder methods in
+  `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T014 [P] [US1] Benchmark test for allocation operations in
+  `sdk/go/testing/benchmark_test.go` - target <100ns/op, 0 allocs
+
+### Implementation for User Story 1
+
+- [x] T015 [US1] Add `allocated_method_id` field (61) string to FocusCostRecord
+  in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+- [x] T016 [P] [US1] Add `allocated_method_details` field (62) string to
+  FocusCostRecord in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+- [x] T017 [P] [US1] Add `allocated_resource_id` field (63) string to
+  FocusCostRecord in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+- [x] T018 [P] [US1] Add `allocated_resource_name` field (64) string to
+  FocusCostRecord in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+- [x] T019 [US1] Add `allocated_tags` field (65) map<string,string> to
+  FocusCostRecord in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+- [x] T020 [US1] Run `make generate` after proto field additions (completed in Phase 2)
+- [x] T021 [US1] Implement `WithAllocation(methodId, methodDetails string)`
+  builder method in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T022 [US1] Implement `WithAllocatedResource(resourceId, resourceName string)`
+  builder method in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T023 [US1] Implement `WithAllocatedTags(tags map[string]string)`
+  builder method in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T024 [US1] Add validation in `Build()` method: if allocated_method_id
+  is set, allocated_resource_id MUST also be set
+- [x] T025 [US1] Verify tests pass: `go test -v ./sdk/go/pluginsdk/...`
+
+**Checkpoint**: User Story 1 complete - allocation fields functional and
+testable independently
+
+---
+
+## Phase 4: User Story 2 - Service/Host Provider Columns (Priority: P1)
+
+**Goal**: As a FinOps Practitioner, I can distinguish between service provider
+and host provider to accurately attribute costs in marketplace scenarios.
+
+**Independent Test**: Create FocusRecordBuilder with provider fields, verify
+deprecation warning when both old and new fields set
+
+### Tests for User Story 2
+
+- [x] T026 [P] [US2] Unit test for service/host provider builder methods in
+  `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T027 [P] [US2] Unit test for deprecation warning logging when provider_name
+  and service_provider_name both set in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T028 [P] [US2] Benchmark test for provider operations in
+  `sdk/go/testing/benchmark_test.go` - target <100ns/op, 0 allocs
+
+### Implementation for User Story 2
+
+- [x] T029 [US2] Add `service_provider_name` field (59) string to FocusCostRecord
+  in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+- [x] T030 [P] [US2] Add `host_provider_name` field (60) string to FocusCostRecord
+  in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+- [x] T031 [US2] Run `make generate` after proto field additions (completed in Phase 2)
+- [x] T032 [US2] Implement `WithServiceProvider(name string)` builder method
+  in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T033 [US2] Implement `WithHostProvider(name string)` builder method
+  in `sdk/go/pluginsdk/focus_builder.go`
+- [x] T034 [US2] Add deprecation warning logic in `Build()` method: log warning
+  if provider_name is set when service_provider_name is also set, prefer
+  service_provider_name value
+- [x] T035 [US2] Add deprecation warning logic: log warning if publisher is set
+  when host_provider_name is also set, prefer host_provider_name value
+- [x] T036 [US2] Verify tests pass: `go test -v ./sdk/go/pluginsdk/...`
+
+**Checkpoint**: User Story 2 complete - provider fields functional with
+deprecation handling
+
+---
+
+## Phase 5: User Story 3 - Contract Commitment Dataset (Priority: P2)
+
+**Goal**: As a Cloud Finance Manager, I can create ContractCommitment records
+to track contract obligations separately from cost line items.
+
+**Independent Test**: Create ContractCommitmentBuilder, verify all 12 fields
+serialize correctly
+
+### Tests for User Story 3
+
+- [x] T037 [P] [US3] Unit test for ContractCommitmentBuilder in
+  `sdk/go/pluginsdk/contract_commitment_builder_test.go`
+- [x] T038 [P] [US3] Unit test for ContractCommitment validation (required
+  fields, period consistency, non-negative values) in
+  `sdk/go/pluginsdk/contract_commitment_builder_test.go`
+- [x] T039 [P] [US3] Benchmark test for ContractCommitment operations in
+  `sdk/go/testing/benchmark_test.go`
+
+### Implementation for User Story 3
+
+- [x] T040 [US3] Create `sdk/go/pluginsdk/contract_commitment_builder.go`
+  with `ContractCommitmentBuilder` struct
+- [x] T041 [US3] Implement `NewContractCommitmentBuilder()` constructor
+- [x] T042 [US3] Implement `WithIdentity(commitmentId, contractId string)`
+  builder method
+- [x] T043 [US3] Implement `WithCategory(category FocusContractCommitmentCategory)`
+  builder method
+- [x] T044 [US3] Implement `WithType(commitmentType string)` builder method
+- [x] T045 [US3] Implement `WithCommitmentPeriod(start, end time.Time)`
+  builder method
+- [x] T046 [US3] Implement `WithContractPeriod(start, end time.Time)`
+  builder method
+- [x] T047 [US3] Implement `WithFinancials(cost, quantity float64, unit,
+  currency string)` builder method
+- [x] T048 [US3] Implement `Build() (*pbc.ContractCommitment, error)` method
+  with validation
+- [x] T049 [US3] Add validation: contract_commitment_id, contract_id,
+  billing_currency are required
+- [x] T050 [US3] Add validation: period_end >= period_start
+- [x] T051 [US3] Add validation: cost >= 0, quantity >= 0
+- [x] T052 [US3] Reuse existing ISO 4217 currency validation from
+  `sdk/go/pricing/` for billing_currency
+- [x] T053 [US3] Verify tests pass: `go test -v ./sdk/go/pluginsdk/...`
+- [x] T053a [US3] Document ContractCommitment dataset and its relationship to
+  FocusCostRecord in `sdk/go/pluginsdk/README.md` (include ContractApplied
+  linking pattern, 12-field overview, usage examples)
+
+**Checkpoint**: User Story 3 complete - ContractCommitment dataset functional
+
+---
+
+## Phase 6: User Story 4 - Contract Applied Column (Priority: P2)
+
+**Goal**: As a Cloud Finance Manager, I can link cost records to contract
+commitments to correlate usage with contractual obligations.
+
+**Independent Test**: Create FocusRecordBuilder with ContractApplied field,
+verify it accepts any string value (opaque reference)
+
+### Tests for User Story 4
+
+- [x] T054 [P] [US4] Unit test for ContractApplied builder method in
+  `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T055 [P] [US4] Unit test verifying no cross-dataset validation
+  (ContractApplied accepts any string) in
+  `sdk/go/pluginsdk/focus_builder_test.go`
+
+### Implementation for User Story 4
+
+- [x] T056 [US4] Add `contract_applied` field (66) string to FocusCostRecord
+  in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+- [x] T057 [US4] Run `make generate` after proto field addition (completed in Phase 2)
+- [x] T058 [US4] Implement `WithContractApplied(commitmentId string)` builder
+  method in `sdk/go/pluginsdk/focus_builder.go` (completed in Phase 3)
+- [x] T059 [US4] Verify tests pass: `go test -v ./sdk/go/pluginsdk/...`
+
+**Checkpoint**: User Story 4 complete - contract linking functional
+
+---
+
+## Phase 7: User Story 5 - Backward Compatibility (Priority: P3)
+
+**Goal**: As a Plugin Developer, I can continue using existing FOCUS 1.2 code
+while incrementally adopting FOCUS 1.3 features.
+
+**Independent Test**: Build a FOCUS 1.2-only record (no new fields), verify
+it passes validation and serializes correctly
+
+### Tests for User Story 5
+
+- [x] T060 [P] [US5] Unit test that FOCUS 1.2 records (no new fields) still
+  validate successfully in `sdk/go/pluginsdk/focus_builder_test.go`
+- [x] T061 [P] [US5] Conformance test for backward compatibility in
+  `sdk/go/testing/focus13_conformance_test.go`
+- [x] T062 [P] [US5] Test that deprecated fields still work (provider_name,
+  publisher) in `sdk/go/pluginsdk/focus_builder_test.go`
+
+### Implementation for User Story 5
+
+- [x] T063 [US5] Verify all new FOCUS 1.3 fields have default/zero values that
+  don't affect existing behavior
+- [x] T064 [US5] Ensure `WithIdentity()` continues to set provider_name for
+  backward compatibility (existing behavior)
+- [x] T065 [US5] Document migration path in code comments for deprecated fields
+- [x] T066 [US5] Add FOCUS 1.3 conformance test suite in
+  `sdk/go/testing/focus13_conformance_test.go`
+- [x] T067 [US5] Implement `RunFocus13ConformanceTests(t, plugin)` function
+  in `sdk/go/testing/focus13_conformance_test.go` (tests directly callable)
+- [x] T068 [US5] Verify tests pass: `go test -v ./sdk/go/testing/...`
+
+**Checkpoint**: User Story 5 complete - backward compatibility verified
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [x] T069 [P] Update `specs/026-focus-1-3-migration/quickstart.md` with
+  actual API usage after implementation
+- [x] T070 [P] Add FOCUS 1.3 section to `sdk/go/pluginsdk/README.md`
+- [x] T077 [P] Update `docs/focus-columns.md` with FOCUS 1.3 column documentation
+  (AllocatedMethodId, AllocatedMethodDetails, AllocatedResourceId, AllocatedResourceName,
+  AllocatedTags, ContractApplied, ServiceProviderName, HostProviderName)
+- [x] T071 [P] Update root CLAUDE.md with FOCUS 1.3 patterns and learnings
+- [x] T072 Run full test suite: `make test`
+- [x] T073 Run full linting: `make lint` (deprecated field warnings expected for
+  backward compatibility tests)
+- [x] T074 Run benchmarks and verify performance targets:
+  `go test -bench=BenchmarkFocus -benchmem ./sdk/go/pluginsdk/`
+  (All FOCUS 1.3 methods: < 2 ns/op, 0 allocs except tags at ~130 ns/op)
+- [x] T075 Validate quickstart.md examples compile and run correctly
+- [x] T076 Code review for consistency with existing SDK patterns
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-7)**: All depend on Foundational phase completion
+  - User stories can then proceed in parallel (if staffed)
+  - Or sequentially in priority order (P1 → P2 → P3)
+- **Polish (Phase 8)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - No dependencies
+  on other stories
+- **User Story 2 (P1)**: Can start after Foundational (Phase 2) - No dependencies
+  on other stories, can run parallel with US1
+- **User Story 3 (P2)**: Can start after Foundational (Phase 2) - No dependencies
+  on US1/US2
+- **User Story 4 (P2)**: Can start after Foundational (Phase 2) - Conceptually
+  links to US3 but implementation is independent
+- **User Story 5 (P3)**: Should wait until US1-US4 complete for comprehensive
+  backward compatibility testing
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Proto changes before SDK implementation
+- Builder methods before validation logic
+- Core implementation before integration
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel
+- All Foundational tasks are sequential (proto changes must be ordered)
+- Once Foundational phase completes:
+  - US1 and US2 can run in parallel (both P1, different field groups)
+  - US3 and US4 can run in parallel (both P2, different features)
+- All tests for a user story marked [P] can run in parallel
+- Proto field additions within a story marked [P] can run in parallel
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 2)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1 (Cost Allocation)
+4. Complete Phase 4: User Story 2 (Service/Host Provider)
+5. **STOP and VALIDATE**: Test MVP with all P1 features
+6. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add US1 + US2 → Test independently → Deploy/Demo (MVP with P1 features!)
+3. Add US3 + US4 → Test independently → Deploy/Demo (P2 features)
+4. Add US5 → Test independently → Deploy/Demo (P3 backward compat)
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 (Allocation)
+   - Developer B: User Story 2 (Provider)
+3. After P1 complete:
+   - Developer A: User Story 3 (ContractCommitment)
+   - Developer B: User Story 4 (ContractApplied)
+4. All: User Story 5 (Backward Compatibility verification)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Performance target: <100ns/op, 0 allocs for builder operations
+- All new proto fields use numbers 59-66 (no conflicts with existing 1-58)


### PR DESCRIPTION
## Summary

- Add 8 new FOCUS 1.3 columns to FocusCostRecord: AllocatedMethodId, AllocatedMethodDetails, AllocatedResourceId, AllocatedResourceName, AllocatedTags, ContractApplied, ServiceProviderName, HostProviderName
- Create ContractCommitment supplemental dataset with 12 fields for tracking contractual obligations separately from cost line items
- Add FocusRecordBuilder methods: WithAllocation(), WithAllocatedResource(), WithAllocatedTags(), WithContractApplied(), WithServiceProvider(), WithHostProvider()
- Create ContractCommitmentBuilder with fluent API for commitment records
- Implement deprecation handling for provider_name and publisher fields with zerolog warnings when both deprecated and replacement fields are set
- Add validation: AllocatedMethodId requires AllocatedResourceId

## Test plan

- [x] FOCUS 1.2 backward compatibility tests pass (T060, T061)
- [x] Service/Host provider methods work correctly (T062, T063, T064)
- [x] Allocation methods set fields properly (T070-T073)
- [x] ContractCommitmentBuilder creates valid records (T080-T085)
- [x] Validation enforces AllocatedMethodId requires AllocatedResourceId
- [x] `make test` passes
- [x] `make lint` passes

## Changes

### New files

- `sdk/go/pluginsdk/contract_commitment_builder.go` - Builder for FOCUS 1.3 Contract Commitment dataset with identity, category, period, and financials
- `sdk/go/pluginsdk/contract_commitment_builder_test.go` - Tests for ContractCommitmentBuilder
- `sdk/go/testing/focus13_conformance_test.go` - 434-line FOCUS 1.3 conformance test suite covering backward compatibility, provider columns, allocation fields, and contract commitments
- `specs/026-focus-1-3-migration/` - Complete feature specification with research, data model, plan, tasks, and checklists

### Modified files

- `proto/pulumicost/v1/focus.proto` - Add FOCUS 1.3 columns and ContractCommitment message with enums
- `sdk/go/proto/pulumicost/v1/focus.pb.go` - Regenerated proto code
- `sdk/go/pluginsdk/focus_builder.go` - Add 6 new FOCUS 1.3 builder methods with migration documentation
- `sdk/go/pluginsdk/focus_builder_test.go` - Tests for new builder methods
- `sdk/go/pluginsdk/focus_conformance.go` - Add FOCUS 1.3 validation rules
- `sdk/go/pluginsdk/README.md` - Document new FOCUS 1.3 features
- `docs/focus-columns.md` - Add FOCUS 1.3 column documentation

Closes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FOCUS 1.3: split-cost allocation, service/host provider fields, ContractCommitment dataset and contract linkage (SPEND/USAGE), new proto fields and builder APIs, and allocation/period/currency handling.

* **Deprecations**
  * Legacy provider and publisher fields marked deprecated; runtime deprecation warnings and migration guidance when mixing 1.2/1.3.

* **Documentation**
  * Expanded column reference, examples, queries, migration steps, and SDK README content for 1.3.

* **Tests**
  * Comprehensive conformance, builder, and benchmark tests covering 1.3 features and backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->