### PR TITLE
feat(proto): add forecasting primitives for cost projections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,44 @@ Performance (FOCUS 1.3 builder methods):
 - Allocation methods: 1.5-1.8 ns/op, 0 allocs/op
 - Tag operations: ~130 ns/op (map copy overhead)
 
+**Forecasting Primitives (`sdk/go/pricing/growth.go`)**
+
+The pricing package provides growth projection helpers for cost forecasting:
+
+- **GrowthType Enum**: NONE, LINEAR, EXPONENTIAL (UNSPECIFIED treated as NONE)
+- **Growth Formulas**:
+  - Linear: `cost = baseCost * (1 + rate * periods)`
+  - Exponential: `cost = baseCost * (1 + rate)^periods`
+- **Validation**: `ValidateGrowthParams()` validates growth type and rate combinations
+- **Warnings**: `CheckGrowthWarnings()` detects unrealistic assumptions
+
+Key files:
+
+- `growth.go` - Growth calculation and validation functions
+- `growth_test.go` - Comprehensive tests including overflow edge cases
+
+Constants:
+
+- `HighGrowthRateThreshold = 1.0` (100% per period triggers warning)
+- `LongProjectionThreshold = 36` (months for exponential projection warning)
+- `MinValidGrowthRate = -1.0` (minimum allowed rate)
+
+Usage patterns:
+
+```go
+// Apply growth projection
+cost := pricing.ApplyGrowth(baseCost, pbc.GrowthType_GROWTH_TYPE_LINEAR, &rate, periods)
+
+// Validate parameters
+err := pricing.ValidateGrowthParams(growthType, &rate)
+
+// Check for warnings
+warnings := pricing.CheckGrowthWarnings(growthType, &rate, periods)
+```
+
+See `specs/030-forecasting-primitives/` for complete specification and `sdk/go/pricing/README.md`
+for detailed documentation.
+
 **Examples (`examples/`)**
 
 - `examples/specs/` - 8 comprehensive cross-vendor JSON examples

--- a/examples/requests/projected_cost_exponential_growth.json
+++ b/examples/requests/projected_cost_exponential_growth.json
@@ -1,0 +1,12 @@
+{
+  "$comment": "GetProjectedCostRequest with EXPONENTIAL growth - 5% compounding per month",
+  "resource": {
+    "provider": "aws",
+    "resource_type": "s3",
+    "sku": "standard",
+    "region": "us-east-1",
+    "growth_type": "GROWTH_TYPE_EXPONENTIAL",
+    "growth_rate": 0.05
+  },
+  "utilization_percentage": 0.75
+}

--- a/examples/requests/projected_cost_linear_growth.json
+++ b/examples/requests/projected_cost_linear_growth.json
@@ -1,0 +1,12 @@
+{
+  "$comment": "GetProjectedCostRequest with LINEAR growth - 10% per month",
+  "resource": {
+    "provider": "aws",
+    "resource_type": "ec2",
+    "sku": "t3.medium",
+    "region": "us-east-1",
+    "growth_type": "GROWTH_TYPE_LINEAR",
+    "growth_rate": 0.10
+  },
+  "utilization_percentage": 0.5
+}

--- a/examples/requests/projected_cost_override.json
+++ b/examples/requests/projected_cost_override.json
@@ -1,0 +1,14 @@
+{
+  "$comment": "GetProjectedCostRequest with request-level override of resource defaults",
+  "resource": {
+    "provider": "aws",
+    "resource_type": "ec2",
+    "sku": "t3.medium",
+    "region": "us-east-1",
+    "growth_type": "GROWTH_TYPE_LINEAR",
+    "growth_rate": 0.10
+  },
+  "utilization_percentage": 0.5,
+  "growth_type": "GROWTH_TYPE_EXPONENTIAL",
+  "growth_rate": 0.05
+}

--- a/proto/pulumicost/v1/costsource.proto
+++ b/proto/pulumicost/v1/costsource.proto
@@ -8,6 +8,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
 import "pulumicost/v1/focus.proto";
 import "pulumicost/v1/budget.proto";
+import "pulumicost/v1/enums.proto";
 
 // CostSourceService provides gRPC interface for cost source plugins to implement.
 // This service defines the contract for retrieving actual costs, projected costs,
@@ -172,6 +173,33 @@ message GetProjectedCostRequest {
   // To explicitly request 0% utilization, use the resource-level override:
   //   resource.utilization_percentage = proto.Float64(0.0)
   double utilization_percentage = 2;
+
+  // growth_type overrides ResourceDescriptor.growth_type for this request.
+  // OPTIONAL. When set, takes precedence over the resource-level default.
+  //
+  // Use case: Project different growth scenarios for the same resource
+  // without modifying the resource descriptor.
+  //
+  // When LINEAR or EXPONENTIAL, growth_rate MUST also be provided
+  // (either here or in ResourceDescriptor).
+  GrowthType growth_type = 3;
+
+  // growth_rate overrides ResourceDescriptor.growth_rate for this request.
+  // OPTIONAL. When set (even to 0.0), takes precedence over resource-level default.
+  //
+  // Valid range: >= -1.0 (no upper bound)
+  //
+  // Proto3 optional field semantics:
+  //   - Not set (nil): Use resource-level growth_rate from ResourceDescriptor
+  //   - Explicitly set to 0.0: Apply 0% growth (overrides resource default)
+  //   - Set to any other value: Use the specified rate
+  //
+  // In generated Go code, check presence with:
+  //   if req.GrowthRate != nil { rate := *req.GrowthRate }
+  //
+  // Override semantics: If this field is set, it fully replaces
+  // ResourceDescriptor.growth_rate for this request.
+  optional double growth_rate = 4;
 }
 
 // GetProjectedCostResponse contains projected cost information.
@@ -303,6 +331,39 @@ message ResourceDescriptor {
   // Plugins MAY validate the arn format for their provider and SHOULD log
   // a warning if the format is invalid before falling back.
   string arn = 8;
+
+  // growth_type specifies the default growth model for cost projections.
+  // OPTIONAL. When set, defines how projected costs should grow over time.
+  // Can be overridden by GetProjectedCostRequest.growth_type.
+  //
+  // Values:
+  //   - GROWTH_TYPE_UNSPECIFIED/NONE: No growth (constant projections)
+  //   - GROWTH_TYPE_LINEAR: Additive growth (cost * (1 + rate * periods))
+  //   - GROWTH_TYPE_EXPONENTIAL: Compounding growth (cost * (1 + rate)^periods)
+  //
+  // When LINEAR or EXPONENTIAL, growth_rate MUST also be provided.
+  GrowthType growth_type = 9;
+
+  // growth_rate specifies the default growth rate per projection period.
+  // OPTIONAL. Required when growth_type is LINEAR or EXPONENTIAL.
+  //
+  // Valid range: >= -1.0 (no upper bound)
+  //   - Positive values: growth (e.g., 0.10 = 10% growth per period)
+  //   - Zero: no growth (equivalent to GROWTH_TYPE_NONE)
+  //   - Negative values: decline (e.g., -0.10 = 10% decline per period)
+  //   - -1.0: complete decline to zero cost
+  //
+  // Values below -1.0 are invalid (would produce negative costs).
+  // Can be overridden by GetProjectedCostRequest.growth_rate.
+  //
+  // Proto3 optional field semantics:
+  //   - Not set (nil): No default rate (caller must provide in request if needed)
+  //   - Explicitly set to 0.0: Resource has 0% growth rate as default
+  //   - Set to any other value: Use as resource-level default rate
+  //
+  // In generated Go code, check presence with:
+  //   if desc.GrowthRate != nil { rate := *desc.GrowthRate }
+  optional double growth_rate = 10;
 }
 
 // ActualCostResult represents a single cost data point.

--- a/proto/pulumicost/v1/enums.proto
+++ b/proto/pulumicost/v1/enums.proto
@@ -85,3 +85,25 @@ enum FocusCapacityReservationStatus {
   // Unused: Charges representing the unused portion of a capacity reservation.
   FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED = 2;
 }
+
+// GrowthType represents the mathematical model used for projecting cost growth.
+// Used in ResourceDescriptor and GetProjectedCostRequest for forward-looking projections.
+enum GrowthType {
+  // Default value - treated identically to GROWTH_TYPE_NONE.
+  // When unset, no growth is applied to projections.
+  GROWTH_TYPE_UNSPECIFIED = 0;
+
+  // No growth applied to projections.
+  // Cost projections remain constant at the base cost.
+  GROWTH_TYPE_NONE = 1;
+
+  // Linear (additive) growth per projection period.
+  // Formula: cost_at_n = base_cost * (1 + rate * n)
+  // Requires growth_rate to be set.
+  GROWTH_TYPE_LINEAR = 2;
+
+  // Exponential (compounding) growth per projection period.
+  // Formula: cost_at_n = base_cost * (1 + rate)^n
+  // Requires growth_rate to be set.
+  GROWTH_TYPE_EXPONENTIAL = 3;
+}

--- a/sdk/go/pricing/README.md
+++ b/sdk/go/pricing/README.md
@@ -1,0 +1,325 @@
+# Pricing Package
+
+Package `pricing` provides domain types, validation, and growth calculation helpers for the
+PulumiCost SDK.
+
+## Features
+
+- **Billing Mode Validation**: Validate 44+ billing modes across all cloud providers
+- **Growth Projections**: Calculate linear and exponential cost growth projections
+- **JSON Schema Validation**: Validate PricingSpec documents against embedded schema
+- **Warning Detection**: Detect unrealistic growth assumptions
+
+## Installation
+
+```go
+import "github.com/rshade/pulumicost-spec/sdk/go/pricing"
+```
+
+## Growth Projection Helpers
+
+The package provides comprehensive helpers for projecting future costs based on growth
+assumptions.
+
+### Growth Types
+
+| Type | Description | Formula |
+|------|-------------|---------|
+| `GROWTH_TYPE_NONE` | No growth applied | `cost = baseCost` |
+| `GROWTH_TYPE_LINEAR` | Linear (additive) growth | `cost = baseCost * (1 + rate * n)` |
+| `GROWTH_TYPE_EXPONENTIAL` | Compound growth | `cost = baseCost * (1 + rate)^n` |
+| `GROWTH_TYPE_UNSPECIFIED` | Default (treated as NONE) | `cost = baseCost` |
+
+### Basic Usage
+
+```go
+import (
+    "github.com/rshade/pulumicost-spec/sdk/go/pricing"
+    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// Apply linear growth: 10% per period for 12 periods
+// Formula: $100 * (1 + 0.10 * 12) = $220
+cost := pricing.ApplyLinearGrowth(100.0, 0.10, 12)
+
+// Apply exponential growth: 5% per period for 12 periods
+// Formula: $100 * (1.05)^12 = $179.59
+cost := pricing.ApplyExponentialGrowth(100.0, 0.05, 12)
+
+// Use the dispatcher function with growth type enum
+rate := 0.10
+cost := pricing.ApplyGrowth(100.0, pbc.GrowthType_GROWTH_TYPE_LINEAR, &rate, 12)
+```
+
+### Validation
+
+Always validate growth parameters before applying them:
+
+```go
+rate := 0.10
+err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_LINEAR, &rate)
+if err != nil {
+    // Handle validation error
+}
+```
+
+**Validation Rules:**
+
+- `LINEAR` or `EXPONENTIAL` require a non-nil growth rate
+- Growth rate must be >= -1.0 (rates below -100% would result in negative costs)
+- `NONE` and `UNSPECIFIED` are always valid (rate is ignored)
+
+### Parameter Resolution
+
+When merging request-level overrides with resource-level defaults:
+
+```go
+// Request-level parameters override resource-level defaults
+effectiveType, effectiveRate := pricing.ResolveGrowthParams(
+    requestGrowthType, requestRate,   // Request-level (overrides)
+    resourceGrowthType, resourceRate, // Resource-level (defaults)
+)
+```
+
+### Warning Detection
+
+Detect potentially unrealistic growth assumptions:
+
+```go
+warnings := pricing.CheckGrowthWarnings(
+    pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+    &rate,
+    periods,
+)
+
+for _, w := range warnings {
+    log.Warn().
+        Str("code", w.Code).
+        Str("message", w.Message).
+        Float64("rate", w.Rate).
+        Int("periods", w.Periods).
+        Msg("growth warning")
+}
+```
+
+**Warning Codes:**
+
+| Code | Condition | Description |
+|------|-----------|-------------|
+| `OVERFLOW_RISK` | calculation would overflow | Projection would result in +Inf (requires `CheckGrowthWarningsWithCost`) |
+| `HIGH_GROWTH_RATE` | rate > 1.0 (>100%) | Hyper-growth may be unrealistic |
+| `LONG_PROJECTION` | exponential + periods > 36 | Long-term projections become unreliable |
+
+**Convenience Functions:**
+
+```go
+if pricing.IsHighGrowthRate(rate) {
+    // Log warning about high growth rate
+}
+
+if pricing.IsLongProjection(pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, periods) {
+    // Log warning about long projection
+}
+```
+
+## Constants
+
+The package exports constants for threshold values:
+
+```go
+const (
+    HighGrowthRateThreshold = 1.0   // 100% per period
+    LongProjectionThreshold = 36    // months
+    MinValidGrowthRate      = -1.0  // -100% (minimum allowed)
+)
+```
+
+## Error Handling
+
+```go
+var (
+    ErrMissingGrowthRate = errors.New("growth_rate required for LINEAR/EXPONENTIAL growth type")
+    ErrInvalidGrowthRate = errors.New("growth_rate must be >= -1.0")
+    ErrOverflow          = errors.New("growth projection resulted in overflow")
+)
+```
+
+Check for specific errors:
+
+```go
+// Validation errors
+err := pricing.ValidateGrowthParams(growthType, rate)
+if errors.Is(err, pricing.ErrMissingGrowthRate) {
+    // Handle missing rate for LINEAR/EXPONENTIAL
+}
+if errors.Is(err, pricing.ErrInvalidGrowthRate) {
+    // Handle rate below -1.0
+}
+
+// Overflow errors (from ProjectCostSafely)
+cost, warnings, err := pricing.ProjectCostSafely(baseCost, growthType, rate, periods)
+if errors.Is(err, pricing.ErrOverflow) {
+    // Handle overflow - projection would result in +Inf
+}
+```
+
+## Safe Projections
+
+For production use, prefer `ProjectCostSafely` which combines validation, overflow detection, and warning checks:
+
+```go
+cost, warnings, err := pricing.ProjectCostSafely(
+    baseCost,
+    pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+    &rate,
+    periods,
+)
+if err != nil {
+    if errors.Is(err, pricing.ErrOverflow) {
+        // Handle overflow - projection would result in +Inf
+    }
+    // Handle other validation errors
+}
+for _, w := range warnings {
+    log.Warn().Str("code", w.Code).Msg(w.Message)
+}
+```
+
+### Overflow Detection
+
+Check for potential overflow before calculation:
+
+```go
+if pricing.CheckOverflowRisk(baseCost, growthType, &rate, periods) {
+    // Don't perform calculation - it would overflow
+}
+
+// Or use CheckGrowthWarningsWithCost for OVERFLOW_RISK warning
+warnings := pricing.CheckGrowthWarningsWithCost(baseCost, growthType, &rate, periods)
+for _, w := range warnings {
+    if w.Code == "OVERFLOW_RISK" {
+        // Handle overflow risk
+    }
+}
+```
+
+## Troubleshooting
+
+### Why am I getting +Inf results?
+
+Overflow to `+Inf` occurs when the projected cost exceeds `math.MaxFloat64` (~1.8×10^308).
+
+**Common causes:**
+
+1. **Extreme growth rates**: Rates like 100.0 (10000%) quickly overflow
+2. **Very long projections**: Even 10% growth over 100,000 periods overflows
+3. **Large base costs**: Starting near MaxFloat64 with any positive growth
+
+**Solutions:**
+
+- Use `CheckOverflowRisk()` to detect overflow before calculation
+- Use `ProjectCostSafely()` which returns `ErrOverflow` instead of +Inf
+- Cap projection periods to realistic values (e.g., 120 months = 10 years)
+
+### Can I use negative growth rates?
+
+Yes, negative rates model cost decline. Valid range is >= -1.0:
+
+```go
+// 10% decline per period
+rate := -0.10
+cost := pricing.ApplyExponentialGrowth(100.0, rate, 12)
+// Result: 100 * (0.90)^12 = $28.24
+
+// Complete decline to zero
+rate := -1.0
+cost := pricing.ApplyExponentialGrowth(100.0, rate, 1)
+// Result: 100 * (0)^1 = $0
+```
+
+**Rates below -1.0 are invalid** (would produce negative costs) and will fail validation.
+
+### What happens with negative periods?
+
+Negative periods are mathematically valid and produce "backprojection" results:
+
+- **Linear**: `100 * (1 + 0.10 * -5) = 50` (projects backward)
+- **Exponential**: `100 * (1.10)^-5 = 62.09` (fractional multiplier)
+
+This can be useful for calculating what costs were in past periods. If negative periods don't
+make sense for your use case, validate `periods >= 0` in your application.
+
+### How do I detect unrealistic projections?
+
+Use `CheckGrowthWarnings` or `CheckGrowthWarningsWithCost`:
+
+```go
+warnings := pricing.CheckGrowthWarningsWithCost(baseCost, growthType, &rate, periods)
+for _, w := range warnings {
+    switch w.Code {
+    case "OVERFLOW_RISK":
+        // Projection would overflow to +Inf
+    case "HIGH_GROWTH_RATE":
+        // Rate exceeds 100% per period
+    case "LONG_PROJECTION":
+        // Exponential over 36 months
+    }
+}
+```
+
+## Billing Mode Validation
+
+```go
+if pricing.ValidBillingMode("per_hour") {
+    // Valid billing mode
+}
+
+// Get all supported billing modes
+modes := pricing.GetAllBillingModes()
+```
+
+**Supported Categories:**
+
+- **Time-based**: per_hour, per_minute, per_second, per_day, per_month, per_year
+- **Storage-based**: per_gb_month, per_gb_hour, per_gb_day
+- **Usage-based**: per_request, per_operation, per_transaction, per_invocation
+- **Compute-based**: per_cpu_hour, per_vcpu_hour, per_memory_gb_hour
+- **Database-specific**: per_rcu, per_wcu, per_dtu, per_ru
+- **Pricing models**: on_demand, reserved, spot, savings_plan
+
+## PricingSpec Validation
+
+Validate JSON documents against the embedded pricing spec schema:
+
+```go
+jsonData := []byte(`{
+    "provider": "aws",
+    "resource_type": "ec2",
+    "billing_mode": "per_hour",
+    "rate_per_unit": 0.10,
+    "currency": "USD"
+}`)
+
+err := pricing.ValidatePricingSpec(jsonData)
+if err != nil {
+    // Handle validation error
+}
+```
+
+## Performance
+
+| Operation | Time | Allocations |
+|-----------|------|-------------|
+| ApplyLinearGrowth | <5 ns/op | 0 B/op |
+| ApplyExponentialGrowth | <30 ns/op | 0 B/op |
+| ApplyGrowth | <35 ns/op | 0 B/op |
+| ValidateGrowthParams | <10 ns/op | 0 B/op |
+| CheckOverflowRisk | <50 ns/op | 0 B/op |
+| CheckGrowthWarnings | <200 ns/op | ~100 B/op (when warnings returned) |
+| ProjectCostSafely | <300 ns/op | ~100 B/op (when warnings returned) |
+
+## References
+
+- [GrowthType Proto Definition](../../../proto/pulumicost/v1/enums.proto)
+- [ResourceDescriptor Proto](../../../proto/pulumicost/v1/costsource.proto)
+- [Forecasting Primitives Spec](../../../specs/030-forecasting-primitives/)

--- a/sdk/go/pricing/growth.go
+++ b/sdk/go/pricing/growth.go
@@ -1,0 +1,437 @@
+// Package pricing provides domain types and validation for PulumiCost pricing specifications.
+package pricing
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// Growth thresholds and limits.
+const (
+	// HighGrowthRateThreshold is the rate above which warnings are generated (100% per period).
+	// Rates exceeding this may indicate unrealistic hyper-growth assumptions.
+	HighGrowthRateThreshold = 1.0
+
+	// LongProjectionThreshold is the number of periods (months) above which warnings are
+	// generated for exponential growth. Projections beyond this become increasingly unreliable.
+	LongProjectionThreshold = 36
+
+	// MinValidGrowthRate is the minimum allowed growth rate (-100%).
+	// Rates below this would result in negative costs, which is invalid.
+	MinValidGrowthRate = -1.0
+)
+
+// Growth validation errors.
+var (
+	// ErrMissingGrowthRate is returned when LINEAR or EXPONENTIAL growth type is specified
+	// without a growth_rate value.
+	ErrMissingGrowthRate = errors.New("growth_rate required for LINEAR/EXPONENTIAL growth type")
+
+	// ErrInvalidGrowthRate is returned when growth_rate is less than -1.0,
+	// which would result in negative costs.
+	ErrInvalidGrowthRate = errors.New("growth_rate must be >= -1.0")
+)
+
+// ApplyLinearGrowth calculates the cost at period n using linear growth.
+// Formula: cost_at_n = baseCost * (1 + rate * n)
+//
+// Parameters:
+//   - baseCost: The starting cost (e.g., current monthly cost)
+//   - rate: Growth rate as a decimal fraction (e.g., 0.10 for 10%)
+//   - periods: Number of periods (e.g., months) to project
+//
+// Returns the projected cost at period n.
+//
+// Example:
+//
+//	base=$100, rate=0.10, periods=3
+//	Period 0: $100 * (1 + 0.10 * 0) = $100.00
+//	Period 1: $100 * (1 + 0.10 * 1) = $110.00
+//	Period 2: $100 * (1 + 0.10 * 2) = $120.00
+//	Period 3: $100 * (1 + 0.10 * 3) = $130.00
+func ApplyLinearGrowth(baseCost, rate float64, periods int) float64 {
+	return baseCost * (1 + rate*float64(periods))
+}
+
+// ApplyExponentialGrowth calculates the cost at period n using exponential (compounding) growth.
+// Formula: cost_at_n = baseCost * (1 + rate)^n
+//
+// Parameters:
+//   - baseCost: The starting cost (e.g., current monthly cost)
+//   - rate: Growth rate as a decimal fraction (e.g., 0.05 for 5%)
+//   - periods: Number of periods (e.g., months) to project
+//
+// Returns the projected cost at period n.
+//
+// Example:
+//
+//	base=$100, rate=0.10, periods=3
+//	Period 0: $100 * (1.10)^0 = $100.00
+//	Period 1: $100 * (1.10)^1 = $110.00
+//	Period 2: $100 * (1.10)^2 = $121.00
+//	Period 3: $100 * (1.10)^3 = $133.10
+func ApplyExponentialGrowth(baseCost, rate float64, periods int) float64 {
+	return baseCost * math.Pow(1+rate, float64(periods))
+}
+
+// ApplyGrowth calculates the projected cost based on the growth type.
+// This is a convenience function that dispatches to the appropriate growth function.
+//
+// Parameters:
+//   - baseCost: The starting cost
+//   - growthType: The type of growth model to apply
+//   - rate: Growth rate (pointer, nil treated as 0)
+//   - periods: Number of periods to project
+//
+// For GROWTH_TYPE_NONE or GROWTH_TYPE_UNSPECIFIED, returns the base cost unchanged.
+// For GROWTH_TYPE_LINEAR, applies linear growth formula.
+// For GROWTH_TYPE_EXPONENTIAL, applies exponential growth formula.
+func ApplyGrowth(baseCost float64, growthType pbc.GrowthType, rate *float64, periods int) float64 {
+	// Handle nil rate as 0 (no growth)
+	r := 0.0
+	if rate != nil {
+		r = *rate
+	}
+
+	switch growthType {
+	case pbc.GrowthType_GROWTH_TYPE_LINEAR:
+		return ApplyLinearGrowth(baseCost, r, periods)
+	case pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL:
+		return ApplyExponentialGrowth(baseCost, r, periods)
+	case pbc.GrowthType_GROWTH_TYPE_NONE, pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED:
+		return baseCost
+	default:
+		// Unknown growth type - return base cost unchanged
+		return baseCost
+	}
+}
+
+// ResolveGrowthType returns the effective growth type, treating UNSPECIFIED as NONE.
+// This ensures consistent default behavior across the codebase.
+func ResolveGrowthType(gt pbc.GrowthType) pbc.GrowthType {
+	if gt == pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED {
+		return pbc.GrowthType_GROWTH_TYPE_NONE
+	}
+	return gt
+}
+
+// ResolveGrowthParams merges request-level growth parameters with resource-level defaults.
+// Request-level parameters take precedence when set.
+//
+// Parameters:
+//   - reqType: Growth type from request (overrides if not UNSPECIFIED)
+//   - reqRate: Growth rate from request (overrides if not nil)
+//   - resType: Default growth type from resource
+//   - resRate: Default growth rate from resource
+//
+// Returns the effective growth type and rate to use.
+func ResolveGrowthParams(
+	reqType pbc.GrowthType, reqRate *float64,
+	resType pbc.GrowthType, resRate *float64,
+) (pbc.GrowthType, *float64) {
+	// Start with resource defaults
+	effectiveType := resType
+	effectiveRate := resRate
+
+	// Override with request-level values if set
+	if reqType != pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED {
+		effectiveType = reqType
+	}
+	if reqRate != nil {
+		effectiveRate = reqRate
+	}
+
+	// Normalize UNSPECIFIED to NONE
+	effectiveType = ResolveGrowthType(effectiveType)
+
+	return effectiveType, effectiveRate
+}
+
+// ValidateGrowthParams validates the growth_type and growth_rate combination.
+// Returns an error if the parameters are invalid:
+//   - LINEAR or EXPONENTIAL without growth_rate: returns ErrMissingGrowthRate
+//   - growth_rate < -1.0: returns ErrInvalidGrowthRate
+//   - NONE or UNSPECIFIED: always valid (rate is ignored if present)
+//
+// This function is designed for use in plugin implementations to validate
+// incoming requests before processing.
+func ValidateGrowthParams(growthType pbc.GrowthType, growthRate *float64) error {
+	// Check if rate is required but missing
+	if growthType == pbc.GrowthType_GROWTH_TYPE_LINEAR ||
+		growthType == pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL {
+		if growthRate == nil {
+			return fmt.Errorf("%w: %s", ErrMissingGrowthRate, growthType.String())
+		}
+	}
+
+	// Check if rate is in valid range (if provided)
+	if growthRate != nil && *growthRate < MinValidGrowthRate {
+		return fmt.Errorf("%w: got %.4f (minimum allowed: %.1f)", ErrInvalidGrowthRate, *growthRate, MinValidGrowthRate)
+	}
+
+	return nil
+}
+
+// GrowthWarning represents a warning condition for growth parameter usage.
+type GrowthWarning struct {
+	Code    string
+	Message string
+	Rate    float64
+	Periods int
+}
+
+// CheckGrowthWarnings examines growth parameters and returns any warnings.
+// These are non-fatal conditions that may indicate unrealistic projections.
+//
+// Warnings are returned for:
+//   - High growth rate (>100% per period): May indicate hyper-growth assumptions
+//   - Long exponential projections (>36 months): Results become increasingly unreliable
+//
+// Note: For overflow detection, use CheckGrowthWarningsWithCost which includes
+// OVERFLOW_RISK warnings when baseCost is provided.
+func CheckGrowthWarnings(growthType pbc.GrowthType, growthRate *float64, periods int) []GrowthWarning {
+	return checkGrowthWarningsInternal(0, growthType, growthRate, periods, false)
+}
+
+// CheckGrowthWarningsWithCost examines growth parameters including baseCost and returns warnings.
+// This extended version includes OVERFLOW_RISK detection in addition to standard warnings.
+//
+// Warnings are returned for:
+//   - OVERFLOW_RISK: Calculation would overflow to +Inf
+//   - HIGH_GROWTH_RATE: Rate exceeds 100% per period
+//   - LONG_PROJECTION: Exponential projection over 36 months
+func CheckGrowthWarningsWithCost(
+	baseCost float64,
+	growthType pbc.GrowthType,
+	growthRate *float64,
+	periods int,
+) []GrowthWarning {
+	return checkGrowthWarningsInternal(baseCost, growthType, growthRate, periods, true)
+}
+
+// checkGrowthWarningsInternal is the shared implementation for warning checks.
+// Optimized to count warnings first, then allocate slice with exact capacity.
+func checkGrowthWarningsInternal(
+	baseCost float64,
+	growthType pbc.GrowthType,
+	growthRate *float64,
+	periods int,
+	checkOverflow bool,
+) []GrowthWarning {
+	// Check conditions and count warnings first to avoid reallocation
+	hasOverflowRisk := checkOverflow && CheckOverflowRisk(baseCost, growthType, growthRate, periods)
+
+	// Early return if no rate - only overflow warning possible
+	if growthRate == nil {
+		if hasOverflowRisk {
+			return []GrowthWarning{{
+				Code: "OVERFLOW_RISK",
+				Message: fmt.Sprintf(
+					"projection with baseCost=%.2f, rate=0.0000, periods=%d would overflow to +Inf",
+					baseCost,
+					periods,
+				),
+				Rate:    0,
+				Periods: periods,
+			}}
+		}
+		return nil
+	}
+
+	rate := *growthRate
+	hasHighGrowth := rate > HighGrowthRateThreshold
+	hasLongProjection := growthType == pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL && periods > LongProjectionThreshold
+
+	// Count warnings to allocate exact capacity
+	count := 0
+	if hasOverflowRisk {
+		count++
+	}
+	if hasHighGrowth {
+		count++
+	}
+	if hasLongProjection {
+		count++
+	}
+
+	// No warnings - return nil (zero allocation)
+	if count == 0 {
+		return nil
+	}
+
+	// Allocate slice with exact capacity
+	warnings := make([]GrowthWarning, 0, count)
+
+	// Add warnings in order
+	if hasOverflowRisk {
+		warnings = append(warnings, GrowthWarning{
+			Code: "OVERFLOW_RISK",
+			Message: fmt.Sprintf(
+				"projection with baseCost=%.2f, rate=%.4f, periods=%d would overflow to +Inf",
+				baseCost,
+				rate,
+				periods,
+			),
+			Rate:    rate,
+			Periods: periods,
+		})
+	}
+
+	const percentMultiplier = 100.0
+	if hasHighGrowth {
+		warnings = append(warnings, GrowthWarning{
+			Code: "HIGH_GROWTH_RATE",
+			Message: fmt.Sprintf(
+				"growth_rate %.2f (%.0f%%) exceeds 100%% per period - verify assumptions",
+				rate,
+				rate*percentMultiplier,
+			),
+			Rate:    rate,
+			Periods: periods,
+		})
+	}
+
+	if hasLongProjection {
+		multiplier := math.Pow(1+rate, float64(periods))
+		warnings = append(warnings, GrowthWarning{
+			Code: "LONG_PROJECTION",
+			Message: fmt.Sprintf(
+				"exponential projection over %d periods results in %.1fx multiplier - results may be unreliable",
+				periods,
+				multiplier,
+			),
+			Rate:    rate,
+			Periods: periods,
+		})
+	}
+
+	return warnings
+}
+
+// IsHighGrowthRate returns true if the rate exceeds HighGrowthRateThreshold (100% per period).
+// This is a convenience function for checking if a warning log should be emitted.
+func IsHighGrowthRate(rate float64) bool {
+	return rate > HighGrowthRateThreshold
+}
+
+// IsLongProjection returns true if exponential growth is projected over LongProjectionThreshold months.
+// This is a convenience function for checking if a warning log should be emitted.
+func IsLongProjection(growthType pbc.GrowthType, periods int) bool {
+	return growthType == pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL && periods > LongProjectionThreshold
+}
+
+// CheckOverflowRisk returns true if the growth calculation would likely overflow to +Inf.
+// This allows callers to detect potential overflow before performing the calculation.
+//
+// For exponential growth, overflow occurs when (1+rate)^periods exceeds MaxFloat64/baseCost.
+// For linear growth, overflow occurs when baseCost * rate * periods exceeds MaxFloat64.
+//
+// Parameters:
+//   - baseCost: The starting cost (must be > 0 for overflow to be possible)
+//   - growthType: The type of growth model to check
+//   - rate: Growth rate (nil is treated as 0, no overflow possible)
+//   - periods: Number of periods to project
+//
+// Returns true if overflow is likely, false otherwise.
+func CheckOverflowRisk(
+	baseCost float64,
+	growthType pbc.GrowthType,
+	rate *float64,
+	periods int,
+) bool {
+	// No risk for no-growth types or non-positive base/periods
+	if growthType == pbc.GrowthType_GROWTH_TYPE_NONE ||
+		growthType == pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED {
+		return false
+	}
+
+	if baseCost <= 0 || periods <= 0 || rate == nil {
+		return false
+	}
+
+	r := *rate
+	if r <= 0 {
+		// Negative or zero growth cannot overflow
+		return false
+	}
+
+	switch growthType {
+	case pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL:
+		// Overflow when: baseCost * (1+r)^periods > MaxFloat64
+		// Rearranged: periods > log(MaxFloat64/baseCost) / log(1+r)
+		if baseCost >= math.MaxFloat64 {
+			return true // Already at max
+		}
+		logBase := math.Log(1 + r)
+		if logBase <= 0 {
+			return false // Rate near 0, won't overflow
+		}
+		maxSafePeriods := math.Log(math.MaxFloat64/baseCost) / logBase
+		return float64(periods) > maxSafePeriods
+
+	case pbc.GrowthType_GROWTH_TYPE_LINEAR:
+		// Overflow when: baseCost * (1 + r * periods) > MaxFloat64
+		// Rearranged: baseCost * r * periods > MaxFloat64 - baseCost
+		if baseCost >= math.MaxFloat64 {
+			return true // Already at max
+		}
+		// Check if the multiplication would overflow
+		// baseCost * r * periods
+		product := baseCost * r * float64(periods)
+		return math.IsInf(product, 1) || product > math.MaxFloat64-baseCost
+
+	case pbc.GrowthType_GROWTH_TYPE_NONE, pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED:
+		// No growth types never overflow
+		return false
+	}
+
+	return false
+}
+
+// ErrOverflow is returned when a growth projection would overflow to +Inf or NaN.
+var ErrOverflow = errors.New("growth projection resulted in overflow")
+
+// ProjectCostSafely calculates projected cost with built-in validation and warning checks.
+// This is a convenience function that combines validation, overflow detection, and calculation.
+//
+// Unlike ApplyGrowth, this function:
+//   - Validates growth parameters before calculation
+//   - Checks for overflow risk and returns ErrOverflow instead of +Inf
+//   - Returns any growth warnings detected
+//
+// Returns:
+//   - cost: The projected cost (0 if validation/overflow fails)
+//   - warnings: Any growth warnings detected (may be nil)
+//   - err: Validation or overflow errors (nil on success)
+func ProjectCostSafely(
+	baseCost float64,
+	growthType pbc.GrowthType,
+	rate *float64,
+	periods int,
+) (float64, []GrowthWarning, error) {
+	// Validate parameters first
+	if validErr := ValidateGrowthParams(growthType, rate); validErr != nil {
+		return 0, nil, validErr
+	}
+
+	// Collect warnings
+	warnings := CheckGrowthWarnings(growthType, rate, periods)
+
+	// Check for overflow risk before calculation
+	if CheckOverflowRisk(baseCost, growthType, rate, periods) {
+		return 0, warnings, ErrOverflow
+	}
+
+	// Perform the calculation
+	cost := ApplyGrowth(baseCost, growthType, rate, periods)
+
+	// Final check for unexpected overflow/NaN (shouldn't happen if CheckOverflowRisk is accurate)
+	if math.IsInf(cost, 0) || math.IsNaN(cost) {
+		return 0, warnings, ErrOverflow
+	}
+
+	return cost, warnings, nil
+}

--- a/sdk/go/pricing/growth_test.go
+++ b/sdk/go/pricing/growth_test.go
@@ -1,0 +1,983 @@
+package pricing_test
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pricing"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+const tolerance = 0.0001
+
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) <= tolerance*math.Max(math.Abs(a), math.Abs(b))
+}
+
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
+func TestApplyLinearGrowth(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseCost float64
+		rate     float64
+		periods  int
+		expected float64
+	}{
+		{"No growth", 100, 0, 3, 100},
+		{"10% linear 3 periods", 100, 0.10, 3, 130},
+		{"5% linear 12 periods", 100, 0.05, 12, 160},
+		{"Zero base cost", 0, 0.10, 5, 0},
+		{"One period", 100, 0.10, 1, 110},
+		{"Zero periods", 100, 0.10, 0, 100},
+		{"Negative rate", 100, -0.10, 3, 70},
+		{"High rate", 100, 2.0, 3, 700},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyLinearGrowth(tt.baseCost, tt.rate, tt.periods)
+			if !almostEqual(result, tt.expected) {
+				t.Errorf("ApplyLinearGrowth(%v, %v, %d) = %v, want %v",
+					tt.baseCost, tt.rate, tt.periods, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyExponentialGrowth(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseCost float64
+		rate     float64
+		periods  int
+		expected float64
+	}{
+		{"No growth", 100, 0, 3, 100},
+		{"10% exponential 3 periods", 100, 0.10, 3, 133.1},
+		{"5% exponential 12 periods", 100, 0.05, 12, 179.5856},
+		{"Zero base cost", 0, 0.10, 5, 0},
+		{"One period", 100, 0.10, 1, 110},
+		{"Zero periods", 100, 0.10, 0, 100},
+		{"Negative rate", 100, -0.10, 3, 72.9},
+		{"High rate", 100, 2.0, 3, 2700},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyExponentialGrowth(tt.baseCost, tt.rate, tt.periods)
+			if !almostEqual(result, tt.expected) {
+				t.Errorf("ApplyExponentialGrowth(%v, %v, %d) = %v, want %v",
+					tt.baseCost, tt.rate, tt.periods, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyGrowth(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseCost   float64
+		growthType pbc.GrowthType
+		rate       *float64
+		periods    int
+		expected   float64
+	}{
+		{"LINEAR with rate", 100, pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.10), 3, 130},
+		{"EXPONENTIAL with rate", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.10), 3, 133.1},
+		{"NONE with rate", 100, pbc.GrowthType_GROWTH_TYPE_NONE, floatPtr(0.10), 3, 100},
+		{"UNSPECIFIED with rate", 100, pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, floatPtr(0.10), 3, 100},
+		{"LINEAR with nil rate", 100, pbc.GrowthType_GROWTH_TYPE_LINEAR, nil, 3, 100},
+		{"EXPONENTIAL with nil rate", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, nil, 3, 100},
+		{"NONE with nil rate", 100, pbc.GrowthType_GROWTH_TYPE_NONE, nil, 3, 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyGrowth(tt.baseCost, tt.growthType, tt.rate, tt.periods)
+			if !almostEqual(result, tt.expected) {
+				t.Errorf("ApplyGrowth(%v, %v, %v, %d) = %v, want %v",
+					tt.baseCost, tt.growthType, tt.rate, tt.periods, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveGrowthType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    pbc.GrowthType
+		expected pbc.GrowthType
+	}{
+		{"UNSPECIFIED becomes NONE", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, pbc.GrowthType_GROWTH_TYPE_NONE},
+		{"NONE stays NONE", pbc.GrowthType_GROWTH_TYPE_NONE, pbc.GrowthType_GROWTH_TYPE_NONE},
+		{"LINEAR stays LINEAR", pbc.GrowthType_GROWTH_TYPE_LINEAR, pbc.GrowthType_GROWTH_TYPE_LINEAR},
+		{
+			"EXPONENTIAL stays EXPONENTIAL",
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ResolveGrowthType(tt.input)
+			if result != tt.expected {
+				t.Errorf("ResolveGrowthType(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestResolveGrowthParams(t *testing.T) {
+	tests := []struct {
+		name         string
+		reqType      pbc.GrowthType
+		reqRate      *float64
+		resType      pbc.GrowthType
+		resRate      *float64
+		expectedType pbc.GrowthType
+		expectedRate *float64
+	}{
+		{
+			name:         "Request overrides resource type",
+			reqType:      pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			reqRate:      nil,
+			resType:      pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			resRate:      floatPtr(0.10),
+			expectedType: pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			expectedRate: floatPtr(0.10),
+		},
+		{
+			name:         "Request overrides resource rate",
+			reqType:      pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED,
+			reqRate:      floatPtr(0.20),
+			resType:      pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			resRate:      floatPtr(0.10),
+			expectedType: pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			expectedRate: floatPtr(0.20),
+		},
+		{
+			name:         "Request overrides both",
+			reqType:      pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			reqRate:      floatPtr(0.25),
+			resType:      pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			resRate:      floatPtr(0.10),
+			expectedType: pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			expectedRate: floatPtr(0.25),
+		},
+		{
+			name:         "Use resource defaults",
+			reqType:      pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED,
+			reqRate:      nil,
+			resType:      pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			resRate:      floatPtr(0.10),
+			expectedType: pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			expectedRate: floatPtr(0.10),
+		},
+		{
+			name:         "Both unspecified becomes NONE",
+			reqType:      pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED,
+			reqRate:      nil,
+			resType:      pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED,
+			resRate:      nil,
+			expectedType: pbc.GrowthType_GROWTH_TYPE_NONE,
+			expectedRate: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resultType, resultRate := pricing.ResolveGrowthParams(tt.reqType, tt.reqRate, tt.resType, tt.resRate)
+
+			if resultType != tt.expectedType {
+				t.Errorf("ResolveGrowthParams type = %v, want %v", resultType, tt.expectedType)
+			}
+
+			if tt.expectedRate == nil && resultRate != nil {
+				t.Errorf("ResolveGrowthParams rate = %v, want nil", *resultRate)
+			}
+			if tt.expectedRate != nil && resultRate == nil {
+				t.Errorf("ResolveGrowthParams rate = nil, want %v", *tt.expectedRate)
+			}
+			if tt.expectedRate != nil && resultRate != nil && *resultRate != *tt.expectedRate {
+				t.Errorf("ResolveGrowthParams rate = %v, want %v", *resultRate, *tt.expectedRate)
+			}
+		})
+	}
+}
+
+func BenchmarkApplyLinearGrowth(b *testing.B) {
+	for range b.N {
+		_ = pricing.ApplyLinearGrowth(100.0, 0.10, 12)
+	}
+}
+
+func BenchmarkApplyExponentialGrowth(b *testing.B) {
+	for range b.N {
+		_ = pricing.ApplyExponentialGrowth(100.0, 0.10, 12)
+	}
+}
+
+func BenchmarkApplyGrowth(b *testing.B) {
+	rate := floatPtr(0.10)
+	for range b.N {
+		_ = pricing.ApplyGrowth(100.0, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, rate, 12)
+	}
+}
+
+func BenchmarkResolveGrowthParams(b *testing.B) {
+	reqRate := floatPtr(0.20)
+	resRate := floatPtr(0.10)
+	for range b.N {
+		_, _ = pricing.ResolveGrowthParams(
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, reqRate,
+			pbc.GrowthType_GROWTH_TYPE_LINEAR, resRate,
+		)
+	}
+}
+
+func TestValidateGrowthParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		growthType pbc.GrowthType
+		rate       *float64
+		wantErr    bool
+		errType    error
+	}{
+		// Valid cases
+		{"UNSPECIFIED nil", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, nil, false, nil},
+		{"NONE nil", pbc.GrowthType_GROWTH_TYPE_NONE, nil, false, nil},
+		{"LINEAR with rate", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.10), false, nil},
+		{"EXPONENTIAL with rate", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.05), false, nil},
+		{"LINEAR with zero rate", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.0), false, nil},
+		{"LINEAR with -1.0 rate", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(-1.0), false, nil},
+
+		// Invalid: missing rate
+		{"LINEAR nil rate", pbc.GrowthType_GROWTH_TYPE_LINEAR, nil, true, pricing.ErrMissingGrowthRate},
+		{"EXPONENTIAL nil rate", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, nil, true, pricing.ErrMissingGrowthRate},
+
+		// Invalid: rate too low
+		{"LINEAR rate < -1.0", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(-1.5), true, pricing.ErrInvalidGrowthRate},
+		{
+			"EXPONENTIAL rate < -1.0",
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(-2.0),
+			true,
+			pricing.ErrInvalidGrowthRate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pricing.ValidateGrowthParams(tt.growthType, tt.rate)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateGrowthParams() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.errType != nil && err != nil {
+				if !errors.Is(err, tt.errType) {
+					t.Errorf("ValidateGrowthParams() error type = %v, want %v", err, tt.errType)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkValidateGrowthParams(b *testing.B) {
+	rate := floatPtr(0.10)
+	for range b.N {
+		_ = pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_LINEAR, rate)
+	}
+}
+
+func TestCheckGrowthWarnings(t *testing.T) {
+	tests := []struct {
+		name          string
+		growthType    pbc.GrowthType
+		growthRate    *float64
+		periods       int
+		expectedCodes []string
+	}{
+		{"Nil rate returns no warnings", pbc.GrowthType_GROWTH_TYPE_LINEAR, nil, 12, []string{}},
+		{"Normal rate no warnings", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.10), 12, []string{}},
+		{"High rate warning", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(1.5), 12, []string{"HIGH_GROWTH_RATE"}},
+		{"200% rate warning", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(2.0), 12, []string{"HIGH_GROWTH_RATE"}},
+		{
+			"Long projection warning",
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(0.05),
+			48,
+			[]string{"LONG_PROJECTION"},
+		},
+		{
+			"Both warnings",
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(2.0),
+			48,
+			[]string{"HIGH_GROWTH_RATE", "LONG_PROJECTION"},
+		},
+		{"Linear long projection no warning", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.05), 48, []string{}},
+		{"Exactly 36 periods no warning", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.05), 36, []string{}},
+		{"37 periods warning", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.05), 37, []string{"LONG_PROJECTION"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := pricing.CheckGrowthWarnings(tt.growthType, tt.growthRate, tt.periods)
+
+			if len(warnings) != len(tt.expectedCodes) {
+				t.Errorf(
+					"CheckGrowthWarnings() returned %d warnings, want %d",
+					len(warnings),
+					len(tt.expectedCodes),
+				)
+				return
+			}
+
+			for i, expectedCode := range tt.expectedCodes {
+				if warnings[i].Code != expectedCode {
+					t.Errorf("Warning[%d].Code = %s, want %s", i, warnings[i].Code, expectedCode)
+				}
+			}
+		})
+	}
+}
+
+func TestIsHighGrowthRate(t *testing.T) {
+	tests := []struct {
+		name     string
+		rate     float64
+		expected bool
+	}{
+		{"Zero rate", 0.0, false},
+		{"10% rate", 0.10, false},
+		{"100% rate boundary", 1.0, false},
+		{"Just over 100%", 1.01, true},
+		{"200% rate", 2.0, true},
+		{"Negative rate", -0.5, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.IsHighGrowthRate(tt.rate)
+			if result != tt.expected {
+				t.Errorf("IsHighGrowthRate(%v) = %v, want %v", tt.rate, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsLongProjection(t *testing.T) {
+	tests := []struct {
+		name       string
+		growthType pbc.GrowthType
+		periods    int
+		expected   bool
+	}{
+		{"Linear 12 periods", pbc.GrowthType_GROWTH_TYPE_LINEAR, 12, false},
+		{"Linear 48 periods", pbc.GrowthType_GROWTH_TYPE_LINEAR, 48, false},
+		{"Exponential 12 periods", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, 12, false},
+		{"Exponential 36 periods boundary", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, 36, false},
+		{"Exponential 37 periods", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, 37, true},
+		{"Exponential 48 periods", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, 48, true},
+		{"None 48 periods", pbc.GrowthType_GROWTH_TYPE_NONE, 48, false},
+		{"Unspecified 48 periods", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, 48, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.IsLongProjection(tt.growthType, tt.periods)
+			if result != tt.expected {
+				t.Errorf("IsLongProjection(%v, %d) = %v, want %v", tt.growthType, tt.periods, result, tt.expected)
+			}
+		})
+	}
+}
+
+func BenchmarkCheckGrowthWarnings(b *testing.B) {
+	rate := floatPtr(2.0)
+	for range b.N {
+		_ = pricing.CheckGrowthWarnings(pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, rate, 48)
+	}
+}
+
+func BenchmarkCheckGrowthWarningsNoWarnings(b *testing.B) {
+	rate := floatPtr(0.10) // Normal rate, no warnings
+	for range b.N {
+		_ = pricing.CheckGrowthWarnings(pbc.GrowthType_GROWTH_TYPE_LINEAR, rate, 12)
+	}
+}
+
+// TestExponentialGrowthOverflow documents behavior with extreme values that cause float64 overflow.
+// This is important for understanding edge cases in production systems.
+func TestExponentialGrowthOverflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseCost float64
+		rate     float64
+		periods  int
+		checkInf bool // whether to verify result is +Inf
+	}{
+		{
+			name:     "extreme rate causes overflow",
+			baseCost: 100.0,
+			rate:     100.0, // 10000% growth per period
+			periods:  1000,
+			checkInf: true,
+		},
+		{
+			name:     "large periods cause overflow",
+			baseCost: 100.0,
+			rate:     0.10,   // 10% growth
+			periods:  100000, // very long projection
+			checkInf: true,
+		},
+		{
+			name:     "max float64 base with any growth overflows",
+			baseCost: math.MaxFloat64,
+			rate:     0.01,
+			periods:  1,
+			checkInf: true,
+		},
+		{
+			name:     "realistic high growth does not overflow",
+			baseCost: 1000000.0, // $1M
+			rate:     0.50,      // 50% annual growth
+			periods:  120,       // 10 years monthly
+			checkInf: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyExponentialGrowth(tt.baseCost, tt.rate, tt.periods)
+
+			if tt.checkInf {
+				if !math.IsInf(result, 1) {
+					t.Errorf("Expected +Inf for extreme values, got %v", result)
+				}
+				t.Logf("Confirmed overflow to +Inf: baseCost=%v, rate=%v, periods=%d",
+					tt.baseCost, tt.rate, tt.periods)
+			} else if math.IsInf(result, 0) || math.IsNaN(result) {
+				t.Errorf("Unexpected overflow for realistic values: got %v", result)
+			}
+		})
+	}
+}
+
+// TestLinearGrowthOverflow documents behavior with extreme values for linear growth.
+func TestLinearGrowthOverflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseCost float64
+		rate     float64
+		periods  int
+		checkInf bool
+	}{
+		{
+			name:     "extreme rate and periods causes overflow",
+			baseCost: 1e300,   // very large base
+			rate:     1e10,    // very large rate
+			periods:  1000000, // many periods
+			checkInf: true,
+		},
+		{
+			name:     "max float64 base overflows on any positive growth",
+			baseCost: math.MaxFloat64,
+			rate:     0.01,
+			periods:  1,
+			checkInf: true,
+		},
+		{
+			name:     "realistic linear growth does not overflow",
+			baseCost: 1000000.0, // $1M
+			rate:     0.10,      // 10% linear growth
+			periods:  1200,      // 100 years monthly
+			checkInf: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyLinearGrowth(tt.baseCost, tt.rate, tt.periods)
+
+			if tt.checkInf {
+				if !math.IsInf(result, 1) {
+					t.Errorf("Expected +Inf for extreme values, got %v", result)
+				}
+			} else {
+				if math.IsInf(result, 0) || math.IsNaN(result) {
+					t.Errorf("Unexpected overflow for realistic values: got %v", result)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyGrowthWithExtremeValues tests ApplyGrowth wrapper with extreme inputs.
+func TestApplyGrowthWithExtremeValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseCost   float64
+		growthType pbc.GrowthType
+		rate       *float64
+		periods    int
+		checkInf   bool
+	}{
+		{
+			name:       "exponential overflow via ApplyGrowth",
+			baseCost:   100.0,
+			growthType: pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			rate:       floatPtr(100.0),
+			periods:    500,
+			checkInf:   true,
+		},
+		{
+			name:       "linear overflow via ApplyGrowth",
+			baseCost:   math.MaxFloat64,
+			growthType: pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			rate:       floatPtr(0.01),
+			periods:    1,
+			checkInf:   true,
+		},
+		{
+			name:       "NONE never overflows",
+			baseCost:   math.MaxFloat64,
+			growthType: pbc.GrowthType_GROWTH_TYPE_NONE,
+			rate:       floatPtr(100.0),
+			periods:    1000000,
+			checkInf:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyGrowth(tt.baseCost, tt.growthType, tt.rate, tt.periods)
+
+			if tt.checkInf {
+				if !math.IsInf(result, 1) {
+					t.Errorf("Expected +Inf for extreme values, got %v", result)
+				}
+			} else {
+				if math.IsInf(result, 0) || math.IsNaN(result) {
+					t.Errorf("Unexpected overflow: got %v", result)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckOverflowRisk(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseCost   float64
+		growthType pbc.GrowthType
+		rate       *float64
+		periods    int
+		expected   bool
+	}{
+		// No risk cases
+		{"NONE never overflows", math.MaxFloat64, pbc.GrowthType_GROWTH_TYPE_NONE, floatPtr(100.0), 1000000, false},
+		{
+			"UNSPECIFIED never overflows",
+			math.MaxFloat64,
+			pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED,
+			floatPtr(100.0),
+			1000000,
+			false,
+		},
+		{"zero base cost", 0, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(100.0), 1000, false},
+		{"negative base cost", -100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(100.0), 1000, false},
+		{"zero periods", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(100.0), 0, false},
+		{"negative periods", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(100.0), -5, false},
+		{"nil rate", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, nil, 1000, false},
+		{"zero rate", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0), 1000000, false},
+		{"negative rate", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(-0.5), 1000000, false},
+
+		// Realistic safe cases
+		{"realistic exponential safe", 1000000, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.50), 120, false},
+		{"realistic linear safe", 1000000, pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.10), 1200, false},
+
+		// Overflow cases - exponential
+		{"exponential extreme rate overflow", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(100.0), 1000, true},
+		{
+			"exponential long periods overflow",
+			100,
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(0.10),
+			100000,
+			true,
+		},
+		{
+			"exponential max base overflow",
+			math.MaxFloat64,
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(0.01),
+			1,
+			true,
+		},
+
+		// Overflow cases - linear
+		{"linear extreme values overflow", 1e300, pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(1e10), 1000000, true},
+		{"linear max base overflow", math.MaxFloat64, pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.01), 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.CheckOverflowRisk(tt.baseCost, tt.growthType, tt.rate, tt.periods)
+			if result != tt.expected {
+				t.Errorf("CheckOverflowRisk() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCheckGrowthWarningsWithCost(t *testing.T) {
+	tests := []struct {
+		name          string
+		baseCost      float64
+		growthType    pbc.GrowthType
+		growthRate    *float64
+		periods       int
+		expectedCodes []string
+	}{
+		{"No overflow normal case", 100, pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.10), 12, []string{}},
+		// 1000 periods with 100x rate overflows AND is long projection
+		{
+			"Overflow with long projection",
+			100,
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(100.0),
+			1000,
+			[]string{"OVERFLOW_RISK", "HIGH_GROWTH_RATE", "LONG_PROJECTION"},
+		},
+		// 50 periods with 100x rate: high rate + long projection but may not overflow at 50 periods
+		{
+			"High rate and long projection",
+			100,
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(2.0),
+			48,
+			[]string{"HIGH_GROWTH_RATE", "LONG_PROJECTION"},
+		},
+		// Overflow with extreme rate at boundary (>36 for long projection)
+		{
+			"Overflow extreme rate short projection",
+			100,
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(100.0),
+			200,
+			[]string{"OVERFLOW_RISK", "HIGH_GROWTH_RATE", "LONG_PROJECTION"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := pricing.CheckGrowthWarningsWithCost(tt.baseCost, tt.growthType, tt.growthRate, tt.periods)
+
+			if len(warnings) != len(tt.expectedCodes) {
+				t.Errorf(
+					"CheckGrowthWarningsWithCost() returned %d warnings, want %d",
+					len(warnings),
+					len(tt.expectedCodes),
+				)
+				for i, w := range warnings {
+					t.Logf("  warning[%d]: %s", i, w.Code)
+				}
+				return
+			}
+
+			for i, expectedCode := range tt.expectedCodes {
+				if warnings[i].Code != expectedCode {
+					t.Errorf("Warning[%d].Code = %s, want %s", i, warnings[i].Code, expectedCode)
+				}
+			}
+		})
+	}
+}
+
+func TestProjectCostSafely(t *testing.T) {
+	tests := []struct {
+		name         string
+		baseCost     float64
+		growthType   pbc.GrowthType
+		rate         *float64
+		periods      int
+		expectedCost float64
+		wantErr      bool
+		errType      error
+	}{
+		// Success cases
+		{"linear growth", 100, pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.10), 3, 130, false, nil},
+		{"exponential growth", 100, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.10), 3, 133.1, false, nil},
+		{"no growth", 100, pbc.GrowthType_GROWTH_TYPE_NONE, floatPtr(0.10), 3, 100, false, nil},
+
+		// Validation errors
+		{
+			"missing rate for LINEAR",
+			100,
+			pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			nil,
+			3,
+			0,
+			true,
+			pricing.ErrMissingGrowthRate,
+		},
+		{
+			"invalid rate below -1.0",
+			100,
+			pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			floatPtr(-1.5),
+			3,
+			0,
+			true,
+			pricing.ErrInvalidGrowthRate,
+		},
+
+		// Overflow error
+		{
+			"overflow detection",
+			100,
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(100.0),
+			1000,
+			0,
+			true,
+			pricing.ErrOverflow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cost, _, err := pricing.ProjectCostSafely(tt.baseCost, tt.growthType, tt.rate, tt.periods)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ProjectCostSafely() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.errType != nil && err != nil && !errors.Is(err, tt.errType) {
+				t.Errorf("ProjectCostSafely() error type = %v, want %v", err, tt.errType)
+			}
+
+			if !tt.wantErr && !almostEqual(cost, tt.expectedCost) {
+				t.Errorf("ProjectCostSafely() cost = %v, want %v", cost, tt.expectedCost)
+			}
+		})
+	}
+}
+
+func TestProjectCostSafelyReturnsWarnings(t *testing.T) {
+	// Test that warnings are returned even on success
+	rate := 2.0 // High growth rate
+	cost, warnings, err := pricing.ProjectCostSafely(100, pbc.GrowthType_GROWTH_TYPE_LINEAR, &rate, 48)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if cost == 0 {
+		t.Error("Expected non-zero cost")
+	}
+
+	// Should have HIGH_GROWTH_RATE warning
+	found := false
+	for _, w := range warnings {
+		if w.Code == "HIGH_GROWTH_RATE" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected HIGH_GROWTH_RATE warning")
+	}
+}
+
+func BenchmarkCheckOverflowRisk(b *testing.B) {
+	rate := floatPtr(0.10)
+	for range b.N {
+		_ = pricing.CheckOverflowRisk(100.0, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, rate, 120)
+	}
+}
+
+func BenchmarkProjectCostSafely(b *testing.B) {
+	rate := floatPtr(0.10)
+	for range b.N {
+		_, _, _ = pricing.ProjectCostSafely(100.0, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, rate, 12)
+	}
+}
+
+// TestRateBoundaryAtMinusOne verifies behavior at the exact -1.0 boundary.
+func TestRateBoundaryAtMinusOne(t *testing.T) {
+	// Rate of exactly -1.0 should be valid and produce zero cost
+	rate := -1.0
+
+	// Validate that -1.0 is accepted
+	err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_LINEAR, &rate)
+	if err != nil {
+		t.Errorf("Rate -1.0 should be valid, got error: %v", err)
+	}
+
+	// Linear: 100 * (1 + -1.0 * n) approaches 0 as n increases
+	// At n=1: 100 * (1 - 1) = 0
+	linearResult := pricing.ApplyLinearGrowth(100.0, rate, 1)
+	if linearResult != 0 {
+		t.Errorf("Linear at -1.0 rate, 1 period should be 0, got %v", linearResult)
+	}
+
+	// Exponential: 100 * (1 + -1.0)^n = 100 * 0^n = 0 for n > 0
+	expResult := pricing.ApplyExponentialGrowth(100.0, rate, 1)
+	if expResult != 0 {
+		t.Errorf("Exponential at -1.0 rate, 1 period should be 0, got %v", expResult)
+	}
+
+	// At 0 periods, both should return base cost
+	linearZero := pricing.ApplyLinearGrowth(100.0, rate, 0)
+	if linearZero != 100.0 {
+		t.Errorf("Linear at -1.0 rate, 0 periods should be 100, got %v", linearZero)
+	}
+
+	expZero := pricing.ApplyExponentialGrowth(100.0, rate, 0)
+	if expZero != 100.0 {
+		t.Errorf("Exponential at -1.0 rate, 0 periods should be 100, got %v", expZero)
+	}
+}
+
+// TestChainedProjections tests applying growth multiple times sequentially.
+func TestChainedProjections(t *testing.T) {
+	rate := 0.10 // 10% growth
+
+	// Scenario: Project cost for 3 periods, then use that as base for 3 more
+	baseCost := 100.0
+
+	// First projection: 3 periods
+	cost1 := pricing.ApplyExponentialGrowth(baseCost, rate, 3)
+	// Expected: 100 * 1.10^3 = 133.1
+
+	// Second projection: 3 more periods starting from cost1
+	cost2 := pricing.ApplyExponentialGrowth(cost1, rate, 3)
+	// Expected: 133.1 * 1.10^3 = 177.16
+
+	// This should equal single projection of 6 periods
+	costDirect := pricing.ApplyExponentialGrowth(baseCost, rate, 6)
+	// Expected: 100 * 1.10^6 = 177.16
+
+	if !almostEqual(cost2, costDirect) {
+		t.Errorf("Chained projection mismatch: chained=%v, direct=%v", cost2, costDirect)
+	}
+
+	// Verify intermediate value
+	expected1 := 133.1
+	if !almostEqual(cost1, expected1) {
+		t.Errorf("First projection: got %v, want %v", cost1, expected1)
+	}
+
+	t.Logf("Chained projections verified: $%.2f → $%.2f → $%.2f (direct: $%.2f)",
+		baseCost, cost1, cost2, costDirect)
+}
+
+// TestConcurrentGrowthCalculations verifies thread safety.
+func TestConcurrentGrowthCalculations(t *testing.T) {
+	const numGoroutines = 100
+	const iterations = 1000
+
+	rate := floatPtr(0.10)
+	expectedLinear := 130.0      // 100 * (1 + 0.10 * 3)
+	expectedExponential := 133.1 // 100 * 1.10^3
+
+	errChan := make(chan error, numGoroutines*2)
+
+	// Test ApplyGrowth concurrently
+	for i := range numGoroutines {
+		go func(id int) {
+			for range iterations {
+				result := pricing.ApplyGrowth(100.0, pbc.GrowthType_GROWTH_TYPE_LINEAR, rate, 3)
+				if !almostEqual(result, expectedLinear) {
+					errChan <- fmt.Errorf("goroutine %d: linear got %v, want %v", id, result, expectedLinear)
+					return
+				}
+			}
+			errChan <- nil
+		}(i)
+
+		go func(id int) {
+			for range iterations {
+				result := pricing.ApplyGrowth(100.0, pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, rate, 3)
+				if !almostEqual(result, expectedExponential) {
+					errChan <- fmt.Errorf("goroutine %d: exponential got %v, want %v", id, result, expectedExponential)
+					return
+				}
+			}
+			errChan <- nil
+		}(i)
+	}
+
+	// Collect results
+	for range numGoroutines * 2 {
+		if err := <-errChan; err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// TestNegativePeriods documents behavior with negative periods.
+// Current implementation does not validate periods, treating negative as valid input.
+func TestNegativePeriods(t *testing.T) {
+	tests := []struct {
+		name       string
+		growthType pbc.GrowthType
+		periods    int
+		validate   func(t *testing.T, result float64)
+	}{
+		{
+			name:       "linear negative periods produces negative multiplier",
+			growthType: pbc.GrowthType_GROWTH_TYPE_LINEAR,
+			periods:    -5,
+			validate: func(t *testing.T, result float64) {
+				// LINEAR: 100 * (1 + 0.10 * -5) = 100 * 0.5 = 50
+				expected := 50.0
+				if !almostEqual(result, expected) {
+					t.Errorf("Expected %v, got %v", expected, result)
+				}
+			},
+		},
+		{
+			name:       "exponential negative periods produces fractional result",
+			growthType: pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			periods:    -5,
+			validate: func(t *testing.T, result float64) {
+				// EXPONENTIAL: 100 * (1.10)^-5 = 100 * 0.6209... ≈ 62.09
+				expected := 100.0 * math.Pow(1.10, -5)
+				if !almostEqual(result, expected) {
+					t.Errorf("Expected %v, got %v", expected, result)
+				}
+			},
+		},
+		{
+			name:       "NONE ignores negative periods",
+			growthType: pbc.GrowthType_GROWTH_TYPE_NONE,
+			periods:    -100,
+			validate: func(t *testing.T, result float64) {
+				if result != 100.0 {
+					t.Errorf("Expected 100.0, got %v", result)
+				}
+			},
+		},
+	}
+
+	baseCost := 100.0
+	rate := floatPtr(0.10)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyGrowth(baseCost, tt.growthType, rate, tt.periods)
+			tt.validate(t, result)
+			t.Logf("Negative periods behavior: type=%v, periods=%d, result=%v",
+				tt.growthType, tt.periods, result)
+		})
+	}
+}

--- a/sdk/go/proto/pulumicost/v1/enums.pb.go
+++ b/sdk/go/proto/pulumicost/v1/enums.pb.go
@@ -477,6 +477,70 @@ func (FocusCapacityReservationStatus) EnumDescriptor() ([]byte, []int) {
 	return file_pulumicost_v1_enums_proto_rawDescGZIP(), []int{7}
 }
 
+// GrowthType represents the mathematical model used for projecting cost growth.
+// Used in ResourceDescriptor and GetProjectedCostRequest for forward-looking projections.
+type GrowthType int32
+
+const (
+	// Default value - treated identically to GROWTH_TYPE_NONE.
+	// When unset, no growth is applied to projections.
+	GrowthType_GROWTH_TYPE_UNSPECIFIED GrowthType = 0
+	// No growth applied to projections.
+	// Cost projections remain constant at the base cost.
+	GrowthType_GROWTH_TYPE_NONE GrowthType = 1
+	// Linear (additive) growth per projection period.
+	// Formula: cost_at_n = base_cost * (1 + rate * n)
+	// Requires growth_rate to be set.
+	GrowthType_GROWTH_TYPE_LINEAR GrowthType = 2
+	// Exponential (compounding) growth per projection period.
+	// Formula: cost_at_n = base_cost * (1 + rate)^n
+	// Requires growth_rate to be set.
+	GrowthType_GROWTH_TYPE_EXPONENTIAL GrowthType = 3
+)
+
+// Enum value maps for GrowthType.
+var (
+	GrowthType_name = map[int32]string{
+		0: "GROWTH_TYPE_UNSPECIFIED",
+		1: "GROWTH_TYPE_NONE",
+		2: "GROWTH_TYPE_LINEAR",
+		3: "GROWTH_TYPE_EXPONENTIAL",
+	}
+	GrowthType_value = map[string]int32{
+		"GROWTH_TYPE_UNSPECIFIED": 0,
+		"GROWTH_TYPE_NONE":        1,
+		"GROWTH_TYPE_LINEAR":      2,
+		"GROWTH_TYPE_EXPONENTIAL": 3,
+	}
+)
+
+func (x GrowthType) Enum() *GrowthType {
+	p := new(GrowthType)
+	*p = x
+	return p
+}
+
+func (x GrowthType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (GrowthType) Descriptor() protoreflect.EnumDescriptor {
+	return file_pulumicost_v1_enums_proto_enumTypes[8].Descriptor()
+}
+
+func (GrowthType) Type() protoreflect.EnumType {
+	return &file_pulumicost_v1_enums_proto_enumTypes[8]
+}
+
+func (x GrowthType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use GrowthType.Descriptor instead.
+func (GrowthType) EnumDescriptor() ([]byte, []int) {
+	return file_pulumicost_v1_enums_proto_rawDescGZIP(), []int{8}
+}
+
 var File_pulumicost_v1_enums_proto protoreflect.FileDescriptor
 
 const file_pulumicost_v1_enums_proto_rawDesc = "" +
@@ -529,7 +593,13 @@ const file_pulumicost_v1_enums_proto_rawDesc = "" +
 	"\x1eFocusCapacityReservationStatus\x121\n" +
 	"-FOCUS_CAPACITY_RESERVATION_STATUS_UNSPECIFIED\x10\x00\x12*\n" +
 	"&FOCUS_CAPACITY_RESERVATION_STATUS_USED\x10\x01\x12,\n" +
-	"(FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED\x10\x02BBZ@github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1;pbcb\x06proto3"
+	"(FOCUS_CAPACITY_RESERVATION_STATUS_UNUSED\x10\x02*t\n" +
+	"\n" +
+	"GrowthType\x12\x1b\n" +
+	"\x17GROWTH_TYPE_UNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10GROWTH_TYPE_NONE\x10\x01\x12\x16\n" +
+	"\x12GROWTH_TYPE_LINEAR\x10\x02\x12\x1b\n" +
+	"\x17GROWTH_TYPE_EXPONENTIAL\x10\x03BBZ@github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1;pbcb\x06proto3"
 
 var (
 	file_pulumicost_v1_enums_proto_rawDescOnce sync.Once
@@ -543,7 +613,7 @@ func file_pulumicost_v1_enums_proto_rawDescGZIP() []byte {
 	return file_pulumicost_v1_enums_proto_rawDescData
 }
 
-var file_pulumicost_v1_enums_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
+var file_pulumicost_v1_enums_proto_enumTypes = make([]protoimpl.EnumInfo, 9)
 var file_pulumicost_v1_enums_proto_goTypes = []any{
 	(FocusServiceCategory)(0),            // 0: pulumicost.v1.FocusServiceCategory
 	(FocusChargeCategory)(0),             // 1: pulumicost.v1.FocusChargeCategory
@@ -553,6 +623,7 @@ var file_pulumicost_v1_enums_proto_goTypes = []any{
 	(FocusCommitmentDiscountCategory)(0), // 5: pulumicost.v1.FocusCommitmentDiscountCategory
 	(FocusCommitmentDiscountStatus)(0),   // 6: pulumicost.v1.FocusCommitmentDiscountStatus
 	(FocusCapacityReservationStatus)(0),  // 7: pulumicost.v1.FocusCapacityReservationStatus
+	(GrowthType)(0),                      // 8: pulumicost.v1.GrowthType
 }
 var file_pulumicost_v1_enums_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -572,7 +643,7 @@ func file_pulumicost_v1_enums_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pulumicost_v1_enums_proto_rawDesc), len(file_pulumicost_v1_enums_proto_rawDesc)),
-			NumEnums:      8,
+			NumEnums:      9,
 			NumMessages:   0,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/sdk/go/testing/forecasting_backward_test.go
+++ b/sdk/go/testing/forecasting_backward_test.go
@@ -1,0 +1,208 @@
+package testing_test
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pricing"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// TestBackwardCompatibility_NoGrowthFields validates that requests without growth fields
+// behave exactly as before the forecasting feature was added.
+//
+// This test ensures FR-009: Backward compatibility - existing clients continue to work
+// without modification.
+func TestBackwardCompatibility_NoGrowthFields(t *testing.T) {
+	baseCost := 100.0
+	periods := 12
+
+	// Simulate a request without any growth fields set
+	// (the default state for old clients)
+	result := pricing.ApplyGrowth(
+		baseCost,
+		pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, // Default proto value
+		nil,                                    // No rate set
+		periods,
+	)
+
+	// Without growth fields, the base cost should be returned unchanged
+	expected := 100.0
+	if result != expected {
+		t.Errorf("Backward compatibility broken: with no growth fields, got %v, want %v", result, expected)
+	}
+}
+
+// TestUnspecifiedEqualsNone validates that GROWTH_TYPE_UNSPECIFIED is treated as GROWTH_TYPE_NONE.
+// This ensures that old clients sending zero/default values get consistent behavior.
+func TestUnspecifiedEqualsNone(t *testing.T) {
+	baseCost := 100.0
+	rate := floatPtr(0.10)
+	periods := 12
+
+	// UNSPECIFIED should produce the same result as NONE
+	unspecifiedResult := pricing.ApplyGrowth(baseCost, pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, rate, periods)
+	noneResult := pricing.ApplyGrowth(baseCost, pbc.GrowthType_GROWTH_TYPE_NONE, rate, periods)
+
+	if unspecifiedResult != noneResult {
+		t.Errorf("UNSPECIFIED should equal NONE: UNSPECIFIED=%v, NONE=%v", unspecifiedResult, noneResult)
+	}
+
+	// Both should be the unchanged base cost
+	expected := 100.0
+	if unspecifiedResult != expected {
+		t.Errorf("Expected %v for UNSPECIFIED, got %v", expected, unspecifiedResult)
+	}
+}
+
+// TestResolveGrowthType_UnspecifiedToNone validates the ResolveGrowthType helper.
+func TestResolveGrowthType_UnspecifiedToNone(t *testing.T) {
+	resolved := pricing.ResolveGrowthType(pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED)
+	if resolved != pbc.GrowthType_GROWTH_TYPE_NONE {
+		t.Errorf("ResolveGrowthType(UNSPECIFIED) = %v, want NONE", resolved)
+	}
+}
+
+// TestOldClientNewServer simulates an old client (no growth fields) sending to a new server.
+func TestOldClientNewServer(t *testing.T) {
+	// Old client creates ResourceDescriptor without growth fields
+	oldClientResource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.medium",
+		Region:       "us-east-1",
+		// GrowthType and GrowthRate intentionally not set (zero values)
+	}
+
+	// Verify the proto zero values
+	if oldClientResource.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED {
+		t.Errorf("Expected default GrowthType to be UNSPECIFIED, got %v", oldClientResource.GetGrowthType())
+	}
+	if oldClientResource.GrowthRate != nil {
+		t.Errorf("Expected default GrowthRate to be nil, got %v", oldClientResource.GetGrowthRate())
+	}
+
+	// Old client creates request without growth fields
+	oldClientRequest := &pbc.GetProjectedCostRequest{
+		Resource:              oldClientResource,
+		UtilizationPercentage: 0.5,
+		// GrowthType and GrowthRate intentionally not set
+	}
+
+	// Verify request zero values
+	if oldClientRequest.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED {
+		t.Errorf("Expected request default GrowthType to be UNSPECIFIED, got %v", oldClientRequest.GetGrowthType())
+	}
+	if oldClientRequest.GrowthRate != nil {
+		t.Errorf("Expected request default GrowthRate to be nil, got %v", oldClientRequest.GetGrowthRate())
+	}
+
+	// Server should treat this as "no growth" and return unchanged cost
+	// We use direct field access to get *float64 (pointer), GetGrowthRate() returns unwrapped float64
+	effectiveType, effectiveRate := pricing.ResolveGrowthParams(
+		oldClientRequest.GetGrowthType(), oldClientRequest.GrowthRate, //nolint:protogetter // need *float64
+		oldClientResource.GetGrowthType(), oldClientResource.GrowthRate, //nolint:protogetter // need *float64
+	)
+
+	if effectiveType != pbc.GrowthType_GROWTH_TYPE_NONE {
+		t.Errorf("Server should resolve to NONE for old client, got %v", effectiveType)
+	}
+	if effectiveRate != nil {
+		t.Errorf("Server should have nil rate for old client, got %v", effectiveRate)
+	}
+}
+
+// TestNewClientOldServer simulates a new client (with growth fields) sending to an old server.
+// Old servers ignore unknown fields per protobuf wire format - this is handled at the proto level.
+func TestNewClientOldServer(t *testing.T) {
+	// New client creates ResourceDescriptor with growth fields
+	newClientResource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.medium",
+		Region:       "us-east-1",
+		GrowthType:   pbc.GrowthType_GROWTH_TYPE_LINEAR,
+		GrowthRate:   floatPtr(0.10),
+	}
+
+	// Serialize to wire format
+	data, err := proto.Marshal(newClientResource)
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+
+	// Deserialize back (simulating old server with new proto definition)
+	// An old server would just ignore fields it doesn't know about
+	var restored pbc.ResourceDescriptor
+	if unmarshalErr := proto.Unmarshal(data, &restored); unmarshalErr != nil {
+		t.Fatalf("Failed to unmarshal: %v", unmarshalErr)
+	}
+
+	// Verify fields survived round-trip (new server reading new client)
+	if restored.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_LINEAR {
+		t.Errorf("GrowthType not preserved: got %v", restored.GetGrowthType())
+	}
+	if restored.GetGrowthRate() != 0.10 {
+		t.Errorf("GrowthRate not preserved: got %v", restored.GetGrowthRate())
+	}
+
+	t.Log("Wire format verified: growth fields round-trip correctly")
+	t.Log("Note: Actual old servers would ignore unknown fields per protobuf spec")
+}
+
+// TestDefaultValuesDoNotAffectProjections ensures default/zero values don't change behavior.
+func TestDefaultValuesDoNotAffectProjections(t *testing.T) {
+	tests := []struct {
+		name       string
+		growthType pbc.GrowthType
+		growthRate *float64
+		baseCost   float64
+		periods    int
+		expected   float64
+	}{
+		// All cases where growth is effectively "off" should return base cost
+		{"Zero value GrowthType", pbc.GrowthType(0), nil, 100.0, 12, 100.0},
+		{"UNSPECIFIED with nil rate", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, nil, 100.0, 12, 100.0},
+		{"NONE with nil rate", pbc.GrowthType_GROWTH_TYPE_NONE, nil, 100.0, 12, 100.0},
+		{"UNSPECIFIED with rate", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, floatPtr(0.10), 100.0, 12, 100.0},
+		{"NONE with rate", pbc.GrowthType_GROWTH_TYPE_NONE, floatPtr(0.10), 100.0, 12, 100.0},
+		{"NONE with zero rate", pbc.GrowthType_GROWTH_TYPE_NONE, floatPtr(0.0), 100.0, 12, 100.0},
+		{"LINEAR with zero rate", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.0), 100.0, 12, 100.0},
+		{"EXPONENTIAL with zero rate", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.0), 100.0, 12, 100.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyGrowth(tt.baseCost, tt.growthType, tt.growthRate, tt.periods)
+			if result != tt.expected {
+				t.Errorf("ApplyGrowth() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestProtoDefaultsAreZero validates that proto default values are what we expect.
+func TestProtoDefaultsAreZero(t *testing.T) {
+	// Empty ResourceDescriptor should have zero/nil for growth fields
+	rd := &pbc.ResourceDescriptor{}
+
+	if rd.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED {
+		t.Errorf("Expected default GrowthType to be UNSPECIFIED (0), got %v", rd.GetGrowthType())
+	}
+
+	if rd.GrowthRate != nil {
+		t.Errorf("Expected default GrowthRate to be nil, got %v", rd.GetGrowthRate())
+	}
+
+	// Empty request should also have zero/nil
+	req := &pbc.GetProjectedCostRequest{}
+
+	if req.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED {
+		t.Errorf("Expected request default GrowthType to be UNSPECIFIED (0), got %v", req.GetGrowthType())
+	}
+
+	if req.GrowthRate != nil {
+		t.Errorf("Expected request default GrowthRate to be nil, got %v", req.GetGrowthRate())
+	}
+}

--- a/sdk/go/testing/forecasting_test.go
+++ b/sdk/go/testing/forecasting_test.go
@@ -1,0 +1,295 @@
+package testing_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pricing"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// tolerance defines the acceptable delta for floating point comparisons.
+// Per SC-002/SC-003, accuracy must be within 0.01%.
+const tolerance = 0.0001
+
+// floatPtr is a helper to create a *float64 from a literal.
+func floatPtr(f float64) *float64 {
+	return &f
+}
+
+// almostEqual compares two floats within the tolerance.
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) <= tolerance*math.Max(math.Abs(a), math.Abs(b))
+}
+
+// TestLinearGrowthConformance validates LINEAR growth calculations.
+// Given growth_type=LINEAR, rate=0.10, verify cost increases 10% per period linearly.
+func TestLinearGrowthConformance(t *testing.T) {
+	baseCost := 100.0
+	rate := 0.10 // 10% per period
+
+	tests := []struct {
+		name     string
+		periods  int
+		expected float64
+	}{
+		{"Period 0", 0, 100.00},
+		{"Period 1", 1, 110.00},
+		{"Period 2", 2, 120.00},
+		{"Period 3", 3, 130.00},
+		{"Period 12", 12, 220.00},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyLinearGrowth(baseCost, rate, tt.periods)
+			if !almostEqual(result, tt.expected) {
+				t.Errorf("ApplyLinearGrowth(%v, %v, %d) = %v, want %v",
+					baseCost, rate, tt.periods, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestExponentialGrowthConformance validates EXPONENTIAL growth calculations.
+// Given growth_type=EXPONENTIAL, rate=0.05, verify cost compounds at 5% per period.
+func TestExponentialGrowthConformance(t *testing.T) {
+	baseCost := 100.0
+	rate := 0.05 // 5% per period
+
+	tests := []struct {
+		name     string
+		periods  int
+		expected float64
+	}{
+		{"Period 0", 0, 100.00},
+		{"Period 1", 1, 105.00},
+		{"Period 2", 2, 110.25},
+		{"Period 3", 3, 115.7625},
+		{"Period 12", 12, 179.5856}, // (1.05)^12 ≈ 1.795856
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyExponentialGrowth(baseCost, rate, tt.periods)
+			if !almostEqual(result, tt.expected) {
+				t.Errorf("ApplyExponentialGrowth(%v, %v, %d) = %v, want %v",
+					baseCost, rate, tt.periods, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestNoneGrowthConformance validates NONE growth type.
+// Given growth_type=NONE, verify no growth is applied.
+func TestNoneGrowthConformance(t *testing.T) {
+	baseCost := 100.0
+	rate := floatPtr(0.10) // Rate should be ignored
+
+	tests := []struct {
+		name     string
+		periods  int
+		expected float64
+	}{
+		{"Period 0", 0, 100.00},
+		{"Period 1", 1, 100.00},
+		{"Period 12", 12, 100.00},
+		{"Period 36", 36, 100.00},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyGrowth(baseCost, pbc.GrowthType_GROWTH_TYPE_NONE, rate, tt.periods)
+			if !almostEqual(result, tt.expected) {
+				t.Errorf("ApplyGrowth(%v, NONE, %v, %d) = %v, want %v",
+					baseCost, *rate, tt.periods, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestUnspecifiedTreatedAsNone validates that UNSPECIFIED is treated as NONE.
+func TestUnspecifiedTreatedAsNone(t *testing.T) {
+	baseCost := 100.0
+	rate := floatPtr(0.20) // Rate should be ignored
+
+	result := pricing.ApplyGrowth(baseCost, pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, rate, 12)
+	expected := 100.0
+
+	if !almostEqual(result, expected) {
+		t.Errorf("ApplyGrowth with UNSPECIFIED should not apply growth: got %v, want %v", result, expected)
+	}
+}
+
+// TestActualCostIgnoresGrowthParams validates FR-008: GetActualCost ignores growth parameters.
+// Growth parameters are for projections only; actual cost retrieval is unaffected.
+func TestActualCostIgnoresGrowthParams(t *testing.T) {
+	// Create a ResourceDescriptor with growth parameters
+	resource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.medium",
+		Region:       "us-east-1",
+		GrowthType:   pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+		GrowthRate:   floatPtr(0.25), // 25% growth - should be ignored
+	}
+
+	// Verify the growth fields are set (proto fields exist)
+	if resource.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL {
+		t.Errorf("Expected GrowthType to be EXPONENTIAL, got %v", resource.GetGrowthType())
+	}
+	if resource.GetGrowthRate() != 0.25 {
+		t.Errorf("Expected GrowthRate to be 0.25, got %v", resource.GetGrowthRate())
+	}
+
+	// In practice, GetActualCost implementation should not use these fields.
+	// This test documents the contract that growth params exist on ResourceDescriptor
+	// but have no effect on actual cost calculations.
+	t.Log("FR-008 Validated: ResourceDescriptor accepts growth_type and growth_rate fields")
+	t.Log("Plugin implementations MUST ignore these fields in GetActualCost RPC")
+}
+
+// TestApplyGrowthWithAllTypes tests the unified ApplyGrowth function.
+func TestApplyGrowthWithAllTypes(t *testing.T) {
+	baseCost := 100.0
+	rate := floatPtr(0.10)
+	periods := 3
+
+	tests := []struct {
+		name       string
+		growthType pbc.GrowthType
+		expected   float64
+	}{
+		{"LINEAR", pbc.GrowthType_GROWTH_TYPE_LINEAR, 130.0},           // 100 * (1 + 0.1*3)
+		{"EXPONENTIAL", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, 133.1}, // 100 * (1.1)^3
+		{"NONE", pbc.GrowthType_GROWTH_TYPE_NONE, 100.0},
+		{"UNSPECIFIED", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, 100.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pricing.ApplyGrowth(baseCost, tt.growthType, rate, periods)
+			if !almostEqual(result, tt.expected) {
+				t.Errorf("ApplyGrowth(%v, %v, %v, %d) = %v, want %v",
+					baseCost, tt.growthType, *rate, periods, result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestNilRateTreatedAsZero tests that nil rate is treated as 0 growth.
+func TestNilRateTreatedAsZero(t *testing.T) {
+	baseCost := 100.0
+	var rate *float64 // nil by default
+	periods := 12
+
+	// With LINEAR and nil rate, should apply no growth (rate=0)
+	result := pricing.ApplyGrowth(baseCost, pbc.GrowthType_GROWTH_TYPE_LINEAR, rate, periods)
+	expected := 100.0 // 100 * (1 + 0*12) = 100
+
+	if !almostEqual(result, expected) {
+		t.Errorf("ApplyGrowth with nil rate should apply 0 growth: got %v, want %v", result, expected)
+	}
+}
+
+// TestNegativeGrowthRate tests decline scenarios.
+func TestNegativeGrowthRate(t *testing.T) {
+	baseCost := 100.0
+	rate := floatPtr(-0.10) // 10% decline per period
+
+	t.Run("LinearDecline", func(t *testing.T) {
+		result := pricing.ApplyLinearGrowth(baseCost, *rate, 3)
+		expected := 70.0 // 100 * (1 + (-0.1)*3) = 100 * 0.7 = 70
+		if !almostEqual(result, expected) {
+			t.Errorf("Linear decline: got %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("ExponentialDecline", func(t *testing.T) {
+		result := pricing.ApplyExponentialGrowth(baseCost, *rate, 3)
+		expected := 72.9 // 100 * (0.9)^3 = 72.9
+		if !almostEqual(result, expected) {
+			t.Errorf("Exponential decline: got %v, want %v", result, expected)
+		}
+	})
+}
+
+// TestHighGrowthRates tests hyper-growth scenarios (>100% per period).
+func TestHighGrowthRates(t *testing.T) {
+	baseCost := 100.0
+	rate := floatPtr(2.0) // 200% growth per period
+	periods := 3
+
+	t.Run("LinearHyperGrowth", func(t *testing.T) {
+		result := pricing.ApplyLinearGrowth(baseCost, *rate, periods)
+		expected := 700.0 // 100 * (1 + 2.0*3) = 100 * 7 = 700
+		if !almostEqual(result, expected) {
+			t.Errorf("Linear hyper-growth: got %v, want %v", result, expected)
+		}
+	})
+
+	t.Run("ExponentialHyperGrowth", func(t *testing.T) {
+		result := pricing.ApplyExponentialGrowth(baseCost, *rate, periods)
+		expected := 2700.0 // 100 * (3.0)^3 = 100 * 27 = 2700
+		if !almostEqual(result, expected) {
+			t.Errorf("Exponential hyper-growth: got %v, want %v", result, expected)
+		}
+	})
+}
+
+// TestProtoFieldsExist validates that the proto fields were generated correctly.
+func TestProtoFieldsExist(t *testing.T) {
+	// Test ResourceDescriptor fields
+	rd := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.medium",
+		Region:       "us-east-1",
+		GrowthType:   pbc.GrowthType_GROWTH_TYPE_LINEAR,
+		GrowthRate:   floatPtr(0.05),
+	}
+
+	if rd.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_LINEAR {
+		t.Errorf("ResourceDescriptor.GrowthType not set correctly")
+	}
+	if rd.GetGrowthRate() != 0.05 {
+		t.Errorf("ResourceDescriptor.GrowthRate not set correctly")
+	}
+
+	// Test GetProjectedCostRequest fields
+	req := &pbc.GetProjectedCostRequest{
+		Resource:              rd,
+		UtilizationPercentage: 0.5,
+		GrowthType:            pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+		GrowthRate:            floatPtr(0.10),
+	}
+
+	if req.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL {
+		t.Errorf("GetProjectedCostRequest.GrowthType not set correctly")
+	}
+	if req.GetGrowthRate() != 0.10 {
+		t.Errorf("GetProjectedCostRequest.GrowthRate not set correctly")
+	}
+}
+
+// TestGrowthTypeEnum validates all GrowthType enum values exist.
+func TestGrowthTypeEnum(t *testing.T) {
+	tests := []struct {
+		name  string
+		value pbc.GrowthType
+		num   int32
+	}{
+		{"UNSPECIFIED", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, 0},
+		{"NONE", pbc.GrowthType_GROWTH_TYPE_NONE, 1},
+		{"LINEAR", pbc.GrowthType_GROWTH_TYPE_LINEAR, 2},
+		{"EXPONENTIAL", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if int32(tt.value) != tt.num {
+				t.Errorf("%s has wrong value: got %d, want %d", tt.name, int32(tt.value), tt.num)
+			}
+		})
+	}
+}

--- a/sdk/go/testing/forecasting_validation_test.go
+++ b/sdk/go/testing/forecasting_validation_test.go
@@ -1,0 +1,208 @@
+package testing_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pricing"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// TestValidation_LinearWithoutRate validates that LINEAR without growth_rate returns error.
+func TestValidation_LinearWithoutRate(t *testing.T) {
+	err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_LINEAR, nil)
+
+	if err == nil {
+		t.Error("Expected error for LINEAR without growth_rate, got nil")
+	}
+
+	if !errors.Is(err, pricing.ErrMissingGrowthRate) {
+		t.Errorf("Expected ErrMissingGrowthRate, got %v", err)
+	}
+}
+
+// TestValidation_ExponentialWithoutRate validates that EXPONENTIAL without growth_rate returns error.
+func TestValidation_ExponentialWithoutRate(t *testing.T) {
+	err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, nil)
+
+	if err == nil {
+		t.Error("Expected error for EXPONENTIAL without growth_rate, got nil")
+	}
+
+	if !errors.Is(err, pricing.ErrMissingGrowthRate) {
+		t.Errorf("Expected ErrMissingGrowthRate, got %v", err)
+	}
+}
+
+// TestValidation_RateBelowNegativeOne validates that rate < -1.0 returns error.
+func TestValidation_RateBelowNegativeOne(t *testing.T) {
+	invalidRate := floatPtr(-1.5) // -150% decline is invalid
+
+	err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_LINEAR, invalidRate)
+
+	if err == nil {
+		t.Error("Expected error for growth_rate < -1.0, got nil")
+	}
+
+	if !errors.Is(err, pricing.ErrInvalidGrowthRate) {
+		t.Errorf("Expected ErrInvalidGrowthRate, got %v", err)
+	}
+}
+
+// TestValidation_NegativeRateAccepted validates that rate >= -1.0 is accepted.
+func TestValidation_NegativeRateAccepted(t *testing.T) {
+	tests := []struct {
+		name string
+		rate float64
+	}{
+		{"minus one (boundary)", -1.0},
+		{"minus ninety percent", -0.9},
+		{"minus ten percent", -0.10},
+		{"zero", 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(tt.rate))
+			if err != nil {
+				t.Errorf("Expected no error for rate %v, got %v", tt.rate, err)
+			}
+		})
+	}
+}
+
+// TestValidation_HighRateAccepted validates that very high rates are accepted.
+func TestValidation_HighRateAccepted(t *testing.T) {
+	tests := []struct {
+		name string
+		rate float64
+	}{
+		{"one hundred percent", 1.0},
+		{"two hundred percent", 2.0},
+		{"one thousand percent", 10.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(tt.rate))
+			if err != nil {
+				t.Errorf("Expected no error for rate %v, got %v", tt.rate, err)
+			}
+		})
+	}
+}
+
+// TestValidation_NoneWithoutRate validates that NONE without rate is valid.
+func TestValidation_NoneWithoutRate(t *testing.T) {
+	err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_NONE, nil)
+	if err != nil {
+		t.Errorf("Expected no error for NONE without rate, got %v", err)
+	}
+}
+
+// TestValidation_NoneWithRate validates that NONE with rate is valid (rate is ignored).
+func TestValidation_NoneWithRate(t *testing.T) {
+	err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_NONE, floatPtr(0.10))
+	if err != nil {
+		t.Errorf("Expected no error for NONE with rate (ignored), got %v", err)
+	}
+}
+
+// TestValidation_UnspecifiedWithoutRate validates that UNSPECIFIED without rate is valid.
+func TestValidation_UnspecifiedWithoutRate(t *testing.T) {
+	err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, nil)
+	if err != nil {
+		t.Errorf("Expected no error for UNSPECIFIED without rate, got %v", err)
+	}
+}
+
+// TestValidation_UnspecifiedWithRate validates that UNSPECIFIED with rate is valid.
+func TestValidation_UnspecifiedWithRate(t *testing.T) {
+	err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, floatPtr(0.10))
+	if err != nil {
+		t.Errorf("Expected no error for UNSPECIFIED with rate (ignored), got %v", err)
+	}
+}
+
+// TestValidation_ErrorMessages validates error messages are descriptive.
+func TestValidation_ErrorMessages(t *testing.T) {
+	t.Run("MissingRateMessage", func(t *testing.T) {
+		err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_LINEAR, nil)
+		if err == nil {
+			t.Fatal("Expected error")
+		}
+		if err.Error() == "" {
+			t.Error("Expected non-empty error message")
+		}
+		t.Logf("Error message: %s", err.Error())
+	})
+
+	t.Run("InvalidRateMessage", func(t *testing.T) {
+		err := pricing.ValidateGrowthParams(pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(-2.0))
+		if err == nil {
+			t.Fatal("Expected error")
+		}
+		if err.Error() == "" {
+			t.Error("Expected non-empty error message")
+		}
+		t.Logf("Error message: %s", err.Error())
+	})
+}
+
+// TestValidation_ComprehensiveMatrix tests all growth type and rate combinations.
+func TestValidation_ComprehensiveMatrix(t *testing.T) {
+	tests := []struct {
+		name        string
+		growthType  pbc.GrowthType
+		rate        *float64
+		expectError bool
+		errorType   error
+	}{
+		// UNSPECIFIED - always valid
+		{"UNSPECIFIED nil", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, nil, false, nil},
+		{"UNSPECIFIED 0.0", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, floatPtr(0.0), false, nil},
+		{"UNSPECIFIED 0.10", pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED, floatPtr(0.10), false, nil},
+
+		// NONE - always valid
+		{"NONE nil", pbc.GrowthType_GROWTH_TYPE_NONE, nil, false, nil},
+		{"NONE 0.0", pbc.GrowthType_GROWTH_TYPE_NONE, floatPtr(0.0), false, nil},
+		{"NONE 0.10", pbc.GrowthType_GROWTH_TYPE_NONE, floatPtr(0.10), false, nil},
+
+		// LINEAR - requires rate
+		{"LINEAR nil", pbc.GrowthType_GROWTH_TYPE_LINEAR, nil, true, pricing.ErrMissingGrowthRate},
+		{"LINEAR 0.0", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.0), false, nil},
+		{"LINEAR 0.10", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(0.10), false, nil},
+		{"LINEAR -1.0", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(-1.0), false, nil},
+		{"LINEAR -1.5", pbc.GrowthType_GROWTH_TYPE_LINEAR, floatPtr(-1.5), true, pricing.ErrInvalidGrowthRate},
+
+		// EXPONENTIAL - requires rate
+		{"EXPONENTIAL nil", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, nil, true, pricing.ErrMissingGrowthRate},
+		{"EXPONENTIAL 0.0", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.0), false, nil},
+		{"EXPONENTIAL 0.10", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(0.10), false, nil},
+		{"EXPONENTIAL -1.0", pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL, floatPtr(-1.0), false, nil},
+		{
+			"EXPONENTIAL -1.5",
+			pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+			floatPtr(-1.5),
+			true,
+			pricing.ErrInvalidGrowthRate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pricing.ValidateGrowthParams(tt.growthType, tt.rate)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+				if tt.errorType != nil && !errors.Is(err, tt.errorType) {
+					t.Errorf("Expected error type %v, got %v", tt.errorType, err)
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/specs/030-forecasting-primitives/checklists/requirements.md
+++ b/specs/030-forecasting-primitives/checklists/requirements.md
@@ -1,0 +1,58 @@
+# Specification Quality Checklist: Forecasting Primitives
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Results
+
+**Status**: PASSED
+
+All checklist items validated successfully:
+
+1. **Content Quality**: Spec focuses on WHAT (growth types, growth rates, cost projections)
+   not HOW (no proto syntax, Go code, or implementation details mentioned)
+
+2. **Requirement Completeness**: All 9 functional requirements are testable with clear MUST
+   statements. No ambiguous requirements or clarification markers.
+
+3. **Success Criteria**: All 6 success criteria are measurable and technology-agnostic:
+   - SC-001: 100% resource support
+   - SC-002/SC-003: 0.01% accuracy thresholds
+   - SC-004: 100% backward compatibility
+   - SC-005: <100ms response for errors
+   - SC-006: <30 minutes for developer onboarding
+
+4. **Edge Cases**: Four edge cases documented covering extreme values, zero handling, long
+   projections, and historical data handling.
+
+## Notes
+
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- No issues requiring user input were identified
+- All growth model behaviors are fully specified with mathematical definitions

--- a/specs/030-forecasting-primitives/contracts/forecasting.proto.md
+++ b/specs/030-forecasting-primitives/contracts/forecasting.proto.md
@@ -1,0 +1,173 @@
+# Proto Contract: Forecasting Primitives
+
+This document defines the protocol buffer changes for the forecasting primitives feature.
+
+## New Enum: GrowthType
+
+**File**: `proto/pulumicost/v1/enums.proto`
+
+```protobuf
+// GrowthType represents the mathematical model used for projecting cost growth.
+// Used in ResourceDescriptor and GetProjectedCostRequest for forward-looking projections.
+enum GrowthType {
+  // Default value - treated identically to GROWTH_TYPE_NONE.
+  // When unset, no growth is applied to projections.
+  GROWTH_TYPE_UNSPECIFIED = 0;
+
+  // No growth applied to projections.
+  // Cost projections remain constant at the base cost.
+  GROWTH_TYPE_NONE = 1;
+
+  // Linear (additive) growth per projection period.
+  // Formula: cost_at_n = base_cost * (1 + rate * n)
+  // Requires growth_rate to be set.
+  GROWTH_TYPE_LINEAR = 2;
+
+  // Exponential (compounding) growth per projection period.
+  // Formula: cost_at_n = base_cost * (1 + rate)^n
+  // Requires growth_rate to be set.
+  GROWTH_TYPE_EXPONENTIAL = 3;
+}
+```
+
+## Extended Message: ResourceDescriptor
+
+**File**: `proto/pulumicost/v1/costsource.proto`
+
+Add the following fields after field 8 (arn):
+
+```protobuf
+message ResourceDescriptor {
+  // ... existing fields 1-8 ...
+
+  // growth_type specifies the default growth model for cost projections.
+  // OPTIONAL. When set, defines how projected costs should grow over time.
+  // Can be overridden by GetProjectedCostRequest.growth_type.
+  //
+  // Values:
+  //   - GROWTH_TYPE_UNSPECIFIED/NONE: No growth (constant projections)
+  //   - GROWTH_TYPE_LINEAR: Additive growth (cost * (1 + rate * periods))
+  //   - GROWTH_TYPE_EXPONENTIAL: Compounding growth (cost * (1 + rate)^periods)
+  //
+  // When LINEAR or EXPONENTIAL, growth_rate MUST also be provided.
+  GrowthType growth_type = 9;
+
+  // growth_rate specifies the default growth rate per projection period.
+  // OPTIONAL. Required when growth_type is LINEAR or EXPONENTIAL.
+  //
+  // Valid range: >= -1.0 (no upper bound)
+  //   - Positive values: growth (e.g., 0.10 = 10% growth per period)
+  //   - Zero: no growth (equivalent to GROWTH_TYPE_NONE)
+  //   - Negative values: decline (e.g., -0.10 = 10% decline per period)
+  //   - -1.0: complete decline to zero cost
+  //
+  // Values below -1.0 are invalid (would produce negative costs).
+  // Can be overridden by GetProjectedCostRequest.growth_rate.
+  optional double growth_rate = 10;
+}
+```
+
+## Extended Message: GetProjectedCostRequest
+
+**File**: `proto/pulumicost/v1/costsource.proto`
+
+Add the following fields after field 2 (utilization_percentage):
+
+```protobuf
+message GetProjectedCostRequest {
+  // ... existing fields 1-2 ...
+
+  // growth_type overrides ResourceDescriptor.growth_type for this request.
+  // OPTIONAL. When set, takes precedence over the resource-level default.
+  //
+  // Use case: Project different growth scenarios for the same resource
+  // without modifying the resource descriptor.
+  //
+  // When LINEAR or EXPONENTIAL, growth_rate MUST also be provided
+  // (either here or in ResourceDescriptor).
+  GrowthType growth_type = 3;
+
+  // growth_rate overrides ResourceDescriptor.growth_rate for this request.
+  // OPTIONAL. When set, takes precedence over the resource-level default.
+  //
+  // Valid range: >= -1.0 (no upper bound)
+  //
+  // Override semantics: If this field is set, it fully replaces
+  // ResourceDescriptor.growth_rate for this request.
+  optional double growth_rate = 4;
+}
+```
+
+## Validation Specification
+
+### SDK Validation Function
+
+```go
+// ValidateGrowthParams validates growth_type and growth_rate combination.
+// Returns InvalidArgument gRPC status on validation failure.
+//
+// Rules:
+//   - LINEAR/EXPONENTIAL require growth_rate to be set
+//   - growth_rate must be >= -1.0
+//   - NONE/UNSPECIFIED ignore growth_rate (optional warning)
+func ValidateGrowthParams(growthType GrowthType, growthRate *float64) error
+```
+
+### Error Codes
+
+| Condition | gRPC Status | Message |
+|-----------|-------------|---------|
+| LINEAR without rate | InvalidArgument | "growth_rate required for LINEAR growth type" |
+| EXPONENTIAL without rate | InvalidArgument | "growth_rate required for EXPONENTIAL growth type" |
+| Rate < -1.0 | InvalidArgument | "growth_rate must be >= -1.0" |
+
+## Wire Format Examples
+
+### Request with Linear Growth
+
+```json
+{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "ec2",
+    "sku": "t3.medium",
+    "region": "us-east-1",
+    "growth_type": "GROWTH_TYPE_LINEAR",
+    "growth_rate": 0.10
+  },
+  "utilization_percentage": 0.5
+}
+```
+
+### Request with Override
+
+```json
+{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "ec2",
+    "sku": "t3.medium",
+    "region": "us-east-1",
+    "growth_type": "GROWTH_TYPE_LINEAR",
+    "growth_rate": 0.10
+  },
+  "utilization_percentage": 0.5,
+  "growth_type": "GROWTH_TYPE_EXPONENTIAL",
+  "growth_rate": 0.05
+}
+```
+
+In this example, the request uses EXPONENTIAL at 5% (override), not LINEAR at 10%
+(resource default).
+
+## Breaking Change Analysis
+
+| Change | Breaking? | Reason |
+|--------|-----------|--------|
+| Add GrowthType enum | No | New type, no existing references |
+| Add growth_type to ResourceDescriptor | No | Optional field, defaults to unset |
+| Add growth_rate to ResourceDescriptor | No | Optional field, defaults to unset |
+| Add growth_type to GetProjectedCostRequest | No | Optional field, defaults to unset |
+| Add growth_rate to GetProjectedCostRequest | No | Optional field, defaults to unset |
+
+**buf breaking check**: Expected to PASS (no breaking changes)

--- a/specs/030-forecasting-primitives/data-model.md
+++ b/specs/030-forecasting-primitives/data-model.md
@@ -1,0 +1,172 @@
+# Data Model: Forecasting Primitives
+
+**Feature**: 030-forecasting-primitives
+**Date**: 2025-12-30
+
+## Entities
+
+### GrowthType (Enum)
+
+Represents the mathematical model used for projecting cost growth over time.
+
+| Value | Number | Description |
+|-------|--------|-------------|
+| GROWTH_TYPE_UNSPECIFIED | 0 | Default/unset - treated as NONE |
+| GROWTH_TYPE_NONE | 1 | No growth applied to projections |
+| GROWTH_TYPE_LINEAR | 2 | Additive growth per period |
+| GROWTH_TYPE_EXPONENTIAL | 3 | Compounding growth per period |
+
+**Validation Rules**:
+
+- UNSPECIFIED and NONE are functionally equivalent (no growth)
+- LINEAR and EXPONENTIAL require a valid `growth_rate` value
+
+**State Transitions**: N/A (enum is stateless)
+
+### growth_rate (Field)
+
+The rate of growth per projection period, expressed as a decimal fraction.
+
+| Attribute | Value |
+|-----------|-------|
+| Type | optional double |
+| Range | >= -1.0 (no upper bound) |
+| Unit | Decimal fraction (0.10 = 10%) |
+| Default | Unset (nil in Go) |
+
+**Validation Rules**:
+
+- REQUIRED when `growth_type` is LINEAR or EXPONENTIAL
+- MUST be >= -1.0 (prevents negative costs)
+- IGNORED when `growth_type` is NONE or UNSPECIFIED
+- Value of 0.0 is valid (no growth, equivalent to NONE)
+
+**Examples**:
+
+| Value | Meaning |
+|-------|---------|
+| 0.10 | 10% growth per period |
+| 0.05 | 5% growth per period |
+| 0.0 | No growth |
+| -0.10 | 10% decline per period |
+| -1.0 | 100% decline (to zero) |
+| 2.0 | 200% growth per period (hyper-growth) |
+
+## Message Extensions
+
+### ResourceDescriptor (Extended)
+
+```text
+Existing fields (1-8):
+  1: provider (string)
+  2: resource_type (string)
+  3: sku (string)
+  4: region (string)
+  5: tags (map<string, string>)
+  6: utilization_percentage (optional double)
+  7: id (string)
+  8: arn (string)
+
+New fields:
+  9: growth_type (GrowthType) - Default growth model for this resource
+  10: growth_rate (optional double) - Default growth rate for this resource
+```
+
+**Semantics**: Growth parameters on ResourceDescriptor serve as defaults for all
+projection requests involving this resource.
+
+### GetProjectedCostRequest (Extended)
+
+```text
+Existing fields (1-2):
+  1: resource (ResourceDescriptor)
+  2: utilization_percentage (double)
+
+New fields:
+  3: growth_type (GrowthType) - Override growth model for this request
+  4: growth_rate (optional double) - Override growth rate for this request
+```
+
+**Semantics**: Request-level growth parameters override ResourceDescriptor defaults
+when set, enabling different projection scenarios for the same resource.
+
+## Relationships
+
+```text
+┌─────────────────────────────────┐
+│   GetProjectedCostRequest       │
+│  ┌───────────────────────────┐  │
+│  │ growth_type (override)    │──┼──┐
+│  │ growth_rate (override)    │  │  │
+│  └───────────────────────────┘  │  │
+│              │                  │  │  Overrides if set
+│              ▼                  │  │
+│  ┌───────────────────────────┐  │  │
+│  │    ResourceDescriptor     │  │  │
+│  │  ┌─────────────────────┐  │  │  │
+│  │  │ growth_type (default)│◄─┼──┼──┘
+│  │  │ growth_rate (default)│  │  │
+│  │  └─────────────────────┘  │  │
+│  └───────────────────────────┘  │
+└─────────────────────────────────┘
+```
+
+## Growth Formulas
+
+### Linear Growth
+
+```text
+cost_at_period_n = base_cost × (1 + rate × n)
+
+Where:
+  base_cost = current monthly cost
+  rate = growth_rate (decimal)
+  n = number of periods (months)
+
+Example: base=$100, rate=0.10, n=3
+  Period 0: $100 × (1 + 0.10 × 0) = $100.00
+  Period 1: $100 × (1 + 0.10 × 1) = $110.00
+  Period 2: $100 × (1 + 0.10 × 2) = $120.00
+  Period 3: $100 × (1 + 0.10 × 3) = $130.00
+```
+
+### Exponential Growth
+
+```text
+cost_at_period_n = base_cost × (1 + rate)^n
+
+Where:
+  base_cost = current monthly cost
+  rate = growth_rate (decimal)
+  n = number of periods (months)
+
+Example: base=$100, rate=0.10, n=3
+  Period 0: $100 × (1.10)^0 = $100.00
+  Period 1: $100 × (1.10)^1 = $110.00
+  Period 2: $100 × (1.10)^2 = $121.00
+  Period 3: $100 × (1.10)^3 = $133.10
+```
+
+## Validation Matrix
+
+| growth_type | growth_rate | Result |
+|-------------|-------------|--------|
+| UNSPECIFIED | unset | Valid (no growth) |
+| UNSPECIFIED | set | Valid (rate ignored, warning) |
+| NONE | unset | Valid (no growth) |
+| NONE | set | Valid (rate ignored, warning) |
+| LINEAR | unset | Invalid (InvalidArgument) |
+| LINEAR | >= -1.0 | Valid |
+| LINEAR | < -1.0 | Invalid (InvalidArgument) |
+| EXPONENTIAL | unset | Invalid (InvalidArgument) |
+| EXPONENTIAL | >= -1.0 | Valid |
+| EXPONENTIAL | < -1.0 | Invalid (InvalidArgument) |
+
+## Backward Compatibility
+
+| Scenario | Behavior |
+|----------|----------|
+| Old client, new server | Works - new fields default to unset/UNSPECIFIED |
+| New client, old server | Works - server ignores unknown fields |
+| Old client, old server | Unchanged |
+| New client, new server | Full forecasting support |

--- a/specs/030-forecasting-primitives/plan.md
+++ b/specs/030-forecasting-primitives/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: Forecasting Primitives
+
+**Branch**: `030-forecasting-primitives` | **Date**: 2025-12-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/030-forecasting-primitives/spec.md`
+
+## Summary
+
+Add forecasting primitives (`GrowthType` enum and `growth_rate` field) to enable forward-looking
+cost projections with linear or exponential growth models. Fields are added to both
+`ResourceDescriptor` (defaults) and `GetProjectedCostRequest` (overrides) to support flexible
+projection scenarios while maintaining backward compatibility.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5 (per go.mod) + Protocol Buffers v3
+**Primary Dependencies**: google.golang.org/protobuf, google.golang.org/grpc, buf v1.32.1
+**Storage**: N/A (stateless proto definitions)
+**Testing**: go test, conformance tests via sdk/go/testing harness
+**Target Platform**: gRPC service specification (cross-platform)
+**Project Type**: gRPC proto specification repository
+**Performance Goals**: Validation <100ms, projection calculations with 0.01% accuracy
+**Constraints**: Backward compatible (optional fields only), buf breaking check must pass
+**Scale/Scope**: Extends existing ResourceDescriptor and GetProjectedCostRequest messages
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. gRPC Proto Specification-First | PASS | Proto changes defined before SDK implementation |
+| II. Multi-Provider Consistency | PASS | Growth fields are provider-agnostic |
+| III. Test-First Protocol | PASS | Conformance tests will define expected behavior |
+| IV. Protobuf Backward Compatibility | PASS | All new fields are optional, no removals |
+| V. Comprehensive Documentation | PENDING | Proto comments required during implementation |
+| VI. Performance Requirements | PASS | Validation <100ms specified in SC-005 |
+| VII. Multi-Layer Validation | PASS | buf lint + schema + conformance planned |
+
+**Gate Status**: PASS - No violations requiring justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-forecasting-primitives/
+├── spec.md              # Feature specification (complete)
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (proto definitions)
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+proto/pulumicost/v1/
+├── costsource.proto     # Extended: ResourceDescriptor, GetProjectedCostRequest
+└── enums.proto          # New: GrowthType enum
+
+sdk/go/
+├── proto/               # Generated code (via buf generate)
+├── pricing/             # SDK helpers (validation, growth calculation)
+└── testing/             # Conformance tests for forecasting
+
+examples/
+└── requests/            # Sample gRPC request payloads with growth parameters
+```
+
+**Structure Decision**: Single project (gRPC spec repo). Proto changes in
+`proto/pulumicost/v1/`, generated SDK in `sdk/go/proto/`, helper code in `sdk/go/pricing/`.
+
+## Complexity Tracking
+
+> No Constitution Check violations requiring justification.

--- a/specs/030-forecasting-primitives/quickstart.md
+++ b/specs/030-forecasting-primitives/quickstart.md
@@ -1,0 +1,199 @@
+# Quickstart: Forecasting Primitives
+
+This guide shows how to use the new forecasting primitives in cost projections.
+
+## Overview
+
+Forecasting primitives allow you to model expected usage growth when projecting future
+costs. Two growth models are supported:
+
+- **Linear**: Costs increase by a fixed percentage of the base cost each period
+- **Exponential**: Costs compound at a fixed rate each period
+
+## Basic Usage
+
+### 1. Linear Growth (10% per month)
+
+```go
+import (
+    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// Create a resource with 10% monthly linear growth
+resource := &pbc.ResourceDescriptor{
+    Provider:     "aws",
+    ResourceType: "ec2",
+    Sku:          "t3.medium",
+    Region:       "us-east-1",
+    GrowthType:   pbc.GrowthType_GROWTH_TYPE_LINEAR,
+    GrowthRate:   proto.Float64(0.10), // 10% growth
+}
+
+// Request projected costs
+req := &pbc.GetProjectedCostRequest{
+    Resource: resource,
+}
+```
+
+**Result**: If base cost is $100/month:
+
+- Month 1: $110 (+10%)
+- Month 2: $120 (+20%)
+- Month 3: $130 (+30%)
+
+### 2. Exponential Growth (5% per month)
+
+```go
+resource := &pbc.ResourceDescriptor{
+    Provider:     "aws",
+    ResourceType: "s3",
+    Sku:          "standard",
+    Region:       "us-east-1",
+    GrowthType:   pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+    GrowthRate:   proto.Float64(0.05), // 5% compounding
+}
+```
+
+**Result**: If base cost is $100/month:
+
+- Month 1: $105.00
+- Month 2: $110.25
+- Month 3: $115.76
+
+### 3. Declining Usage (-10% per month)
+
+```go
+resource := &pbc.ResourceDescriptor{
+    Provider:     "aws",
+    ResourceType: "ec2",
+    Sku:          "t3.large",
+    Region:       "us-east-1",
+    GrowthType:   pbc.GrowthType_GROWTH_TYPE_LINEAR,
+    GrowthRate:   proto.Float64(-0.10), // 10% decline
+}
+```
+
+**Result**: If base cost is $100/month:
+
+- Month 1: $90
+- Month 2: $80
+- Month 3: $70
+
+## Override at Request Level
+
+You can override resource defaults for specific projection scenarios:
+
+```go
+// Resource has 10% linear growth as default
+resource := &pbc.ResourceDescriptor{
+    Provider:     "aws",
+    ResourceType: "ec2",
+    Sku:          "t3.medium",
+    Region:       "us-east-1",
+    GrowthType:   pbc.GrowthType_GROWTH_TYPE_LINEAR,
+    GrowthRate:   proto.Float64(0.10),
+}
+
+// But request uses 5% exponential (override)
+req := &pbc.GetProjectedCostRequest{
+    Resource:   resource,
+    GrowthType: pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+    GrowthRate: proto.Float64(0.05),
+}
+```
+
+## Validation
+
+The SDK validates growth parameters automatically:
+
+```go
+import "github.com/rshade/pulumicost-spec/sdk/go/pricing"
+
+// Validate before sending request
+err := pricing.ValidateGrowthParams(
+    pbc.GrowthType_GROWTH_TYPE_LINEAR,
+    proto.Float64(0.10),
+)
+if err != nil {
+    // Handle validation error
+}
+```
+
+### Validation Rules
+
+| Scenario | Valid? |
+|----------|--------|
+| LINEAR with rate | Yes |
+| LINEAR without rate | No (error) |
+| EXPONENTIAL with rate | Yes |
+| EXPONENTIAL without rate | No (error) |
+| NONE with rate | Yes (rate ignored) |
+| NONE without rate | Yes |
+| Rate < -1.0 | No (error) |
+| Rate > 1.0 (e.g., 200%) | Yes (hyper-growth) |
+
+## Common Patterns
+
+### Budget Planning (12-month projection)
+
+```go
+// Conservative estimate with 5% annual growth (compound monthly)
+resource.GrowthType = pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL
+resource.GrowthRate = proto.Float64(0.004) // ~5% annual
+```
+
+### Scaling Scenarios
+
+```go
+// Aggressive growth scenario
+aggressive := &pbc.GetProjectedCostRequest{
+    Resource:   resource,
+    GrowthType: pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+    GrowthRate: proto.Float64(0.20), // 20% monthly
+}
+
+// Conservative scenario
+conservative := &pbc.GetProjectedCostRequest{
+    Resource:   resource,
+    GrowthType: pbc.GrowthType_GROWTH_TYPE_LINEAR,
+    GrowthRate: proto.Float64(0.05), // 5% monthly
+}
+```
+
+### Sunsetting Resources
+
+```go
+// Resource being phased out over 10 months
+resource.GrowthType = pbc.GrowthType_GROWTH_TYPE_LINEAR
+resource.GrowthRate = proto.Float64(-0.10) // 10% decline
+```
+
+## Error Handling
+
+```go
+import "github.com/rs/zerolog/log"
+
+resp, err := client.GetProjectedCost(ctx, req)
+if err != nil {
+    st, ok := status.FromError(err)
+    if ok && st.Code() == codes.InvalidArgument {
+        // Handle validation error (e.g., missing growth_rate)
+        log.Error().Str("message", st.Message()).Msg("Invalid request")
+    }
+}
+```
+
+## Backward Compatibility
+
+Existing code continues to work unchanged:
+
+```go
+// This still works - no growth applied
+resource := &pbc.ResourceDescriptor{
+    Provider:     "aws",
+    ResourceType: "ec2",
+    Sku:          "t3.medium",
+    Region:       "us-east-1",
+    // No growth fields set - defaults to GROWTH_TYPE_UNSPECIFIED (no growth)
+}
+```

--- a/specs/030-forecasting-primitives/quickstart_test.go
+++ b/specs/030-forecasting-primitives/quickstart_test.go
@@ -1,0 +1,183 @@
+// Package quickstart_test validates that all code samples in quickstart.md compile correctly.
+package quickstart_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pricing"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+)
+
+// TestQuickstartLinearGrowth validates the linear growth example compiles.
+func TestQuickstartLinearGrowth(t *testing.T) {
+	// Create a resource with 10% monthly linear growth
+	resource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.medium",
+		Region:       "us-east-1",
+		GrowthType:   pbc.GrowthType_GROWTH_TYPE_LINEAR,
+		GrowthRate:   proto.Float64(0.10), // 10% growth
+	}
+
+	// Request projected costs
+	req := &pbc.GetProjectedCostRequest{
+		Resource: resource,
+	}
+
+	// Verify fields are set correctly
+	if resource.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_LINEAR {
+		t.Errorf("Expected LINEAR growth type")
+	}
+	if resource.GetGrowthRate() != 0.10 {
+		t.Errorf("Expected 0.10 growth rate, got %v", resource.GetGrowthRate())
+	}
+	if req.GetResource() != resource {
+		t.Errorf("Request resource not set")
+	}
+}
+
+// TestQuickstartExponentialGrowth validates the exponential growth example compiles.
+func TestQuickstartExponentialGrowth(t *testing.T) {
+	resource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "s3",
+		Sku:          "standard",
+		Region:       "us-east-1",
+		GrowthType:   pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+		GrowthRate:   proto.Float64(0.05), // 5% compounding
+	}
+
+	if resource.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL {
+		t.Errorf("Expected EXPONENTIAL growth type")
+	}
+}
+
+// TestQuickstartDecliningUsage validates the declining usage example compiles.
+func TestQuickstartDecliningUsage(t *testing.T) {
+	resource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.large",
+		Region:       "us-east-1",
+		GrowthType:   pbc.GrowthType_GROWTH_TYPE_LINEAR,
+		GrowthRate:   proto.Float64(-0.10), // 10% decline
+	}
+
+	if resource.GetGrowthRate() != -0.10 {
+		t.Errorf("Expected -0.10 growth rate")
+	}
+}
+
+// TestQuickstartRequestOverride validates the request override example compiles.
+func TestQuickstartRequestOverride(t *testing.T) {
+	// Resource has 10% linear growth as default
+	resource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.medium",
+		Region:       "us-east-1",
+		GrowthType:   pbc.GrowthType_GROWTH_TYPE_LINEAR,
+		GrowthRate:   proto.Float64(0.10),
+	}
+
+	// But request uses 5% exponential (override)
+	req := &pbc.GetProjectedCostRequest{
+		Resource:   resource,
+		GrowthType: pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+		GrowthRate: proto.Float64(0.05),
+	}
+
+	if req.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL {
+		t.Errorf("Expected EXPONENTIAL override")
+	}
+	if req.GetGrowthRate() != 0.05 {
+		t.Errorf("Expected 0.05 rate override")
+	}
+}
+
+// TestQuickstartValidation validates the validation example compiles.
+func TestQuickstartValidation(t *testing.T) {
+	// Validate before sending request
+	err := pricing.ValidateGrowthParams(
+		pbc.GrowthType_GROWTH_TYPE_LINEAR,
+		proto.Float64(0.10),
+	)
+	if err != nil {
+		t.Errorf("Validation should pass: %v", err)
+	}
+}
+
+// TestQuickstartScalingScenarios validates the scaling scenarios example compiles.
+func TestQuickstartScalingScenarios(t *testing.T) {
+	resource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.medium",
+		Region:       "us-east-1",
+	}
+
+	// Aggressive growth scenario
+	aggressive := &pbc.GetProjectedCostRequest{
+		Resource:   resource,
+		GrowthType: pbc.GrowthType_GROWTH_TYPE_EXPONENTIAL,
+		GrowthRate: proto.Float64(0.20), // 20% monthly
+	}
+
+	// Conservative scenario
+	conservative := &pbc.GetProjectedCostRequest{
+		Resource:   resource,
+		GrowthType: pbc.GrowthType_GROWTH_TYPE_LINEAR,
+		GrowthRate: proto.Float64(0.05), // 5% monthly
+	}
+
+	if aggressive.GetGrowthRate() != 0.20 {
+		t.Errorf("Aggressive rate should be 0.20")
+	}
+	if conservative.GetGrowthRate() != 0.05 {
+		t.Errorf("Conservative rate should be 0.05")
+	}
+}
+
+// TestQuickstartErrorHandling validates the error handling example compiles.
+func TestQuickstartErrorHandling(t *testing.T) {
+	// This just validates the code compiles - we don't have a real client
+	err := status.Error(codes.InvalidArgument, "test error")
+
+	// Create a logger for this test
+	logger := zerolog.Nop()
+
+	st, ok := status.FromError(err)
+	if ok && st.Code() == codes.InvalidArgument {
+		// Handle validation error (e.g., missing growth_rate)
+		logger.Info().Str("message", st.Message()).Msg("Invalid request")
+	}
+
+	_ = context.Background() // Validate context import works
+	t.Log("Error handling code compiles correctly")
+}
+
+// TestQuickstartBackwardCompatibility validates backward compatibility example compiles.
+func TestQuickstartBackwardCompatibility(t *testing.T) {
+	// This still works - no growth applied
+	resource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Sku:          "t3.medium",
+		Region:       "us-east-1",
+		// No growth fields set - defaults to GROWTH_TYPE_UNSPECIFIED (no growth)
+	}
+
+	if resource.GetGrowthType() != pbc.GrowthType_GROWTH_TYPE_UNSPECIFIED {
+		t.Errorf("Expected UNSPECIFIED as default")
+	}
+	if resource.GrowthRate != nil {
+		t.Errorf("Expected nil growth rate as default")
+	}
+}

--- a/specs/030-forecasting-primitives/research.md
+++ b/specs/030-forecasting-primitives/research.md
@@ -1,0 +1,151 @@
+# Research: Forecasting Primitives
+
+**Feature**: 030-forecasting-primitives
+**Date**: 2025-12-30
+
+## Research Questions
+
+### 1. Field Number Assignment for New Proto Fields
+
+**Decision**: Use field numbers 9-10 for ResourceDescriptor, 3-4 for GetProjectedCostRequest
+
+**Rationale**:
+
+- ResourceDescriptor currently uses fields 1-8 (provider through arn)
+- Fields 9 (`growth_type`) and 10 (`growth_rate`) are next available
+- GetProjectedCostRequest uses fields 1-2 (resource, utilization_percentage)
+- Fields 3 (`growth_type`) and 4 (`growth_rate`) follow sequentially
+- Per protobuf best practices, fields 1-15 use single-byte encoding (efficient for
+  frequently used fields)
+
+**Alternatives considered**:
+
+- Higher field numbers (>15): Rejected - growth fields are likely to be used frequently
+- Shared field numbers across messages: N/A - each message has independent numbering
+
+### 2. GrowthType Enum Placement
+
+**Decision**: Add GrowthType enum to `enums.proto` (existing enum file)
+
+**Rationale**:
+
+- `enums.proto` already contains FOCUS-related enums (FocusServiceCategory,
+  FocusChargeCategory, etc.)
+- Centralizing enums in one file follows existing codebase pattern
+- Avoids circular imports between proto files
+
+**Alternatives considered**:
+
+- Add to `costsource.proto`: Rejected - would make the already large file even longer
+- Create new `forecasting.proto`: Rejected - over-engineering for a single enum
+
+### 3. Optional Field Pattern for growth_rate
+
+**Decision**: Use `optional double growth_rate` (proto3 optional)
+
+**Rationale**:
+
+- Proto3 optional allows distinguishing "not set" from explicit 0.0
+- Matches existing pattern used for `utilization_percentage` in ResourceDescriptor
+- Required for FR-006: detect when LINEAR/EXPONENTIAL is set but rate is missing
+- Go generated code will use `*float64` pointer type
+
+**Alternatives considered**:
+
+- Regular `double` field: Rejected - cannot distinguish 0.0 from unset
+- Wrapper type (DoubleValue): Rejected - more verbose, optional keyword preferred
+
+### 4. Growth Calculation Formula Precision
+
+**Decision**: Document formulas in proto comments, implement in SDK helper
+
+**Rationale**:
+
+- LINEAR: `cost_at_period_n = base_cost * (1 + rate * n)`
+- EXPONENTIAL: `cost_at_period_n = base_cost * (1 + rate)^n`
+- Proto defines the contract; SDK provides helper functions
+- 0.01% accuracy (SC-002/SC-003) achievable with standard IEEE 754 double precision
+
+**Alternatives considered**:
+
+- Use decimal types: Rejected - proto3 doesn't have native decimal; doubles sufficient
+- Store pre-computed projections: Rejected - against stateless design principle
+
+### 5. Override Semantics for Request-Level Fields
+
+**Decision**: Request-level fields fully override resource-level when set
+
+**Rationale**:
+
+- Simpler mental model: "if set, use it; otherwise, use default"
+- Matches existing `utilization_percentage` override pattern in GetProjectedCostRequest
+- No partial override complexity (e.g., override type but use default rate)
+- Both `growth_type` and `growth_rate` on request override both on resource
+
+**Alternatives considered**:
+
+- Partial override (type-only or rate-only): Rejected - adds complexity, unclear semantics
+- Merge semantics: Rejected - harder to reason about, potential for subtle bugs
+
+### 6. Validation Placement
+
+**Decision**: Validation in SDK helper functions, not proto layer
+
+**Rationale**:
+
+- Proto definitions are descriptive, not prescriptive (no proto-level validators)
+- SDK provides `ValidateGrowthParams(type, rate)` returning error
+- Consistent with existing validation pattern in `sdk/go/pricing/validate.go`
+- gRPC status codes (InvalidArgument) returned by SDK validation
+
+**Alternatives considered**:
+
+- Proto constraints (buf validate): Not mature enough for complex cross-field rules
+- Per-plugin validation: Rejected - inconsistent behavior across implementations
+
+## Existing Codebase Patterns
+
+### Enum Definition Pattern (from enums.proto)
+
+```protobuf
+enum GrowthType {
+  GROWTH_TYPE_UNSPECIFIED = 0;
+  GROWTH_TYPE_NONE = 1;
+  GROWTH_TYPE_LINEAR = 2;
+  GROWTH_TYPE_EXPONENTIAL = 3;
+}
+```
+
+### Optional Double Pattern (from costsource.proto:256)
+
+```protobuf
+// utilization_percentage is a per-resource utilization override (0.0 to 1.0).
+// OPTIONAL. If provided, overrides the global request default.
+optional double utilization_percentage = 6;
+```
+
+### Message Extension Pattern (ResourceDescriptor)
+
+New fields added at end with next available numbers, comprehensive proto comments
+documenting semantics, validation rules, and examples.
+
+## Dependencies
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| buf | v1.32.1 | Proto compilation, lint, breaking detection |
+| google.golang.org/protobuf | latest | Go proto runtime |
+| google.golang.org/grpc | latest | gRPC runtime |
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Breaking change detection false positive | Low | Medium | Review buf output carefully |
+| Field number collision | Very Low | High | Verify current max field numbers |
+| SDK validation edge cases | Medium | Low | Comprehensive test coverage |
+
+## Conclusion
+
+All research questions resolved. No NEEDS CLARIFICATION items remain. Ready for Phase 1
+design work.

--- a/specs/030-forecasting-primitives/spec.md
+++ b/specs/030-forecasting-primitives/spec.md
@@ -1,0 +1,208 @@
+# Feature Specification: Forecasting Primitives
+
+**Feature Branch**: `030-forecasting-primitives`
+**Created**: 2025-12-30
+**Status**: Draft
+**Input**: Update resource.proto to include GrowthType (Enum: NONE, LINEAR, EXPONENTIAL)
+and GrowthRate (double) to enable forward-looking cost projections.
+
+## Clarifications
+
+### Session 2025-12-30
+
+- Q: Where should growth fields be placed? → A: Both ResourceDescriptor (default) and
+  GetProjectedCostRequest (override)
+- Q: Should growth_rate have explicit bounds? → A: Lower bound only (>= -1.0), no upper bound
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Project Future Costs with Growth Assumptions (Priority: P1)
+
+As a FinOps practitioner, I want to specify growth assumptions (linear or exponential) for
+resources so that I can project future costs based on anticipated usage growth patterns.
+
+**Why this priority**: Cost projections are the primary use case for forecasting primitives.
+Without the ability to model growth, organizations cannot plan budgets or anticipate
+infrastructure scaling costs.
+
+**Independent Test**: Can be fully tested by providing a resource descriptor with growth
+parameters and verifying that projected cost responses incorporate the growth model into
+their calculations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor with `growth_type = LINEAR` and `growth_rate = 0.10`,
+   **When** requesting projected costs for 12 months ahead,
+   **Then** the system returns cost projections that increase by 10% each month linearly.
+
+2. **Given** a resource descriptor with `growth_type = EXPONENTIAL` and `growth_rate = 0.05`,
+   **When** requesting projected costs for 6 months ahead,
+   **Then** the system returns cost projections that compound at 5% per period.
+
+3. **Given** a resource descriptor with `growth_type = NONE`,
+   **When** requesting projected costs,
+   **Then** the system returns cost projections based on current usage without any growth
+   assumptions applied.
+
+---
+
+### User Story 2 - Default Behavior for Resources Without Growth Specifications (Priority: P2)
+
+As a plugin developer, I want resources without explicit growth specifications to behave
+predictably so that existing integrations continue to work without modification.
+
+**Why this priority**: Backward compatibility ensures existing users are not disrupted.
+New fields must have safe defaults that maintain current behavior.
+
+**Independent Test**: Can be tested by sending requests without growth fields and verifying
+responses match pre-feature behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor with no growth fields specified,
+   **When** requesting projected costs,
+   **Then** the system treats this as `growth_type = NONE` with no growth applied.
+
+2. **Given** a resource descriptor with only `growth_type` specified (no rate),
+   **When** the growth type is `NONE`,
+   **Then** the system ignores the missing growth rate and returns projections without growth.
+
+---
+
+### User Story 3 - Validate Growth Parameters (Priority: P3)
+
+As a FinOps practitioner, I want invalid growth parameters to be rejected with clear error
+messages so that I can correct configuration mistakes before relying on projections.
+
+**Why this priority**: Input validation prevents incorrect projections from being silently
+used for budget planning, which could lead to significant financial planning errors.
+
+**Independent Test**: Can be tested by sending requests with invalid growth parameters and
+verifying appropriate error responses are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor with `growth_type = LINEAR` but no `growth_rate` specified,
+   **When** requesting projected costs,
+   **Then** the system returns an error indicating the growth rate is required for
+   linear growth.
+
+2. **Given** a resource descriptor with `growth_type = EXPONENTIAL` and a negative
+   `growth_rate`,
+   **When** requesting projected costs,
+   **Then** the system accepts this as a valid declining growth model (negative growth
+   represents expected usage decrease).
+
+3. **Given** a resource descriptor with `growth_type = NONE` and a `growth_rate` value
+   specified,
+   **When** requesting projected costs,
+   **Then** the system ignores the growth rate, returns projections without growth, and
+   logs a DEBUG message noting that `growth_rate` was ignored for `GROWTH_TYPE_NONE`.
+
+---
+
+### Edge Cases
+
+- What happens when growth rate exceeds 100% per period (e.g., `growth_rate = 2.0`)?
+  The system accepts it as valid for rapid scaling scenarios. The SDK MUST log a warning
+  via zerolog at WARN level when `growth_rate > 1.0` to alert operators of unusually high
+  growth assumptions.
+- How does the system handle growth rate of exactly 0.0?
+  The system treats this identically to `growth_type = NONE` (no growth applied).
+- What happens with extremely long projection periods (e.g., 120 months) with exponential
+  growth? The system calculates the projection. The SDK SHOULD log an INFO message when
+  projection periods exceed 36 months with exponential growth, noting that accuracy
+  decreases for distant projections. No calculation is blocked.
+- How are growth fields handled for actual cost queries (historical data)?
+  Growth parameters are only relevant for projected costs; they are ignored for actual
+  cost queries.
+- What happens when growth_rate is exactly -1.0? The system projects costs declining to
+  zero over the projection period (100% decline). Values below -1.0 are rejected as invalid.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a `GrowthType` enumeration with values:
+  `GROWTH_TYPE_UNSPECIFIED`, `GROWTH_TYPE_NONE`, `GROWTH_TYPE_LINEAR`,
+  `GROWTH_TYPE_EXPONENTIAL`.
+
+- **FR-002**: System MUST provide a `growth_rate` field as an optional double value
+  representing the growth rate per projection period.
+
+- **FR-003**: System MUST treat `GROWTH_TYPE_UNSPECIFIED` and `GROWTH_TYPE_NONE`
+  identically, applying no growth to projections.
+
+- **FR-004**: For `GROWTH_TYPE_LINEAR`, the system MUST apply the growth rate as an
+  additive percentage per period (e.g., rate=0.10 adds 10% of the base cost each period).
+
+- **FR-005**: For `GROWTH_TYPE_EXPONENTIAL`, the system MUST apply the growth rate as a
+  compounding factor per period (e.g., rate=0.10 multiplies by 1.10 each period).
+
+- **FR-006**: System MUST return an `InvalidArgument` error when `growth_type` is `LINEAR`
+  or `EXPONENTIAL` but `growth_rate` is not provided.
+
+- **FR-007**: System MUST accept negative `growth_rate` values for modeling declining
+  usage scenarios, with a lower bound of -1.0 (representing 100% decline to zero cost).
+
+- **FR-007a**: System MUST return an `InvalidArgument` error when `growth_rate` is less
+  than -1.0, as this would produce mathematically nonsensical negative costs.
+
+- **FR-008**: System MUST ignore growth parameters for actual cost queries
+  (`GetActualCost` RPC) as growth is only applicable to forward-looking projections.
+
+- **FR-009**: System MUST maintain backward compatibility by treating requests without
+  growth fields identically to current behavior.
+
+- **FR-010**: When growth parameters are specified on both `ResourceDescriptor` and
+  `GetProjectedCostRequest`, the request-level parameters MUST override the resource-level
+  defaults.
+
+### Key Entities
+
+- **GrowthType (Enum)**: Represents the mathematical model used for projecting cost growth.
+  Values indicate no growth, linear (additive) growth, or exponential (compounding) growth.
+
+- **growth_rate (double)**: The rate of growth per projection period expressed as a decimal
+  (0.10 = 10%). Valid range: >= -1.0 (no upper bound). Positive values indicate growth,
+  zero indicates no change, negative values (down to -1.0) indicate decline.
+
+- **ResourceDescriptor (Extended)**: The existing resource descriptor message extended with
+  optional growth parameters (`growth_type`, `growth_rate`) as default values for the resource.
+
+- **GetProjectedCostRequest (Extended)**: The existing request message extended with optional
+  growth parameters that override ResourceDescriptor defaults when specified. This enables
+  different projection scenarios for the same resource in a single session.
+
+## Assumptions
+
+- Growth rate is expressed as a decimal fraction, not a percentage (0.10 means 10%, not
+  0.1%).
+- The projection period for growth calculations aligns with the standard monthly projection
+  period used by `GetProjectedCost`.
+- Growth parameters are optional fields to maintain backward compatibility with existing
+  clients.
+- Plugin implementations that do not support forecasting may ignore these fields and return
+  standard projections.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Users can specify growth assumptions for 100% of resources that support
+  projected cost queries.
+
+- **SC-002**: Cost projections with linear growth show predictable, additive increases that
+  match the specified growth rate within 0.01% accuracy.
+
+- **SC-003**: Cost projections with exponential growth show compounding behavior that
+  matches the specified growth rate within 0.01% accuracy.
+
+- **SC-004**: Existing clients without growth parameters continue to receive identical
+  responses (100% backward compatibility).
+
+- **SC-005**: Invalid growth parameter combinations are rejected with clear error messages
+  in less than 100ms.
+
+- **SC-006**: Plugin developers can implement forecasting support using the SDK in under
+  30 minutes with provided documentation and examples.

--- a/specs/030-forecasting-primitives/tasks.md
+++ b/specs/030-forecasting-primitives/tasks.md
@@ -1,0 +1,307 @@
+# Tasks: Forecasting Primitives
+
+**Input**: Design documents from `/specs/030-forecasting-primitives/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Constitution mandates Test-First Protocol (TDD) - conformance tests must fail before
+proto implementation.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths included in descriptions
+
+## Path Conventions
+
+- **Proto definitions**: `proto/pulumicost/v1/`
+- **Generated code**: `sdk/go/proto/` (via buf generate)
+- **SDK helpers**: `sdk/go/pricing/`
+- **Conformance tests**: `sdk/go/testing/`
+- **Examples**: `examples/requests/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Project initialization and proto tooling verification
+
+- [X] T001 Verify buf v1.32.1 is installed via `make generate` in repository root
+- [X] T002 [P] Run `buf lint` to confirm proto files pass linting before changes
+- [X] T003 [P] Run `buf breaking` against main branch to establish baseline
+
+**Checkpoint**: Proto tooling verified, ready for foundational work
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core proto changes that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until GrowthType enum exists in proto
+
+**TDD Deviation Note**: Per Constitution III (Test-First Protocol), tests should fail before
+implementation. However, Phase 3 tests (T009-T011) reference the GrowthType enum which must
+exist for tests to compile. This is an acceptable deviation: the enum is a foundational type
+required for test compilation, not business logic. Tests will fail at runtime (missing fields)
+not compile time, satisfying the TDD spirit.
+
+- [X] T004 Add GrowthType enum to `proto/pulumicost/v1/enums.proto` with values:
+  GROWTH_TYPE_UNSPECIFIED (0), GROWTH_TYPE_NONE (1), GROWTH_TYPE_LINEAR (2),
+  GROWTH_TYPE_EXPONENTIAL (3)
+- [X] T005 Add import for enums.proto in `proto/pulumicost/v1/costsource.proto` if not present
+- [X] T006 Run `buf lint` to validate new enum follows style conventions
+- [X] T007 Run `buf breaking` to confirm no breaking changes introduced
+- [X] T008 Run `make generate` to regenerate Go SDK code in `sdk/go/proto/`
+
+**Checkpoint**: GrowthType enum exists, SDK regenerated, user stories can begin
+
+---
+
+## Phase 3: User Story 1 - Project Future Costs (Priority: P1) MVP
+
+**Goal**: Enable users to specify growth assumptions (linear/exponential) for cost projections
+
+**Independent Test**: Provide resource descriptor with growth params, verify projected cost
+response incorporates growth model
+
+### Tests for User Story 1 (TDD - Write First, Must Fail)
+
+- [X] T009 [P] [US1] Write conformance test for LINEAR growth in
+  `sdk/go/testing/forecasting_test.go`: Given growth_type=LINEAR, rate=0.10, verify
+  cost increases 10% per period linearly
+- [X] T010 [P] [US1] Write conformance test for EXPONENTIAL growth in
+  `sdk/go/testing/forecasting_test.go`: Given growth_type=EXPONENTIAL, rate=0.05, verify
+  cost compounds at 5% per period
+- [X] T011 [P] [US1] Write conformance test for NONE growth in
+  `sdk/go/testing/forecasting_test.go`: Given growth_type=NONE, verify no growth applied
+- [X] T012 [P] [US1] Write conformance test verifying GetActualCost ignores growth params in
+  `sdk/go/testing/forecasting_test.go`: Given growth params on resource, verify GetActualCost
+  response is unchanged (FR-008)
+- [X] T013 [US1] Run tests, confirm all four FAIL (proto fields don't exist yet)
+
+### Implementation for User Story 1
+
+- [X] T014 [US1] Add growth_type (field 9) and growth_rate (field 10) to ResourceDescriptor
+  message in `proto/pulumicost/v1/costsource.proto` per contracts/forecasting.proto.md
+- [X] T015 [US1] Add growth_type (field 3) and growth_rate (field 4) to GetProjectedCostRequest
+  message in `proto/pulumicost/v1/costsource.proto` per contracts/forecasting.proto.md
+- [X] T016 [US1] Add comprehensive proto comments to growth_type and growth_rate fields
+  documenting semantics, valid ranges, and examples per Constitution V
+- [X] T017 [US1] Run `buf lint` to validate proto changes
+- [X] T018 [US1] Run `buf breaking` to confirm backward compatibility
+- [X] T019 [US1] Run `make generate` to regenerate Go SDK
+- [X] T020 [P] [US1] Implement ApplyLinearGrowth helper function in `sdk/go/pricing/growth.go`:
+  `cost_at_n = base_cost * (1 + rate * n)`
+- [X] T021 [P] [US1] Implement ApplyExponentialGrowth helper function in
+  `sdk/go/pricing/growth.go`: `cost_at_n = base_cost * (1 + rate)^n`
+- [X] T022 [US1] Run conformance tests, verify T009-T012 now PASS
+
+**Checkpoint**: User Story 1 complete - growth projections work with LINEAR, EXPONENTIAL, NONE
+
+---
+
+## Phase 4: User Story 2 - Default Behavior (Priority: P2)
+
+**Goal**: Ensure backward compatibility - resources without growth specs behave as before
+
+**Independent Test**: Send requests without growth fields, verify identical to pre-feature behavior
+
+### Tests for User Story 2 (TDD - Write First, Must Fail)
+
+- [X] T023 [P] [US2] Write backward compatibility test in
+  `sdk/go/testing/forecasting_backward_test.go`: Request without growth fields returns
+  projection without growth (same as current behavior)
+- [X] T024 [P] [US2] Write test for UNSPECIFIED equals NONE in
+  `sdk/go/testing/forecasting_backward_test.go`: GROWTH_TYPE_UNSPECIFIED treated as
+  GROWTH_TYPE_NONE
+- [X] T025 [US2] Run tests, confirm they PASS (default behavior already works from Phase 3)
+
+### Implementation for User Story 2
+
+- [X] T026 [US2] Implement ResolveGrowthType helper in `sdk/go/pricing/growth.go` that treats
+  UNSPECIFIED as NONE
+- [X] T027 [US2] Implement ResolveGrowthParams helper in `sdk/go/pricing/growth.go` that merges
+  request-level overrides with resource-level defaults
+- [X] T028 [US2] Add unit tests for ResolveGrowthType and ResolveGrowthParams in
+  `sdk/go/pricing/growth_test.go`
+- [X] T029 [US2] Run all tests, verify backward compatibility maintained
+
+**Checkpoint**: User Story 2 complete - existing clients unaffected by new fields
+
+---
+
+## Phase 5: User Story 3 - Validate Growth Parameters (Priority: P3)
+
+**Goal**: Reject invalid growth parameters with clear error messages
+
+**Independent Test**: Send invalid growth params, verify InvalidArgument errors returned
+
+### Tests for User Story 3 (TDD - Write First, Must Fail)
+
+- [X] T030 [P] [US3] Write validation test in `sdk/go/testing/forecasting_validation_test.go`:
+  LINEAR without growth_rate returns InvalidArgument error
+- [X] T031 [P] [US3] Write validation test in `sdk/go/testing/forecasting_validation_test.go`:
+  EXPONENTIAL without growth_rate returns InvalidArgument error
+- [X] T032 [P] [US3] Write validation test in `sdk/go/testing/forecasting_validation_test.go`:
+  growth_rate < -1.0 returns InvalidArgument error
+- [X] T033 [P] [US3] Write validation test in `sdk/go/testing/forecasting_validation_test.go`:
+  negative growth_rate >= -1.0 is accepted (valid decline)
+- [X] T034 [US3] Run validation tests, confirm they FAIL (validation not implemented)
+
+### Implementation for User Story 3
+
+- [X] T035 [US3] Implement ValidateGrowthParams function in `sdk/go/pricing/growth.go` per
+  contracts/forecasting.proto.md validation specification
+- [X] T036 [US3] Add error constants for growth validation in `sdk/go/pricing/growth.go`:
+  ErrMissingGrowthRate, ErrInvalidGrowthRate
+- [X] T037 [US3] Add unit tests for ValidateGrowthParams edge cases in
+  `sdk/go/pricing/growth_test.go`
+- [X] T038 [US3] Run validation tests, verify T030-T033 now PASS
+
+**Checkpoint**: User Story 3 complete - invalid parameters rejected with clear messages
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, examples, edge case handling, and final validation
+
+- [X] T039 [P] Create example gRPC request with linear growth in
+  `examples/requests/projected_cost_linear_growth.json`
+- [X] T040 [P] Create example gRPC request with exponential growth in
+  `examples/requests/projected_cost_exponential_growth.json`
+- [X] T041 [P] Create example gRPC request with override in
+  `examples/requests/projected_cost_override.json`
+- [X] T042 Update sdk/go/pricing/README.md with growth helper documentation
+- [X] T043 [P] Implement high-rate warning log in `sdk/go/pricing/growth.go`: Log warning via
+  zerolog when growth_rate > 1.0 (>100% per period) per edge case spec
+- [X] T044 [P] Implement long-projection confidence log in `sdk/go/pricing/growth.go`: Log
+  info when projection period > 36 months with exponential growth per edge case spec
+- [X] T045 Run `make validate` to execute full validation suite
+- [X] T046 Run `make test` to verify all tests pass
+- [X] T047 Run quickstart.md validation - verify code samples compile and measure
+  time-to-completion (target: <30 minutes per SC-006)
+- [X] T048 Update CLAUDE.md with forecasting primitives patterns if needed
+
+**Checkpoint**: Feature complete, documented, validated
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - start immediately
+- **Foundational (Phase 2)**: Depends on Setup - BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational (GrowthType enum must exist)
+- **User Story 2 (Phase 4)**: Depends on User Story 1 (proto fields must exist)
+- **User Story 3 (Phase 5)**: Depends on User Story 1 (proto fields must exist)
+- **Polish (Phase 6)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Primary story - implements core proto changes
+- **User Story 2 (P2)**: Depends on US1 proto fields for default behavior testing
+- **User Story 3 (P3)**: Depends on US1 proto fields for validation implementation
+
+Note: US2 and US3 can run in parallel after US1 completes (different test files, no conflicts)
+
+### Within Each User Story (TDD Cycle)
+
+1. Write tests FIRST - they MUST FAIL
+2. Implement proto changes (if needed)
+3. Regenerate SDK
+4. Implement helper functions
+5. Run tests - verify they PASS
+
+### Parallel Opportunities
+
+**Phase 1 (Setup)**:
+
+```text
+- T002 and T003 can run in parallel (independent linting/breaking checks)
+```
+
+**Phase 2 (Foundational)**:
+
+```text
+- T006 and T007 can run in parallel after T004/T005 (different buf commands)
+```
+
+**Phase 3 (User Story 1)**:
+
+```text
+- T009, T010, T011, T012 can run in parallel (different test cases, same file)
+- T020, T021 can run in parallel (different helper functions)
+```
+
+**Phase 4 (User Story 2)**:
+
+```text
+- T023, T024 can run in parallel (different test cases)
+```
+
+**Phase 5 (User Story 3)**:
+
+```text
+- T030, T031, T032, T033 can run in parallel (different validation test cases)
+```
+
+**Phase 6 (Polish)**:
+
+```text
+- T039, T040, T041 can run in parallel (different example files)
+- T043, T044 can run in parallel (different logging implementations)
+```
+
+---
+
+## Parallel Example: User Story 1 Tests
+
+```bash
+# Launch all conformance tests for User Story 1 together:
+Task: "Write conformance test for LINEAR growth in sdk/go/testing/forecasting_test.go"
+Task: "Write conformance test for EXPONENTIAL growth in sdk/go/testing/forecasting_test.go"
+Task: "Write conformance test for NONE growth in sdk/go/testing/forecasting_test.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (verify tooling)
+2. Complete Phase 2: Foundational (add GrowthType enum)
+3. Complete Phase 3: User Story 1 (proto fields + growth helpers)
+4. **STOP and VALIDATE**: Test growth projections work
+5. Deploy/demo if ready - core forecasting is functional
+
+### Incremental Delivery
+
+1. Setup + Foundational → Proto infrastructure ready
+2. Add User Story 1 → Core growth projections work → **MVP!**
+3. Add User Story 2 → Backward compatibility verified
+4. Add User Story 3 → Validation prevents misuse
+5. Add Polish → Documentation and examples complete
+
+### Constitution Compliance
+
+- **Test-First**: All user story phases begin with failing tests
+- **Proto-First**: Proto changes in Phase 2/3 before SDK helpers
+- **Backward Compatible**: All new fields are optional (buf breaking passes)
+- **Documented**: Proto comments required in implementation tasks
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies, can run in parallel
+- [Story] label maps task to user story for traceability
+- TDD cycle: Write failing test → Implement → Verify test passes
+- Run `buf lint` and `buf breaking` after every proto change
+- Commit after each task or logical group
+- Constitution requires conformance tests before proto changes


### PR DESCRIPTION
## Summary

Enable forward-looking cost projections by adding GrowthType enum and growth_rate fields to ResourceDescriptor and GetProjectedCostRequest. Supports linear growth (additive per period) and exponential growth (compounding) models with comprehensive validation and warning detection for unrealistic assumptions.

## Test plan

- [x] `make test` passes - all 48 spec tasks complete
- [x] `golangci-lint run` passes with 0 issues
- [x] `buf lint` and `buf breaking` pass
- [x] Quickstart code samples validated via quickstart_test.go
- [x] Conformance tests for LINEAR, EXPONENTIAL, NONE growth types
- [x] Backward compatibility tests verify old clients work unchanged
- [x] Validation tests for missing rate and invalid rate bounds
- [x] Overflow edge case tests document +Inf behavior

## Changes

### New files

- `proto/pulumicost/v1/enums.proto` - GrowthType enum (UNSPECIFIED, NONE, LINEAR, EXPONENTIAL)
- `sdk/go/pricing/growth.go` - Growth calculation helpers (ApplyLinearGrowth, ApplyExponentialGrowth, ApplyGrowth, ValidateGrowthParams, CheckGrowthWarnings)
- `sdk/go/pricing/growth_test.go` - Comprehensive unit tests with overflow and negative period edge cases
- `sdk/go/pricing/README.md` - Documentation for growth helper functions
- `sdk/go/testing/forecasting_test.go` - Conformance tests for growth types
- `sdk/go/testing/forecasting_backward_test.go` - Backward compatibility tests
- `specs/030-forecasting-primitives/quickstart_test.go` - Quickstart validation
- `examples/requests/projected_cost_linear_growth.json` - Example request
- `examples/requests/projected_cost_exponential_growth.json` - Example request
- `examples/requests/projected_cost_override.json` - Request-level override example

### Modified files

- `proto/pulumicost/v1/costsource.proto` - Added growth_type and growth_rate fields to ResourceDescriptor (fields 9-10) and GetProjectedCostRequest (fields 3-4)
- `sdk/go/proto/pulumicost/v1/enums.pb.go` - Regenerated with GrowthType
- `sdk/go/proto/pulumicost/v1/costsource.pb.go` - Regenerated with growth fields
- `CLAUDE.md` - Added Forecasting Primitives section with usage patterns
- `specs/030-forecasting-primitives/tasks.md` - All 48 tasks marked complete
- `specs/030-forecasting-primitives/quickstart.md` - Updated error handling to use zerolog

Closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cost growth forecasting: NONE, linear, and exponential models; per-request growth-type and growth-rate overrides; example payloads for linear, exponential, and override scenarios.

* **Documentation**
  * Added pricing package guide and forecasting primitives docs with formulas, validation, warnings, and usage patterns.

* **Tests**
  * Extensive unit, benchmark, concurrency, validation, and backward-compatibility tests covering growth logic, overflow, and warnings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->