### PR TITLE
feat(pluginsdk): Add GetPluginInfo RPC for spec version compatibility

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -119,7 +119,7 @@ reviews:
         - Verify that commands and code snippets actually work
   finishing_touches:
     docstrings:
-      enabled: false  # We handle our own documentation standards
+      enabled: true  # We handle our own documentation standards
     unit_tests:
       enabled: false  # We write our own tests
 chat:

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,50 @@
+# NPM Ignore File
+# Standard Node.js patterns
+node_modules/
+dist/
+build/
+*.log
+.env*
+.lock
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Development tools
+.git/
+.github/
+.vscode/
+.idea/
+.coderabbit.yaml
+.golangci.yml
+.markdownlint*
+.mcp.json
+.release-please*
+.yamllint
+commitlint.config.js
+lefthook.yml
+renovate.json
+
+# Project specific
+bin/
+docs/
+scripts/
+sdk/
+specs/
+test/
+src/
+contracts/
+checklists/
+.claude/
+.gemini/
+.opencode/
+.specify/
+
+# Go files
+go.mod
+go.sum
+Makefile
+
+# Temporary
+tmp/
+coverage/

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -51,6 +51,8 @@ tools to create a robust ecosystem of cost-estimation plugins.
 
 ## Active Technologies
 
+- Go 1.25.5+, Protobuf 3 + `google.golang.org/grpc`, `google.golang.org/protobuf` (029-plugin-info-rpc)
+
 - Go 1.25.5+, Protobuf 3 + `google.golang.org/protobuf`, `google.golang.org/grpc` (018-proto-add-arn)
 - N/A (Proto definition) (018-proto-add-arn)
 

--- a/proto/pulumicost/v1/costsource.proto
+++ b/proto/pulumicost/v1/costsource.proto
@@ -86,6 +86,42 @@ service CostSourceService {
   //   - Unavailable: Budget service temporarily unavailable
   //   - Unimplemented: Plugin does not support budget functionality
   rpc GetBudgets(GetBudgetsRequest) returns (GetBudgetsResponse);
+
+  // GetPluginInfo returns metadata about the plugin for compatibility verification,
+  // diagnostics, and graceful degradation handling.
+  //
+  // This RPC enables the core system to:
+  //   1. Verify plugin compatibility by checking spec_version against supported ranges
+  //   2. Display plugin information in diagnostic tools (plugin list commands)
+  //   3. Handle legacy plugins gracefully (Unimplemented error = legacy plugin)
+  //
+  // The SDK provides a default implementation that returns compile-time constants.
+  // Plugins may override this to provide dynamic metadata if needed.
+  //
+  // Response time should be <100ms (metadata retrieval should be instant).
+  //
+  // Error cases:
+  //   - Unimplemented: Plugin is too old to support this RPC (legacy plugin)
+  //   - Internal: Plugin failed to retrieve its own metadata (unexpected)
+  //
+  // Client-side error handling example (Go):
+  //
+  //   resp, err := client.GetPluginInfo(ctx, &GetPluginInfoRequest{})
+  //   if err != nil {
+  //       if status.Code(err) == codes.Unimplemented {
+  //           // Legacy plugin - use fallback values
+  //           log.Info("Plugin does not implement GetPluginInfo")
+  //           return &PluginMetadata{Name: "unknown", Version: "unknown"}
+  //       }
+  //       return nil, fmt.Errorf("GetPluginInfo failed: %w", err)
+  //   }
+  //   return &PluginMetadata{
+  //       Name:        resp.GetName(),
+  //       Version:     resp.GetVersion(),
+  //       SpecVersion: resp.GetSpecVersion(),
+  //   }
+  //
+  rpc GetPluginInfo(GetPluginInfoRequest) returns (GetPluginInfoResponse);
 }
 
 // NameRequest is used for the Name RPC call (empty request).
@@ -1212,4 +1248,34 @@ message DismissRecommendationResponse {
   optional google.protobuf.Timestamp expires_at = 4;
   // recommendation_id echoes back the dismissed recommendation ID for confirmation.
   string recommendation_id = 5;
+}
+
+// =============================================================================
+// GetPluginInfo RPC - Plugin Metadata and Compatibility
+// =============================================================================
+
+// GetPluginInfoRequest is used to request plugin metadata.
+// Currently empty but may be extended in the future.
+message GetPluginInfoRequest {}
+
+// GetPluginInfoResponse contains metadata about the plugin for compatibility
+// verification, diagnostics, and graceful degradation handling.
+message GetPluginInfoResponse {
+  // name is the display name of the plugin (e.g., "aws-cost-plugin").
+  // Required field - must be non-empty.
+  string name = 1;
+  // version is the semantic version of the plugin implementation (e.g., "v1.2.0").
+  // Required field - must be non-empty.
+  string version = 2;
+  // spec_version is the version of the pulumicost-spec protocol the plugin was
+  // compiled against (e.g., "v0.4.11"). Must be a valid SemVer string.
+  // Required field - used for compatibility verification.
+  string spec_version = 3;
+  // providers lists the cloud providers supported by this plugin (e.g., ["aws"]).
+  // At least one provider should be listed for functional plugins.
+  repeated string providers = 4;
+  // metadata contains optional key-value pairs for additional information
+  // such as build hash, commit ID, or plugin-specific configuration.
+  // Free-form; no key restrictions or size limits enforced by SDK.
+  map<string, string> metadata = 5;
 }

--- a/sdk/go/internal/semver/semver.go
+++ b/sdk/go/internal/semver/semver.go
@@ -1,0 +1,44 @@
+// Package semver provides shared semantic versioning validation for the PulumiCost SDK.
+//
+// This package exists to break circular dependencies between sdk/go/pluginsdk and
+// sdk/go/testing. Both packages need semantic version validation but importing
+// between them would create a circular dependency.
+//
+// # Usage
+//
+// This is an internal package. External consumers should use:
+//   - [github.com/rshade/pulumicost-spec/sdk/go/pluginsdk.ValidateSpecVersion]
+//   - [github.com/rshade/pulumicost-spec/sdk/go/testing.IsValidSemVer]
+package semver
+
+import "regexp"
+
+// Regex is a precompiled regular expression for validating semantic versions.
+// Matches: v1.2.3, v0.0.1, v10.20.30, etc.
+// Does not match: 1.2.3 (no v prefix), v1.2 (missing patch), v1.2.3.4 (too many parts).
+//
+// The regex validates strict semantic versions in vMAJOR.MINOR.PATCH format only.
+// Prerelease and build metadata (e.g., v1.0.0-alpha, v1.0.0+build) are intentionally
+// excluded to ensure deterministic compatibility checking. This prevents ambiguity
+// in version comparison (e.g., is v1.0.0-alpha < v1.0.0? Should v1.0.0-beta work
+// with a core requiring v1.0.0?). By requiring exact vMAJOR.MINOR.PATCH format,
+// version compatibility is unambiguous and consistently sortable.
+//
+// Additional validation rules:
+//   - Required 'v' prefix
+//   - No leading zeros (except for 0 itself)
+//
+// Example valid versions: "v0.4.11", "v1.0.0", "v2.15.3".
+// Example invalid versions: "0.4.11" (no v prefix), "v1.2" (missing patch),
+// "v01.2.3" (leading zero), "v1.0.0-alpha" (prerelease), "v1.0.0+build" (metadata).
+var Regex = regexp.MustCompile(`^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
+
+// IsValid returns true if the version string is a valid semantic version.
+// The version must be in the format vMAJOR.MINOR.PATCH where MAJOR, MINOR, and PATCH
+// are non-negative integers without leading zeros (except for 0 itself).
+func IsValid(version string) bool {
+	if version == "" {
+		return false
+	}
+	return Regex.MatchString(version)
+}

--- a/sdk/go/internal/semver/semver_test.go
+++ b/sdk/go/internal/semver/semver_test.go
@@ -1,0 +1,77 @@
+package semver_test
+
+import (
+	"testing"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/internal/semver"
+)
+
+func TestIsValid(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		// Valid versions
+		{"basic version", "v1.0.0", true},
+		{"zero patch", "v1.0.0", true},
+		{"multi-digit", "v10.20.30", true},
+		{"large numbers", "v123.456.789", true},
+		{"zero major", "v0.1.0", true},
+		{"zero minor", "v1.0.1", true},
+		{"all zeros", "v0.0.0", true},
+		{"mixed digits", "v0.4.11", true},
+
+		// Invalid versions
+		{"empty string", "", false},
+		{"no v prefix", "1.0.0", false},
+		{"missing patch", "v1.0", false},
+		{"missing minor and patch", "v1", false},
+		{"extra part", "v1.2.3.4", false},
+		{"leading zero major", "v01.2.3", false},
+		{"leading zero minor", "v1.02.3", false},
+		{"leading zero patch", "v1.2.03", false},
+		{"pre-release suffix", "v1.0.0-alpha", false},
+		{"build metadata", "v1.0.0+build", false},
+		{"negative number", "v-1.0.0", false},
+		{"text in version", "v1.a.0", false},
+		{"spaces", "v1.0.0 ", false},
+		{"uppercase V", "V1.0.0", false},
+		{"just v", "v", false},
+		{"partial version", "v1.", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := semver.IsValid(tt.version); got != tt.want {
+				t.Errorf("IsValid(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegex(t *testing.T) {
+	// Verify regex is exported and usable
+	if semver.Regex == nil {
+		t.Error("Regex is nil")
+	}
+
+	// Test direct regex usage
+	if !semver.Regex.MatchString("v1.0.0") {
+		t.Error("Regex should match v1.0.0")
+	}
+}
+
+func BenchmarkIsValid(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = semver.IsValid("v0.4.11")
+	}
+}
+
+func BenchmarkRegexMatch(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = semver.Regex.MatchString("v0.4.11")
+	}
+}

--- a/sdk/go/pluginsdk/plugin_info.go
+++ b/sdk/go/pluginsdk/plugin_info.go
@@ -1,0 +1,153 @@
+// Package pluginsdk provides plugin information types and builders.
+package pluginsdk
+
+import (
+	"errors"
+	"fmt"
+)
+
+// PluginInfo holds metadata about a plugin that can be reported via GetPluginInfo RPC.
+// This information enables compatibility verification and diagnostic visibility.
+type PluginInfo struct {
+	// Name is the unique identifier for this plugin (required).
+	Name string
+
+	// Version is the plugin version following semantic versioning (required).
+	// Example: "v1.0.0", "v2.1.3"
+	Version string
+
+	// SpecVersion is the pulumicost-spec version this plugin implements (required).
+	// This value should match the SDK's SpecVersion constant unless the plugin
+	// is designed to work with a specific older/newer spec version.
+	// Example: "v0.4.11"
+	SpecVersion string
+
+	// Providers is a list of cloud providers this plugin supports.
+	// Examples: ["aws"], ["azure", "gcp"], ["kubernetes"]
+	// An empty list indicates the plugin is provider-agnostic.
+	Providers []string
+
+	// Metadata is optional key-value pairs for diagnostic information.
+	// Examples: {"build_date": "2024-01-15", "git_commit": "abc123"}
+	Metadata map[string]string
+}
+
+// PluginInfoOption is a functional option for configuring PluginInfo.
+type PluginInfoOption func(*PluginInfo)
+
+// NewPluginInfo creates a new PluginInfo with the given name and version.
+// The SpecVersion is automatically set to the SDK's current SpecVersion constant.
+// Use functional options to customize additional fields.
+//
+// Example:
+//
+//	info := NewPluginInfo("aws-cost-plugin", "v1.0.0",
+//	    WithProviders("aws"),
+//	    WithMetadata("build_date", "2024-01-15"),
+//	)
+func NewPluginInfo(name, version string, opts ...PluginInfoOption) *PluginInfo {
+	info := &PluginInfo{
+		Name:        name,
+		Version:     version,
+		SpecVersion: SpecVersion, // Use SDK's current spec version
+	}
+
+	for _, opt := range opts {
+		opt(info)
+	}
+
+	return info
+}
+
+// WithSpecVersion overrides the spec version for the plugin.
+// Use this only if your plugin needs to report a different spec version than the SDK's default.
+func WithSpecVersion(specVersion string) PluginInfoOption {
+	return func(info *PluginInfo) {
+		info.SpecVersion = specVersion
+	}
+}
+
+// WithProviders sets the list of cloud providers this plugin supports.
+// Multiple providers can be specified in a single call.
+// A defensive copy is made to prevent aliasing issues if the caller modifies
+// the slice after construction.
+//
+// Example:
+//
+//	WithProviders("aws", "azure", "gcp")
+func WithProviders(providers ...string) PluginInfoOption {
+	return func(info *PluginInfo) {
+		// Defensive copy to prevent aliasing issues
+		info.Providers = make([]string, len(providers))
+		copy(info.Providers, providers)
+	}
+}
+
+// WithMetadata adds a key-value pair to the plugin's metadata.
+// Multiple calls can be chained to add multiple metadata entries.
+//
+// Example:
+//
+//	NewPluginInfo("plugin", "v1.0.0",
+//	    WithMetadata("build_date", "2024-01-15"),
+//	    WithMetadata("git_commit", "abc123"),
+//	)
+func WithMetadata(key, value string) PluginInfoOption {
+	return func(info *PluginInfo) {
+		if info.Metadata == nil {
+			info.Metadata = make(map[string]string)
+		}
+		info.Metadata[key] = value
+	}
+}
+
+// WithMetadataMap sets the entire metadata map at once.
+// This replaces any existing metadata.
+// A defensive copy is made to prevent aliasing issues if the caller modifies
+// the map after construction.
+//
+// Example:
+//
+//	WithMetadataMap(map[string]string{
+//	    "build_date": "2024-01-15",
+//	    "git_commit": "abc123",
+//	})
+func WithMetadataMap(metadata map[string]string) PluginInfoOption {
+	return func(info *PluginInfo) {
+		// Defensive copy to prevent aliasing issues
+		info.Metadata = make(map[string]string, len(metadata))
+		for k, v := range metadata {
+			info.Metadata[k] = v
+		}
+	}
+}
+
+// Validate checks that the PluginInfo has all required fields and they are valid.
+// Returns an error if validation fails. Returns an error if info is nil.
+//
+// Error messages include the actual invalid values to aid debugging. This is safe
+// because plugin names, versions, and spec versions are not sensitive data.
+func (info *PluginInfo) Validate() error {
+	if info == nil {
+		return errors.New("plugin info validation failed: PluginInfo is nil")
+	}
+	if info.Name == "" {
+		return errors.New("plugin info validation failed: name is required (got empty string)")
+	}
+	if info.Version == "" {
+		return fmt.Errorf("plugin info validation failed: version is required for plugin %q (got empty string)",
+			info.Name)
+	}
+	if info.SpecVersion == "" {
+		return fmt.Errorf("plugin info validation failed: spec_version is required for plugin %q (got empty string)",
+			info.Name)
+	}
+
+	// Validate spec_version is a valid SemVer
+	if err := ValidateSpecVersion(info.SpecVersion); err != nil {
+		return fmt.Errorf("plugin info validation failed for plugin %q: invalid spec_version %q: %w",
+			info.Name, info.SpecVersion, err)
+	}
+
+	return nil
+}

--- a/sdk/go/pluginsdk/plugin_info_test.go
+++ b/sdk/go/pluginsdk/plugin_info_test.go
@@ -1,0 +1,437 @@
+package pluginsdk_test
+
+import (
+	"testing"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+)
+
+func TestNewPluginInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		pluginName  string
+		version     string
+		opts        []pluginsdk.PluginInfoOption
+		wantName    string
+		wantVersion string
+		wantSpec    string
+		wantProvs   []string
+		wantMeta    map[string]string
+	}{
+		{
+			name:        "basic plugin info",
+			pluginName:  "test-plugin",
+			version:     "v1.0.0",
+			wantName:    "test-plugin",
+			wantVersion: "v1.0.0",
+			wantSpec:    pluginsdk.SpecVersion,
+		},
+		{
+			name:       "with providers",
+			pluginName: "aws-plugin",
+			version:    "v2.0.0",
+			opts: []pluginsdk.PluginInfoOption{
+				pluginsdk.WithProviders("aws", "azure"),
+			},
+			wantName:    "aws-plugin",
+			wantVersion: "v2.0.0",
+			wantSpec:    pluginsdk.SpecVersion,
+			wantProvs:   []string{"aws", "azure"},
+		},
+		{
+			name:       "with metadata",
+			pluginName: "meta-plugin",
+			version:    "v1.0.0",
+			opts: []pluginsdk.PluginInfoOption{
+				pluginsdk.WithMetadata("build_date", "2024-01-15"),
+				pluginsdk.WithMetadata("git_commit", "abc123"),
+			},
+			wantName:    "meta-plugin",
+			wantVersion: "v1.0.0",
+			wantSpec:    pluginsdk.SpecVersion,
+			wantMeta: map[string]string{
+				"build_date": "2024-01-15",
+				"git_commit": "abc123",
+			},
+		},
+		{
+			name:       "with metadata map",
+			pluginName: "maptest-plugin",
+			version:    "v1.0.0",
+			opts: []pluginsdk.PluginInfoOption{
+				pluginsdk.WithMetadataMap(map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				}),
+			},
+			wantName:    "maptest-plugin",
+			wantVersion: "v1.0.0",
+			wantSpec:    pluginsdk.SpecVersion,
+			wantMeta: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name:       "with custom spec version",
+			pluginName: "legacy-plugin",
+			version:    "v1.0.0",
+			opts: []pluginsdk.PluginInfoOption{
+				pluginsdk.WithSpecVersion("v0.3.0"),
+			},
+			wantName:    "legacy-plugin",
+			wantVersion: "v1.0.0",
+			wantSpec:    "v0.3.0",
+		},
+		{
+			name:       "with all options",
+			pluginName: "full-plugin",
+			version:    "v3.0.0",
+			opts: []pluginsdk.PluginInfoOption{
+				pluginsdk.WithProviders("gcp", "kubernetes"),
+				pluginsdk.WithMetadata("author", "test"),
+				pluginsdk.WithSpecVersion("v0.4.0"),
+			},
+			wantName:    "full-plugin",
+			wantVersion: "v3.0.0",
+			wantSpec:    "v0.4.0",
+			wantProvs:   []string{"gcp", "kubernetes"},
+			wantMeta:    map[string]string{"author": "test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := pluginsdk.NewPluginInfo(tt.pluginName, tt.version, tt.opts...)
+			assertPluginInfo(t, info, tt.wantName, tt.wantVersion, tt.wantSpec, tt.wantProvs, tt.wantMeta)
+		})
+	}
+}
+
+func assertPluginInfo(
+	t *testing.T,
+	info *pluginsdk.PluginInfo,
+	wantName, wantVersion, wantSpec string,
+	wantProvs []string,
+	wantMeta map[string]string,
+) {
+	t.Helper()
+	if info.Name != wantName {
+		t.Errorf("Name = %q, want %q", info.Name, wantName)
+	}
+	if info.Version != wantVersion {
+		t.Errorf("Version = %q, want %q", info.Version, wantVersion)
+	}
+	if info.SpecVersion != wantSpec {
+		t.Errorf("SpecVersion = %q, want %q", info.SpecVersion, wantSpec)
+	}
+
+	// Check providers
+	if len(info.Providers) != len(wantProvs) {
+		t.Errorf("Providers length = %d, want %d", len(info.Providers), len(wantProvs))
+	} else {
+		for i, p := range info.Providers {
+			if p != wantProvs[i] {
+				t.Errorf("Providers[%d] = %q, want %q", i, p, wantProvs[i])
+			}
+		}
+	}
+
+	// Check metadata
+	if len(info.Metadata) != len(wantMeta) {
+		t.Errorf("Metadata length = %d, want %d", len(info.Metadata), len(wantMeta))
+	} else {
+		for k, v := range wantMeta {
+			if info.Metadata[k] != v {
+				t.Errorf("Metadata[%q] = %q, want %q", k, info.Metadata[k], v)
+			}
+		}
+	}
+}
+
+func TestPluginInfoValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		info    *pluginsdk.PluginInfo
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil plugin info",
+			info:    nil,
+			wantErr: true,
+			errMsg:  "PluginInfo is nil",
+		},
+		{
+			name: "valid plugin info",
+			info: &pluginsdk.PluginInfo{
+				Name:        "test-plugin",
+				Version:     "v1.0.0",
+				SpecVersion: "v0.4.11",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with providers and metadata",
+			info: &pluginsdk.PluginInfo{
+				Name:        "full-plugin",
+				Version:     "v2.0.0",
+				SpecVersion: "v0.4.11",
+				Providers:   []string{"aws", "azure"},
+				Metadata:    map[string]string{"key": "value"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty name",
+			info: &pluginsdk.PluginInfo{
+				Name:        "",
+				Version:     "v1.0.0",
+				SpecVersion: "v0.4.11",
+			},
+			wantErr: true,
+			errMsg:  "name is required",
+		},
+		{
+			name: "empty version",
+			info: &pluginsdk.PluginInfo{
+				Name:        "test-plugin",
+				Version:     "",
+				SpecVersion: "v0.4.11",
+			},
+			wantErr: true,
+			errMsg:  "version is required",
+		},
+		{
+			name: "empty spec version",
+			info: &pluginsdk.PluginInfo{
+				Name:        "test-plugin",
+				Version:     "v1.0.0",
+				SpecVersion: "",
+			},
+			wantErr: true,
+			errMsg:  "spec_version is required",
+		},
+		{
+			name: "invalid spec version format",
+			info: &pluginsdk.PluginInfo{
+				Name:        "test-plugin",
+				Version:     "v1.0.0",
+				SpecVersion: "0.4.11", // Missing 'v' prefix
+			},
+			wantErr: true,
+			errMsg:  "not a valid semantic version",
+		},
+		{
+			name: "invalid spec version with prerelease",
+			info: &pluginsdk.PluginInfo{
+				Name:        "test-plugin",
+				Version:     "v1.0.0",
+				SpecVersion: "v0.4.11-alpha",
+			},
+			wantErr: true,
+			errMsg:  "not a valid semantic version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.info.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err != nil {
+				if tt.errMsg != "" && !containsString(err.Error(), tt.errMsg) {
+					t.Errorf("Validate() error = %v, want error containing %q", err, tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+// containsString checks if s contains substr.
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && findSubstring(s, substr)
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWithMetadataAppends(t *testing.T) {
+	// Verify that multiple WithMetadata calls append rather than replace
+	info := pluginsdk.NewPluginInfo("test", "v1.0.0",
+		pluginsdk.WithMetadata("key1", "value1"),
+		pluginsdk.WithMetadata("key2", "value2"),
+		pluginsdk.WithMetadata("key3", "value3"),
+	)
+
+	if len(info.Metadata) != 3 {
+		t.Errorf("Expected 3 metadata entries, got %d", len(info.Metadata))
+	}
+
+	expected := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+
+	for k, v := range expected {
+		if info.Metadata[k] != v {
+			t.Errorf("Metadata[%q] = %q, want %q", k, info.Metadata[k], v)
+		}
+	}
+}
+
+func TestWithMetadataMapReplacesExisting(t *testing.T) {
+	// Verify that WithMetadataMap replaces any existing metadata
+	info := pluginsdk.NewPluginInfo("test", "v1.0.0",
+		pluginsdk.WithMetadata("old_key", "old_value"),
+		pluginsdk.WithMetadataMap(map[string]string{
+			"new_key": "new_value",
+		}),
+	)
+
+	if len(info.Metadata) != 1 {
+		t.Errorf("Expected 1 metadata entry after replace, got %d", len(info.Metadata))
+	}
+
+	if info.Metadata["new_key"] != "new_value" {
+		t.Errorf("Metadata[new_key] = %q, want %q", info.Metadata["new_key"], "new_value")
+	}
+
+	if _, exists := info.Metadata["old_key"]; exists {
+		t.Error("old_key should not exist after WithMetadataMap")
+	}
+}
+
+func BenchmarkNewPluginInfo(b *testing.B) {
+	b.ResetTimer()
+	for range b.N {
+		_ = pluginsdk.NewPluginInfo("bench-plugin", "v1.0.0",
+			pluginsdk.WithProviders("aws", "azure", "gcp"),
+			pluginsdk.WithMetadata("key", "value"),
+		)
+	}
+}
+
+func BenchmarkPluginInfoValidate(b *testing.B) {
+	info := pluginsdk.NewPluginInfo("bench-plugin", "v1.0.0",
+		pluginsdk.WithProviders("aws"),
+		pluginsdk.WithMetadata("key", "value"),
+	)
+
+	b.ResetTimer()
+	for range b.N {
+		_ = info.Validate()
+	}
+}
+
+// Edge Case Tests
+
+func TestPluginInfoWithEmptyProviders(t *testing.T) {
+	// Test with empty but non-nil providers slice
+	info := pluginsdk.NewPluginInfo("test-plugin", "v1.0.0",
+		pluginsdk.WithProviders(), // Empty variadic call creates empty slice
+	)
+
+	if info.Providers == nil {
+		t.Error("Expected non-nil empty providers slice")
+	}
+	if len(info.Providers) != 0 {
+		t.Errorf("Expected 0 providers, got %d", len(info.Providers))
+	}
+
+	// Should still validate successfully
+	if err := info.Validate(); err != nil {
+		t.Errorf("Validate() returned unexpected error: %v", err)
+	}
+}
+
+func TestPluginInfoWithExplicitNilMetadata(t *testing.T) {
+	// Test with explicitly nil metadata map (not just unset)
+	info := &pluginsdk.PluginInfo{
+		Name:        "test-plugin",
+		Version:     "v1.0.0",
+		SpecVersion: pluginsdk.SpecVersion,
+		Providers:   []string{"aws"},
+		Metadata:    nil, // Explicitly nil
+	}
+
+	// Should validate successfully (metadata is optional)
+	if err := info.Validate(); err != nil {
+		t.Errorf("Validate() returned unexpected error: %v", err)
+	}
+}
+
+func TestPluginInfoWithLongName(t *testing.T) {
+	// Test with a very long plugin name (boundary testing)
+	// 256 characters is a reasonable max for identifiers
+	longName := make([]byte, 256)
+	for i := range longName {
+		longName[i] = 'a'
+	}
+
+	info := pluginsdk.NewPluginInfo(string(longName), "v1.0.0")
+
+	if info.Name != string(longName) {
+		t.Error("Long plugin name was not preserved")
+	}
+
+	// Should still validate successfully (no length limit enforced)
+	if err := info.Validate(); err != nil {
+		t.Errorf("Validate() returned unexpected error for long name: %v", err)
+	}
+}
+
+func TestWithProvidersDefensiveCopy(t *testing.T) {
+	// Verify that WithProviders creates a defensive copy
+	originalProviders := []string{"aws", "azure"}
+	info := pluginsdk.NewPluginInfo("test-plugin", "v1.0.0",
+		pluginsdk.WithProviders(originalProviders...),
+	)
+
+	// Modify the original slice after construction
+	originalProviders[0] = "modified"
+	originalProviders[1] = "also-modified"
+
+	// The info's providers should be unchanged
+	if info.Providers[0] != "aws" {
+		t.Errorf("Expected Providers[0] = %q, got %q (defensive copy failed)", "aws", info.Providers[0])
+	}
+	if info.Providers[1] != "azure" {
+		t.Errorf("Expected Providers[1] = %q, got %q (defensive copy failed)", "azure", info.Providers[1])
+	}
+}
+
+func TestWithMetadataMapDefensiveCopy(t *testing.T) {
+	// Verify that WithMetadataMap creates a defensive copy
+	originalMetadata := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	info := pluginsdk.NewPluginInfo("test-plugin", "v1.0.0",
+		pluginsdk.WithMetadataMap(originalMetadata),
+	)
+
+	// Modify the original map after construction
+	originalMetadata["key1"] = "modified"
+	originalMetadata["new_key"] = "new_value"
+
+	// The info's metadata should be unchanged
+	if info.Metadata["key1"] != "value1" {
+		t.Errorf("Expected Metadata[key1] = %q, got %q (defensive copy failed)", "value1", info.Metadata["key1"])
+	}
+	if _, exists := info.Metadata["new_key"]; exists {
+		t.Error("new_key should not exist in info's metadata (defensive copy failed)")
+	}
+	if len(info.Metadata) != 2 {
+		t.Errorf("Expected 2 metadata entries, got %d (defensive copy failed)", len(info.Metadata))
+	}
+}

--- a/sdk/go/pluginsdk/version.go
+++ b/sdk/go/pluginsdk/version.go
@@ -1,0 +1,60 @@
+// Package pluginsdk provides version information for the PulumiCost specification.
+package pluginsdk
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/internal/semver"
+)
+
+// init validates the SpecVersion constant at package initialization.
+// This catches invalid versions immediately at startup rather than at runtime
+// when GetPluginInfo is called, providing fail-fast behavior for developers.
+//
+//nolint:gochecknoinits // Intentional validation at package initialization
+func init() {
+	if err := ValidateSpecVersion(SpecVersion); err != nil {
+		panic(fmt.Sprintf("pluginsdk: invalid SpecVersion constant %q: %v", SpecVersion, err))
+	}
+}
+
+// SpecVersion is the version of the pulumicost-spec protocol that this SDK implements.
+// This constant is used by the default GetPluginInfo handler to report the spec version
+// that plugins were compiled against.
+//
+// The version follows Semantic Versioning (https://semver.org/).
+// Format: vMAJOR.MINOR.PATCH (e.g., "v0.4.11")
+//
+// IMPORTANT: This value should be updated when the spec version changes.
+// It is typically synchronized with the repository's release tags.
+const SpecVersion = "v0.4.11"
+
+// ValidateSpecVersion validates that a version string is a valid semantic version.
+// The version must be in the format vMAJOR.MINOR.PATCH where MAJOR, MINOR, and PATCH
+// are non-negative integers without leading zeros (except for 0 itself).
+//
+// Valid examples: "v0.4.11", "v1.0.0", "v2.15.3"
+// Invalid examples: "0.4.11" (no v prefix), "v1.2" (missing patch), "v01.2.3" (leading zero)
+//
+// Returns nil if the version is valid, or an error describing the validation failure.
+func ValidateSpecVersion(version string) error {
+	if version == "" {
+		return errors.New("spec_version is required")
+	}
+
+	if !semver.IsValid(version) {
+		return fmt.Errorf(
+			"spec_version %q is not a valid semantic version (expected format: vMAJOR.MINOR.PATCH)",
+			version,
+		)
+	}
+
+	return nil
+}
+
+// IsValidSpecVersion returns true if the version string is a valid semantic version.
+// This is a convenience wrapper around ValidateSpecVersion for boolean checks.
+func IsValidSpecVersion(version string) bool {
+	return ValidateSpecVersion(version) == nil
+}

--- a/sdk/go/pluginsdk/version_test.go
+++ b/sdk/go/pluginsdk/version_test.go
@@ -1,0 +1,110 @@
+package pluginsdk_test
+
+import (
+	"testing"
+
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+)
+
+func TestSpecVersionConstant(t *testing.T) {
+	// Verify the SpecVersion constant is a valid semantic version
+	if err := pluginsdk.ValidateSpecVersion(pluginsdk.SpecVersion); err != nil {
+		t.Errorf("SpecVersion constant %q is not a valid semantic version: %v", pluginsdk.SpecVersion, err)
+	}
+}
+
+func TestValidateSpecVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		// Valid versions
+		{name: "valid v0.0.0", version: "v0.0.0", wantErr: false},
+		{name: "valid v0.4.11", version: "v0.4.11", wantErr: false},
+		{name: "valid v1.0.0", version: "v1.0.0", wantErr: false},
+		{name: "valid v1.2.3", version: "v1.2.3", wantErr: false},
+		{name: "valid v10.20.30", version: "v10.20.30", wantErr: false},
+		{name: "valid v999.999.999", version: "v999.999.999", wantErr: false},
+
+		// Invalid versions - empty
+		{name: "empty string", version: "", wantErr: true},
+
+		// Invalid versions - missing v prefix
+		{name: "no v prefix", version: "0.4.11", wantErr: true},
+		{name: "no v prefix 1.0.0", version: "1.0.0", wantErr: true},
+
+		// Invalid versions - wrong format
+		{name: "missing patch", version: "v1.2", wantErr: true},
+		{name: "missing minor and patch", version: "v1", wantErr: true},
+		{name: "too many parts", version: "v1.2.3.4", wantErr: true},
+		{name: "prerelease suffix", version: "v1.0.0-alpha", wantErr: true},
+		{name: "build metadata", version: "v1.0.0+build", wantErr: true},
+
+		// Invalid versions - leading zeros
+		{name: "leading zero in major", version: "v01.2.3", wantErr: true},
+		{name: "leading zero in minor", version: "v1.02.3", wantErr: true},
+		{name: "leading zero in patch", version: "v1.2.03", wantErr: true},
+
+		// Invalid versions - non-numeric
+		{name: "non-numeric major", version: "va.2.3", wantErr: true},
+		{name: "non-numeric minor", version: "v1.b.3", wantErr: true},
+		{name: "non-numeric patch", version: "v1.2.c", wantErr: true},
+
+		// Invalid versions - negative numbers
+		{name: "negative major", version: "v-1.2.3", wantErr: true},
+		{name: "negative minor", version: "v1.-2.3", wantErr: true},
+		{name: "negative patch", version: "v1.2.-3", wantErr: true},
+
+		// Invalid versions - special characters
+		{name: "spaces", version: "v 1.2.3", wantErr: true},
+		{name: "dots only", version: "v...", wantErr: true},
+		{name: "uppercase V", version: "V1.2.3", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pluginsdk.ValidateSpecVersion(tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSpecVersion(%q) error = %v, wantErr %v", tt.version, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsValidSpecVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{"v0.4.11", true},
+		{"v1.0.0", true},
+		{"", false},
+		{"1.0.0", false},
+		{"v1.2", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := pluginsdk.IsValidSpecVersion(tt.version); got != tt.want {
+				t.Errorf("IsValidSpecVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkValidateSpecVersion(b *testing.B) {
+	version := "v0.4.11"
+	b.ResetTimer()
+	for range b.N {
+		_ = pluginsdk.ValidateSpecVersion(version)
+	}
+}
+
+func BenchmarkIsValidSpecVersion(b *testing.B) {
+	version := "v0.4.11"
+	b.ResetTimer()
+	for range b.N {
+		_ = pluginsdk.IsValidSpecVersion(version)
+	}
+}

--- a/sdk/go/proto/pulumicost/v1/costsource.pb.go
+++ b/sdk/go/proto/pulumicost/v1/costsource.pb.go
@@ -4975,6 +4975,134 @@ func (x *DismissRecommendationResponse) GetRecommendationId() string {
 	return ""
 }
 
+// GetPluginInfoRequest is used to request plugin metadata.
+// Currently empty but may be extended in the future.
+type GetPluginInfoRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetPluginInfoRequest) Reset() {
+	*x = GetPluginInfoRequest{}
+	mi := &file_pulumicost_v1_costsource_proto_msgTypes[48]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPluginInfoRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPluginInfoRequest) ProtoMessage() {}
+
+func (x *GetPluginInfoRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_pulumicost_v1_costsource_proto_msgTypes[48]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPluginInfoRequest.ProtoReflect.Descriptor instead.
+func (*GetPluginInfoRequest) Descriptor() ([]byte, []int) {
+	return file_pulumicost_v1_costsource_proto_rawDescGZIP(), []int{48}
+}
+
+// GetPluginInfoResponse contains metadata about the plugin for compatibility
+// verification, diagnostics, and graceful degradation handling.
+type GetPluginInfoResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// name is the display name of the plugin (e.g., "aws-cost-plugin").
+	// Required field - must be non-empty.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// version is the semantic version of the plugin implementation (e.g., "v1.2.0").
+	// Required field - must be non-empty.
+	Version string `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
+	// spec_version is the version of the pulumicost-spec protocol the plugin was
+	// compiled against (e.g., "v0.4.11"). Must be a valid SemVer string.
+	// Required field - used for compatibility verification.
+	SpecVersion string `protobuf:"bytes,3,opt,name=spec_version,json=specVersion,proto3" json:"spec_version,omitempty"`
+	// providers lists the cloud providers supported by this plugin (e.g., ["aws"]).
+	// At least one provider should be listed for functional plugins.
+	Providers []string `protobuf:"bytes,4,rep,name=providers,proto3" json:"providers,omitempty"`
+	// metadata contains optional key-value pairs for additional information
+	// such as build hash, commit ID, or plugin-specific configuration.
+	// Free-form; no key restrictions or size limits enforced by SDK.
+	Metadata      map[string]string `protobuf:"bytes,5,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetPluginInfoResponse) Reset() {
+	*x = GetPluginInfoResponse{}
+	mi := &file_pulumicost_v1_costsource_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetPluginInfoResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetPluginInfoResponse) ProtoMessage() {}
+
+func (x *GetPluginInfoResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_pulumicost_v1_costsource_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetPluginInfoResponse.ProtoReflect.Descriptor instead.
+func (*GetPluginInfoResponse) Descriptor() ([]byte, []int) {
+	return file_pulumicost_v1_costsource_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *GetPluginInfoResponse) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *GetPluginInfoResponse) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *GetPluginInfoResponse) GetSpecVersion() string {
+	if x != nil {
+		return x.SpecVersion
+	}
+	return ""
+}
+
+func (x *GetPluginInfoResponse) GetProviders() []string {
+	if x != nil {
+		return x.Providers
+	}
+	return nil
+}
+
+func (x *GetPluginInfoResponse) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 var File_pulumicost_v1_costsource_proto protoreflect.FileDescriptor
 
 const file_pulumicost_v1_costsource_proto_rawDesc = "" +
@@ -5361,7 +5489,17 @@ const file_pulumicost_v1_costsource_proto_rawDesc = "" +
 	"\n" +
 	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\texpiresAt\x88\x01\x01\x12+\n" +
 	"\x11recommendation_id\x18\x05 \x01(\tR\x10recommendationIdB\r\n" +
-	"\v_expires_at*\x8c\x01\n" +
+	"\v_expires_at\"\x16\n" +
+	"\x14GetPluginInfoRequest\"\x93\x02\n" +
+	"\x15GetPluginInfoResponse\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\x12!\n" +
+	"\fspec_version\x18\x03 \x01(\tR\vspecVersion\x12\x1c\n" +
+	"\tproviders\x18\x04 \x03(\tR\tproviders\x12N\n" +
+	"\bmetadata\x18\x05 \x03(\v22.pulumicost.v1.GetPluginInfoResponse.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01*\x8c\x01\n" +
 	"\n" +
 	"MetricKind\x12\x1b\n" +
 	"\x17METRIC_KIND_UNSPECIFIED\x10\x00\x12 \n" +
@@ -5453,7 +5591,7 @@ const file_pulumicost_v1_costsource_proto_rawDesc = "" +
 	"%DISMISSAL_REASON_TECHNICAL_CONSTRAINT\x10\x04\x12\x1d\n" +
 	"\x19DISMISSAL_REASON_DEFERRED\x10\x05\x12\x1f\n" +
 	"\x1bDISMISSAL_REASON_INACCURATE\x10\x06\x12\x1a\n" +
-	"\x16DISMISSAL_REASON_OTHER\x10\a2\xcc\x06\n" +
+	"\x16DISMISSAL_REASON_OTHER\x10\a2\xa8\a\n" +
 	"\x11CostSourceService\x12?\n" +
 	"\x04Name\x12\x1a.pulumicost.v1.NameRequest\x1a\x1b.pulumicost.v1.NameResponse\x12K\n" +
 	"\bSupports\x12\x1e.pulumicost.v1.SupportsRequest\x1a\x1f.pulumicost.v1.SupportsResponse\x12Z\n" +
@@ -5464,7 +5602,8 @@ const file_pulumicost_v1_costsource_proto_rawDesc = "" +
 	"\x12GetRecommendations\x12(.pulumicost.v1.GetRecommendationsRequest\x1a).pulumicost.v1.GetRecommendationsResponse\x12r\n" +
 	"\x15DismissRecommendation\x12+.pulumicost.v1.DismissRecommendationRequest\x1a,.pulumicost.v1.DismissRecommendationResponse\x12Q\n" +
 	"\n" +
-	"GetBudgets\x12 .pulumicost.v1.GetBudgetsRequest\x1a!.pulumicost.v1.GetBudgetsResponse2\xbf\x02\n" +
+	"GetBudgets\x12 .pulumicost.v1.GetBudgetsRequest\x1a!.pulumicost.v1.GetBudgetsResponse\x12Z\n" +
+	"\rGetPluginInfo\x12#.pulumicost.v1.GetPluginInfoRequest\x1a$.pulumicost.v1.GetPluginInfoResponse2\xbf\x02\n" +
 	"\x14ObservabilityService\x12T\n" +
 	"\vHealthCheck\x12!.pulumicost.v1.HealthCheckRequest\x1a\".pulumicost.v1.HealthCheckResponse\x12Q\n" +
 	"\n" +
@@ -5484,7 +5623,7 @@ func file_pulumicost_v1_costsource_proto_rawDescGZIP() []byte {
 }
 
 var file_pulumicost_v1_costsource_proto_enumTypes = make([]protoimpl.EnumInfo, 13)
-var file_pulumicost_v1_costsource_proto_msgTypes = make([]protoimpl.MessageInfo, 65)
+var file_pulumicost_v1_costsource_proto_msgTypes = make([]protoimpl.MessageInfo, 68)
 var file_pulumicost_v1_costsource_proto_goTypes = []any{
 	(MetricKind)(0),                           // 0: pulumicost.v1.MetricKind
 	(FallbackHint)(0),                         // 1: pulumicost.v1.FallbackHint
@@ -5547,82 +5686,85 @@ var file_pulumicost_v1_costsource_proto_goTypes = []any{
 	(*RecommendationSummary)(nil),             // 58: pulumicost.v1.RecommendationSummary
 	(*DismissRecommendationRequest)(nil),      // 59: pulumicost.v1.DismissRecommendationRequest
 	(*DismissRecommendationResponse)(nil),     // 60: pulumicost.v1.DismissRecommendationResponse
-	nil,                                       // 61: pulumicost.v1.SupportsResponse.CapabilitiesEntry
-	nil,                                       // 62: pulumicost.v1.GetActualCostRequest.TagsEntry
-	nil,                                       // 63: pulumicost.v1.ResourceDescriptor.TagsEntry
-	nil,                                       // 64: pulumicost.v1.PricingSpec.PluginMetadataEntry
-	nil,                                       // 65: pulumicost.v1.ErrorDetail.DetailsEntry
-	nil,                                       // 66: pulumicost.v1.MetricSample.LabelsEntry
-	nil,                                       // 67: pulumicost.v1.LogEntry.FieldsEntry
-	nil,                                       // 68: pulumicost.v1.RecommendationFilter.TagsEntry
-	nil,                                       // 69: pulumicost.v1.Recommendation.MetadataEntry
-	nil,                                       // 70: pulumicost.v1.ResourceRecommendationInfo.TagsEntry
-	nil,                                       // 71: pulumicost.v1.ResourceUtilization.CustomMetricsEntry
-	nil,                                       // 72: pulumicost.v1.ModifyAction.CurrentConfigEntry
-	nil,                                       // 73: pulumicost.v1.ModifyAction.RecommendedConfigEntry
-	nil,                                       // 74: pulumicost.v1.RecommendationSummary.CountByCategoryEntry
-	nil,                                       // 75: pulumicost.v1.RecommendationSummary.SavingsByCategoryEntry
-	nil,                                       // 76: pulumicost.v1.RecommendationSummary.CountByActionTypeEntry
-	nil,                                       // 77: pulumicost.v1.RecommendationSummary.SavingsByActionTypeEntry
-	(*timestamppb.Timestamp)(nil),             // 78: google.protobuf.Timestamp
-	(GrowthType)(0),                           // 79: pulumicost.v1.GrowthType
-	(*FocusCostRecord)(nil),                   // 80: pulumicost.v1.FocusCostRecord
-	(*structpb.Struct)(nil),                   // 81: google.protobuf.Struct
-	(*GetBudgetsRequest)(nil),                 // 82: pulumicost.v1.GetBudgetsRequest
-	(*GetBudgetsResponse)(nil),                // 83: pulumicost.v1.GetBudgetsResponse
+	(*GetPluginInfoRequest)(nil),              // 61: pulumicost.v1.GetPluginInfoRequest
+	(*GetPluginInfoResponse)(nil),             // 62: pulumicost.v1.GetPluginInfoResponse
+	nil,                                       // 63: pulumicost.v1.SupportsResponse.CapabilitiesEntry
+	nil,                                       // 64: pulumicost.v1.GetActualCostRequest.TagsEntry
+	nil,                                       // 65: pulumicost.v1.ResourceDescriptor.TagsEntry
+	nil,                                       // 66: pulumicost.v1.PricingSpec.PluginMetadataEntry
+	nil,                                       // 67: pulumicost.v1.ErrorDetail.DetailsEntry
+	nil,                                       // 68: pulumicost.v1.MetricSample.LabelsEntry
+	nil,                                       // 69: pulumicost.v1.LogEntry.FieldsEntry
+	nil,                                       // 70: pulumicost.v1.RecommendationFilter.TagsEntry
+	nil,                                       // 71: pulumicost.v1.Recommendation.MetadataEntry
+	nil,                                       // 72: pulumicost.v1.ResourceRecommendationInfo.TagsEntry
+	nil,                                       // 73: pulumicost.v1.ResourceUtilization.CustomMetricsEntry
+	nil,                                       // 74: pulumicost.v1.ModifyAction.CurrentConfigEntry
+	nil,                                       // 75: pulumicost.v1.ModifyAction.RecommendedConfigEntry
+	nil,                                       // 76: pulumicost.v1.RecommendationSummary.CountByCategoryEntry
+	nil,                                       // 77: pulumicost.v1.RecommendationSummary.SavingsByCategoryEntry
+	nil,                                       // 78: pulumicost.v1.RecommendationSummary.CountByActionTypeEntry
+	nil,                                       // 79: pulumicost.v1.RecommendationSummary.SavingsByActionTypeEntry
+	nil,                                       // 80: pulumicost.v1.GetPluginInfoResponse.MetadataEntry
+	(*timestamppb.Timestamp)(nil),             // 81: google.protobuf.Timestamp
+	(GrowthType)(0),                           // 82: pulumicost.v1.GrowthType
+	(*FocusCostRecord)(nil),                   // 83: pulumicost.v1.FocusCostRecord
+	(*structpb.Struct)(nil),                   // 84: google.protobuf.Struct
+	(*GetBudgetsRequest)(nil),                 // 85: pulumicost.v1.GetBudgetsRequest
+	(*GetBudgetsResponse)(nil),                // 86: pulumicost.v1.GetBudgetsResponse
 }
 var file_pulumicost_v1_costsource_proto_depIdxs = []int32{
 	0,  // 0: pulumicost.v1.ImpactMetric.kind:type_name -> pulumicost.v1.MetricKind
 	24, // 1: pulumicost.v1.SupportsRequest.resource:type_name -> pulumicost.v1.ResourceDescriptor
-	61, // 2: pulumicost.v1.SupportsResponse.capabilities:type_name -> pulumicost.v1.SupportsResponse.CapabilitiesEntry
+	63, // 2: pulumicost.v1.SupportsResponse.capabilities:type_name -> pulumicost.v1.SupportsResponse.CapabilitiesEntry
 	0,  // 3: pulumicost.v1.SupportsResponse.supported_metrics:type_name -> pulumicost.v1.MetricKind
-	78, // 4: pulumicost.v1.GetActualCostRequest.start:type_name -> google.protobuf.Timestamp
-	78, // 5: pulumicost.v1.GetActualCostRequest.end:type_name -> google.protobuf.Timestamp
-	62, // 6: pulumicost.v1.GetActualCostRequest.tags:type_name -> pulumicost.v1.GetActualCostRequest.TagsEntry
+	81, // 4: pulumicost.v1.GetActualCostRequest.start:type_name -> google.protobuf.Timestamp
+	81, // 5: pulumicost.v1.GetActualCostRequest.end:type_name -> google.protobuf.Timestamp
+	64, // 6: pulumicost.v1.GetActualCostRequest.tags:type_name -> pulumicost.v1.GetActualCostRequest.TagsEntry
 	25, // 7: pulumicost.v1.GetActualCostResponse.results:type_name -> pulumicost.v1.ActualCostResult
 	1,  // 8: pulumicost.v1.GetActualCostResponse.fallback_hint:type_name -> pulumicost.v1.FallbackHint
 	24, // 9: pulumicost.v1.GetProjectedCostRequest.resource:type_name -> pulumicost.v1.ResourceDescriptor
-	79, // 10: pulumicost.v1.GetProjectedCostRequest.growth_type:type_name -> pulumicost.v1.GrowthType
+	82, // 10: pulumicost.v1.GetProjectedCostRequest.growth_type:type_name -> pulumicost.v1.GrowthType
 	15, // 11: pulumicost.v1.GetProjectedCostResponse.impact_metrics:type_name -> pulumicost.v1.ImpactMetric
 	24, // 12: pulumicost.v1.GetPricingSpecRequest.resource:type_name -> pulumicost.v1.ResourceDescriptor
 	27, // 13: pulumicost.v1.GetPricingSpecResponse.spec:type_name -> pulumicost.v1.PricingSpec
-	63, // 14: pulumicost.v1.ResourceDescriptor.tags:type_name -> pulumicost.v1.ResourceDescriptor.TagsEntry
-	79, // 15: pulumicost.v1.ResourceDescriptor.growth_type:type_name -> pulumicost.v1.GrowthType
-	78, // 16: pulumicost.v1.ActualCostResult.timestamp:type_name -> google.protobuf.Timestamp
-	80, // 17: pulumicost.v1.ActualCostResult.focus_record:type_name -> pulumicost.v1.FocusCostRecord
+	65, // 14: pulumicost.v1.ResourceDescriptor.tags:type_name -> pulumicost.v1.ResourceDescriptor.TagsEntry
+	82, // 15: pulumicost.v1.ResourceDescriptor.growth_type:type_name -> pulumicost.v1.GrowthType
+	81, // 16: pulumicost.v1.ActualCostResult.timestamp:type_name -> google.protobuf.Timestamp
+	83, // 17: pulumicost.v1.ActualCostResult.focus_record:type_name -> pulumicost.v1.FocusCostRecord
 	15, // 18: pulumicost.v1.ActualCostResult.impact_metrics:type_name -> pulumicost.v1.ImpactMetric
 	26, // 19: pulumicost.v1.PricingSpec.metric_hints:type_name -> pulumicost.v1.UsageMetricHint
-	64, // 20: pulumicost.v1.PricingSpec.plugin_metadata:type_name -> pulumicost.v1.PricingSpec.PluginMetadataEntry
+	66, // 20: pulumicost.v1.PricingSpec.plugin_metadata:type_name -> pulumicost.v1.PricingSpec.PluginMetadataEntry
 	28, // 21: pulumicost.v1.PricingSpec.pricing_tiers:type_name -> pulumicost.v1.PricingTier
 	3,  // 22: pulumicost.v1.ErrorDetail.code:type_name -> pulumicost.v1.ErrorCode
 	2,  // 23: pulumicost.v1.ErrorDetail.category:type_name -> pulumicost.v1.ErrorCategory
-	65, // 24: pulumicost.v1.ErrorDetail.details:type_name -> pulumicost.v1.ErrorDetail.DetailsEntry
-	78, // 25: pulumicost.v1.ErrorDetail.timestamp:type_name -> google.protobuf.Timestamp
+	67, // 24: pulumicost.v1.ErrorDetail.details:type_name -> pulumicost.v1.ErrorDetail.DetailsEntry
+	81, // 25: pulumicost.v1.ErrorDetail.timestamp:type_name -> google.protobuf.Timestamp
 	12, // 26: pulumicost.v1.HealthCheckResponse.status:type_name -> pulumicost.v1.HealthCheckResponse.Status
-	78, // 27: pulumicost.v1.HealthCheckResponse.last_check_time:type_name -> google.protobuf.Timestamp
+	81, // 27: pulumicost.v1.HealthCheckResponse.last_check_time:type_name -> google.protobuf.Timestamp
 	34, // 28: pulumicost.v1.GetMetricsResponse.metrics:type_name -> pulumicost.v1.Metric
-	78, // 29: pulumicost.v1.GetMetricsResponse.timestamp:type_name -> google.protobuf.Timestamp
+	81, // 29: pulumicost.v1.GetMetricsResponse.timestamp:type_name -> google.protobuf.Timestamp
 	4,  // 30: pulumicost.v1.Metric.type:type_name -> pulumicost.v1.MetricType
 	35, // 31: pulumicost.v1.Metric.samples:type_name -> pulumicost.v1.MetricSample
-	66, // 32: pulumicost.v1.MetricSample.labels:type_name -> pulumicost.v1.MetricSample.LabelsEntry
-	78, // 33: pulumicost.v1.MetricSample.timestamp:type_name -> google.protobuf.Timestamp
+	68, // 32: pulumicost.v1.MetricSample.labels:type_name -> pulumicost.v1.MetricSample.LabelsEntry
+	81, // 33: pulumicost.v1.MetricSample.timestamp:type_name -> google.protobuf.Timestamp
 	39, // 34: pulumicost.v1.GetServiceLevelIndicatorsRequest.time_range:type_name -> pulumicost.v1.TimeRange
 	38, // 35: pulumicost.v1.GetServiceLevelIndicatorsResponse.slis:type_name -> pulumicost.v1.ServiceLevelIndicator
-	78, // 36: pulumicost.v1.GetServiceLevelIndicatorsResponse.measurement_time:type_name -> google.protobuf.Timestamp
+	81, // 36: pulumicost.v1.GetServiceLevelIndicatorsResponse.measurement_time:type_name -> google.protobuf.Timestamp
 	5,  // 37: pulumicost.v1.ServiceLevelIndicator.status:type_name -> pulumicost.v1.SLIStatus
-	78, // 38: pulumicost.v1.TimeRange.start:type_name -> google.protobuf.Timestamp
-	78, // 39: pulumicost.v1.TimeRange.end:type_name -> google.protobuf.Timestamp
-	78, // 40: pulumicost.v1.LogEntry.timestamp:type_name -> google.protobuf.Timestamp
-	67, // 41: pulumicost.v1.LogEntry.fields:type_name -> pulumicost.v1.LogEntry.FieldsEntry
+	81, // 38: pulumicost.v1.TimeRange.start:type_name -> google.protobuf.Timestamp
+	81, // 39: pulumicost.v1.TimeRange.end:type_name -> google.protobuf.Timestamp
+	81, // 40: pulumicost.v1.LogEntry.timestamp:type_name -> google.protobuf.Timestamp
+	69, // 41: pulumicost.v1.LogEntry.fields:type_name -> pulumicost.v1.LogEntry.FieldsEntry
 	42, // 42: pulumicost.v1.LogEntry.error_details:type_name -> pulumicost.v1.ErrorDetails
-	81, // 43: pulumicost.v1.EstimateCostRequest.attributes:type_name -> google.protobuf.Struct
+	84, // 43: pulumicost.v1.EstimateCostRequest.attributes:type_name -> google.protobuf.Struct
 	47, // 44: pulumicost.v1.GetRecommendationsRequest.filter:type_name -> pulumicost.v1.RecommendationFilter
 	24, // 45: pulumicost.v1.GetRecommendationsRequest.target_resources:type_name -> pulumicost.v1.ResourceDescriptor
 	48, // 46: pulumicost.v1.GetRecommendationsResponse.recommendations:type_name -> pulumicost.v1.Recommendation
 	58, // 47: pulumicost.v1.GetRecommendationsResponse.summary:type_name -> pulumicost.v1.RecommendationSummary
 	6,  // 48: pulumicost.v1.RecommendationFilter.category:type_name -> pulumicost.v1.RecommendationCategory
 	7,  // 49: pulumicost.v1.RecommendationFilter.action_type:type_name -> pulumicost.v1.RecommendationActionType
-	68, // 50: pulumicost.v1.RecommendationFilter.tags:type_name -> pulumicost.v1.RecommendationFilter.TagsEntry
+	70, // 50: pulumicost.v1.RecommendationFilter.tags:type_name -> pulumicost.v1.RecommendationFilter.TagsEntry
 	8,  // 51: pulumicost.v1.RecommendationFilter.priority:type_name -> pulumicost.v1.RecommendationPriority
 	9,  // 52: pulumicost.v1.RecommendationFilter.sort_by:type_name -> pulumicost.v1.RecommendationSortBy
 	10, // 53: pulumicost.v1.RecommendationFilter.sort_order:type_name -> pulumicost.v1.SortOrder
@@ -5636,55 +5778,58 @@ var file_pulumicost_v1_costsource_proto_depIdxs = []int32{
 	56, // 61: pulumicost.v1.Recommendation.modify:type_name -> pulumicost.v1.ModifyAction
 	57, // 62: pulumicost.v1.Recommendation.impact:type_name -> pulumicost.v1.RecommendationImpact
 	8,  // 63: pulumicost.v1.Recommendation.priority:type_name -> pulumicost.v1.RecommendationPriority
-	78, // 64: pulumicost.v1.Recommendation.created_at:type_name -> google.protobuf.Timestamp
-	69, // 65: pulumicost.v1.Recommendation.metadata:type_name -> pulumicost.v1.Recommendation.MetadataEntry
-	70, // 66: pulumicost.v1.ResourceRecommendationInfo.tags:type_name -> pulumicost.v1.ResourceRecommendationInfo.TagsEntry
+	81, // 64: pulumicost.v1.Recommendation.created_at:type_name -> google.protobuf.Timestamp
+	71, // 65: pulumicost.v1.Recommendation.metadata:type_name -> pulumicost.v1.Recommendation.MetadataEntry
+	72, // 66: pulumicost.v1.ResourceRecommendationInfo.tags:type_name -> pulumicost.v1.ResourceRecommendationInfo.TagsEntry
 	50, // 67: pulumicost.v1.ResourceRecommendationInfo.utilization:type_name -> pulumicost.v1.ResourceUtilization
-	71, // 68: pulumicost.v1.ResourceUtilization.custom_metrics:type_name -> pulumicost.v1.ResourceUtilization.CustomMetricsEntry
+	73, // 68: pulumicost.v1.ResourceUtilization.custom_metrics:type_name -> pulumicost.v1.ResourceUtilization.CustomMetricsEntry
 	50, // 69: pulumicost.v1.RightsizeAction.projected_utilization:type_name -> pulumicost.v1.ResourceUtilization
 	55, // 70: pulumicost.v1.KubernetesAction.current_requests:type_name -> pulumicost.v1.KubernetesResources
 	55, // 71: pulumicost.v1.KubernetesAction.recommended_requests:type_name -> pulumicost.v1.KubernetesResources
 	55, // 72: pulumicost.v1.KubernetesAction.current_limits:type_name -> pulumicost.v1.KubernetesResources
 	55, // 73: pulumicost.v1.KubernetesAction.recommended_limits:type_name -> pulumicost.v1.KubernetesResources
-	72, // 74: pulumicost.v1.ModifyAction.current_config:type_name -> pulumicost.v1.ModifyAction.CurrentConfigEntry
-	73, // 75: pulumicost.v1.ModifyAction.recommended_config:type_name -> pulumicost.v1.ModifyAction.RecommendedConfigEntry
-	74, // 76: pulumicost.v1.RecommendationSummary.count_by_category:type_name -> pulumicost.v1.RecommendationSummary.CountByCategoryEntry
-	75, // 77: pulumicost.v1.RecommendationSummary.savings_by_category:type_name -> pulumicost.v1.RecommendationSummary.SavingsByCategoryEntry
-	76, // 78: pulumicost.v1.RecommendationSummary.count_by_action_type:type_name -> pulumicost.v1.RecommendationSummary.CountByActionTypeEntry
-	77, // 79: pulumicost.v1.RecommendationSummary.savings_by_action_type:type_name -> pulumicost.v1.RecommendationSummary.SavingsByActionTypeEntry
+	74, // 74: pulumicost.v1.ModifyAction.current_config:type_name -> pulumicost.v1.ModifyAction.CurrentConfigEntry
+	75, // 75: pulumicost.v1.ModifyAction.recommended_config:type_name -> pulumicost.v1.ModifyAction.RecommendedConfigEntry
+	76, // 76: pulumicost.v1.RecommendationSummary.count_by_category:type_name -> pulumicost.v1.RecommendationSummary.CountByCategoryEntry
+	77, // 77: pulumicost.v1.RecommendationSummary.savings_by_category:type_name -> pulumicost.v1.RecommendationSummary.SavingsByCategoryEntry
+	78, // 78: pulumicost.v1.RecommendationSummary.count_by_action_type:type_name -> pulumicost.v1.RecommendationSummary.CountByActionTypeEntry
+	79, // 79: pulumicost.v1.RecommendationSummary.savings_by_action_type:type_name -> pulumicost.v1.RecommendationSummary.SavingsByActionTypeEntry
 	11, // 80: pulumicost.v1.DismissRecommendationRequest.reason:type_name -> pulumicost.v1.DismissalReason
-	78, // 81: pulumicost.v1.DismissRecommendationRequest.expires_at:type_name -> google.protobuf.Timestamp
-	78, // 82: pulumicost.v1.DismissRecommendationResponse.dismissed_at:type_name -> google.protobuf.Timestamp
-	78, // 83: pulumicost.v1.DismissRecommendationResponse.expires_at:type_name -> google.protobuf.Timestamp
-	13, // 84: pulumicost.v1.CostSourceService.Name:input_type -> pulumicost.v1.NameRequest
-	16, // 85: pulumicost.v1.CostSourceService.Supports:input_type -> pulumicost.v1.SupportsRequest
-	18, // 86: pulumicost.v1.CostSourceService.GetActualCost:input_type -> pulumicost.v1.GetActualCostRequest
-	20, // 87: pulumicost.v1.CostSourceService.GetProjectedCost:input_type -> pulumicost.v1.GetProjectedCostRequest
-	22, // 88: pulumicost.v1.CostSourceService.GetPricingSpec:input_type -> pulumicost.v1.GetPricingSpecRequest
-	43, // 89: pulumicost.v1.CostSourceService.EstimateCost:input_type -> pulumicost.v1.EstimateCostRequest
-	45, // 90: pulumicost.v1.CostSourceService.GetRecommendations:input_type -> pulumicost.v1.GetRecommendationsRequest
-	59, // 91: pulumicost.v1.CostSourceService.DismissRecommendation:input_type -> pulumicost.v1.DismissRecommendationRequest
-	82, // 92: pulumicost.v1.CostSourceService.GetBudgets:input_type -> pulumicost.v1.GetBudgetsRequest
-	30, // 93: pulumicost.v1.ObservabilityService.HealthCheck:input_type -> pulumicost.v1.HealthCheckRequest
-	32, // 94: pulumicost.v1.ObservabilityService.GetMetrics:input_type -> pulumicost.v1.GetMetricsRequest
-	36, // 95: pulumicost.v1.ObservabilityService.GetServiceLevelIndicators:input_type -> pulumicost.v1.GetServiceLevelIndicatorsRequest
-	14, // 96: pulumicost.v1.CostSourceService.Name:output_type -> pulumicost.v1.NameResponse
-	17, // 97: pulumicost.v1.CostSourceService.Supports:output_type -> pulumicost.v1.SupportsResponse
-	19, // 98: pulumicost.v1.CostSourceService.GetActualCost:output_type -> pulumicost.v1.GetActualCostResponse
-	21, // 99: pulumicost.v1.CostSourceService.GetProjectedCost:output_type -> pulumicost.v1.GetProjectedCostResponse
-	23, // 100: pulumicost.v1.CostSourceService.GetPricingSpec:output_type -> pulumicost.v1.GetPricingSpecResponse
-	44, // 101: pulumicost.v1.CostSourceService.EstimateCost:output_type -> pulumicost.v1.EstimateCostResponse
-	46, // 102: pulumicost.v1.CostSourceService.GetRecommendations:output_type -> pulumicost.v1.GetRecommendationsResponse
-	60, // 103: pulumicost.v1.CostSourceService.DismissRecommendation:output_type -> pulumicost.v1.DismissRecommendationResponse
-	83, // 104: pulumicost.v1.CostSourceService.GetBudgets:output_type -> pulumicost.v1.GetBudgetsResponse
-	31, // 105: pulumicost.v1.ObservabilityService.HealthCheck:output_type -> pulumicost.v1.HealthCheckResponse
-	33, // 106: pulumicost.v1.ObservabilityService.GetMetrics:output_type -> pulumicost.v1.GetMetricsResponse
-	37, // 107: pulumicost.v1.ObservabilityService.GetServiceLevelIndicators:output_type -> pulumicost.v1.GetServiceLevelIndicatorsResponse
-	96, // [96:108] is the sub-list for method output_type
-	84, // [84:96] is the sub-list for method input_type
-	84, // [84:84] is the sub-list for extension type_name
-	84, // [84:84] is the sub-list for extension extendee
-	0,  // [0:84] is the sub-list for field type_name
+	81, // 81: pulumicost.v1.DismissRecommendationRequest.expires_at:type_name -> google.protobuf.Timestamp
+	81, // 82: pulumicost.v1.DismissRecommendationResponse.dismissed_at:type_name -> google.protobuf.Timestamp
+	81, // 83: pulumicost.v1.DismissRecommendationResponse.expires_at:type_name -> google.protobuf.Timestamp
+	80, // 84: pulumicost.v1.GetPluginInfoResponse.metadata:type_name -> pulumicost.v1.GetPluginInfoResponse.MetadataEntry
+	13, // 85: pulumicost.v1.CostSourceService.Name:input_type -> pulumicost.v1.NameRequest
+	16, // 86: pulumicost.v1.CostSourceService.Supports:input_type -> pulumicost.v1.SupportsRequest
+	18, // 87: pulumicost.v1.CostSourceService.GetActualCost:input_type -> pulumicost.v1.GetActualCostRequest
+	20, // 88: pulumicost.v1.CostSourceService.GetProjectedCost:input_type -> pulumicost.v1.GetProjectedCostRequest
+	22, // 89: pulumicost.v1.CostSourceService.GetPricingSpec:input_type -> pulumicost.v1.GetPricingSpecRequest
+	43, // 90: pulumicost.v1.CostSourceService.EstimateCost:input_type -> pulumicost.v1.EstimateCostRequest
+	45, // 91: pulumicost.v1.CostSourceService.GetRecommendations:input_type -> pulumicost.v1.GetRecommendationsRequest
+	59, // 92: pulumicost.v1.CostSourceService.DismissRecommendation:input_type -> pulumicost.v1.DismissRecommendationRequest
+	85, // 93: pulumicost.v1.CostSourceService.GetBudgets:input_type -> pulumicost.v1.GetBudgetsRequest
+	61, // 94: pulumicost.v1.CostSourceService.GetPluginInfo:input_type -> pulumicost.v1.GetPluginInfoRequest
+	30, // 95: pulumicost.v1.ObservabilityService.HealthCheck:input_type -> pulumicost.v1.HealthCheckRequest
+	32, // 96: pulumicost.v1.ObservabilityService.GetMetrics:input_type -> pulumicost.v1.GetMetricsRequest
+	36, // 97: pulumicost.v1.ObservabilityService.GetServiceLevelIndicators:input_type -> pulumicost.v1.GetServiceLevelIndicatorsRequest
+	14, // 98: pulumicost.v1.CostSourceService.Name:output_type -> pulumicost.v1.NameResponse
+	17, // 99: pulumicost.v1.CostSourceService.Supports:output_type -> pulumicost.v1.SupportsResponse
+	19, // 100: pulumicost.v1.CostSourceService.GetActualCost:output_type -> pulumicost.v1.GetActualCostResponse
+	21, // 101: pulumicost.v1.CostSourceService.GetProjectedCost:output_type -> pulumicost.v1.GetProjectedCostResponse
+	23, // 102: pulumicost.v1.CostSourceService.GetPricingSpec:output_type -> pulumicost.v1.GetPricingSpecResponse
+	44, // 103: pulumicost.v1.CostSourceService.EstimateCost:output_type -> pulumicost.v1.EstimateCostResponse
+	46, // 104: pulumicost.v1.CostSourceService.GetRecommendations:output_type -> pulumicost.v1.GetRecommendationsResponse
+	60, // 105: pulumicost.v1.CostSourceService.DismissRecommendation:output_type -> pulumicost.v1.DismissRecommendationResponse
+	86, // 106: pulumicost.v1.CostSourceService.GetBudgets:output_type -> pulumicost.v1.GetBudgetsResponse
+	62, // 107: pulumicost.v1.CostSourceService.GetPluginInfo:output_type -> pulumicost.v1.GetPluginInfoResponse
+	31, // 108: pulumicost.v1.ObservabilityService.HealthCheck:output_type -> pulumicost.v1.HealthCheckResponse
+	33, // 109: pulumicost.v1.ObservabilityService.GetMetrics:output_type -> pulumicost.v1.GetMetricsResponse
+	37, // 110: pulumicost.v1.ObservabilityService.GetServiceLevelIndicators:output_type -> pulumicost.v1.GetServiceLevelIndicatorsResponse
+	98, // [98:111] is the sub-list for method output_type
+	85, // [85:98] is the sub-list for method input_type
+	85, // [85:85] is the sub-list for extension type_name
+	85, // [85:85] is the sub-list for extension extendee
+	0,  // [0:85] is the sub-list for field type_name
 }
 
 func init() { file_pulumicost_v1_costsource_proto_init() }
@@ -5714,7 +5859,7 @@ func file_pulumicost_v1_costsource_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pulumicost_v1_costsource_proto_rawDesc), len(file_pulumicost_v1_costsource_proto_rawDesc)),
 			NumEnums:      13,
-			NumMessages:   65,
+			NumMessages:   68,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/sdk/go/testing/harness.go
+++ b/sdk/go/testing/harness.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/rshade/pulumicost-spec/sdk/go/internal/semver"
 	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
 )
 
@@ -241,6 +242,18 @@ func ValidateNameResponse(response *pbc.NameResponse) error {
 		return fmt.Errorf("plugin name too long: %d characters", len(response.GetName()))
 	}
 	return nil
+}
+
+// IsValidSemVer validates that a version string is a valid semantic version.
+// The version must be in the format vMAJOR.MINOR.PATCH where MAJOR, MINOR, and PATCH
+// are non-negative integers without leading zeros (except for 0 itself).
+//
+// Valid examples: "v0.4.11", "v1.0.0", "v2.15.3"
+// Invalid examples: "0.4.11" (no v prefix), "v1.2" (missing patch), "v01.2.3" (leading zero).
+//
+// This function delegates to the internal/semver package to avoid regex duplication.
+func IsValidSemVer(version string) bool {
+	return semver.IsValid(version)
 }
 
 // ValidateSupportsResponse validates a Supports RPC response.

--- a/specs/029-plugin-info-rpc/checklists/requirements.md
+++ b/specs/029-plugin-info-rpc/checklists/requirements.md
@@ -1,0 +1,35 @@
+<!-- markdownlint-disable MD013 -->
+# Specification Quality Checklist: Add GetPluginInfo RPC
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-30
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The feature is inherently technical (adding an RPC to a protocol), so some domain-specific terms (RPC, CostSource, SDK) are used as functional entities rather than implementation details.

--- a/specs/029-plugin-info-rpc/contracts/costsource.proto
+++ b/specs/029-plugin-info-rpc/contracts/costsource.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package pulumicost.v1;
+
+option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto;pbc";
+
+// ... (existing imports and messages) ...
+
+// Request for plugin metadata.
+message GetPluginInfoRequest {}
+
+// Response containing plugin metadata.
+message GetPluginInfoResponse {
+  // Plugin name (e.g., "aws-cost-plugin").
+  string name = 1;
+  // Plugin implementation version (e.g., "v1.0.0").
+  string version = 2;
+  // Spec version the plugin was built against (e.g., "v0.4.11").
+  string spec_version = 3;
+  // List of supported cloud providers (e.g., ["aws", "azure"]).
+  repeated string providers = 4;
+  // Optional additional metadata.
+  map<string, string> metadata = 5;
+}
+
+service CostSourceService {
+  // ... (existing RPCs) ...
+
+  // GetPluginInfo returns metadata about the plugin, including the spec version
+  // it was built against. This allows the core system to verify compatibility.
+  rpc GetPluginInfo(GetPluginInfoRequest) returns (GetPluginInfoResponse);
+}

--- a/specs/029-plugin-info-rpc/data-model.md
+++ b/specs/029-plugin-info-rpc/data-model.md
@@ -1,0 +1,35 @@
+<!-- markdownlint-disable MD013 -->
+# Data Model: Add GetPluginInfo RPC
+
+## Entities
+
+### Plugin Info
+
+Represents the metadata of a loaded cost source plugin.
+
+| Field          | Type                | Description                                                                                                                                    |
+| :------------- | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`         | `string`            | The display name of the plugin (e.g., "aws-cost-plugin").                                                                                      |
+| `version`      | `string`            | The semantic version of the plugin implementation (e.g., "v1.2.0").                                                                            |
+| `spec_version` | `string`            | The version of the `pulumicost-spec` protocol the plugin was compiled against (e.g., "v0.4.11").                                               |
+| `providers`    | `[]string`          | List of cloud providers supported by this plugin (e.g., `["aws"]`).                                                                            |
+| `metadata`     | `map[string]string` | Optional key-value pairs for additional metadata (e.g., build hash, commit ID). Free-form; no key restrictions or size limits enforced by SDK. |
+
+## Validation Rules
+
+1. **Spec Version**: MUST be a valid Semantic Version (vX.Y.Z).
+2. **Name**: MUST be non-empty.
+3. **Version**: MUST be non-empty.
+4. **Providers**: MUST contain at least one provider if functional.
+
+## RPC Methods
+
+### `GetPluginInfo`
+
+Retrieves the `PluginInfo` from the cost source.
+
+- **Request**: `GetPluginInfoRequest` (Empty)
+- **Response**: `GetPluginInfoResponse`
+- **Error Handling**:
+  - `Unimplemented`: Plugin is too old to support this RPC. Client should treat `spec_version` as "Unknown" and proceed with warning.
+  - `Internal`: Plugin failed to retrieve its own metadata (unexpected).

--- a/specs/029-plugin-info-rpc/plan.md
+++ b/specs/029-plugin-info-rpc/plan.md
@@ -1,0 +1,73 @@
+<!-- markdownlint-disable MD013 -->
+# Implementation Plan: Add GetPluginInfo RPC
+
+**Branch**: `029-plugin-info-rpc` | **Date**: 2025-12-30 | **Spec**: [specs/029-plugin-info-rpc/spec.md](spec.md)
+**Input**: Feature specification from `/specs/029-plugin-info-rpc/spec.md`
+
+## Summary
+
+Add a `GetPluginInfo` RPC to the `CostSource` service. This RPC allows the core system to request metadata from a loaded plugin, specifically the `spec_version` it was built against, to enable compatibility verification, diagnostics, and graceful degradation. The implementation involves updating the `CostSource` proto definition, regenerating the Go SDK, and adding a default implementation in `pluginsdk` that returns compile-time constants (Name, Version, SpecVersion).
+
+## Technical Context
+
+**Language/Version**: Go 1.25.5+, Protobuf 3
+**Primary Dependencies**: `google.golang.org/grpc`, `google.golang.org/protobuf`
+**Storage**: N/A
+**Testing**: Go standard library `testing`, `pluginsdk.test` framework
+**Target Platform**: Linux/macOS/Windows (Cross-platform Go binaries)
+**Project Type**: Single project (SDK + Proto definitions)
+**Performance Goals**: < 100ms response time for `GetPluginInfo` (metadata retrieval should be instant)
+**Constraints**: Must maintain backward compatibility for existing plugins (they will return "Unimplemented").
+**Scale/Scope**: Core protocol change affecting all future plugins.
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+- [x] **I. gRPC Proto Specification-First Development**: Plan starts with updating `costsource.proto`.
+- [x] **II. Multi-Provider gRPC Consistency**: `GetPluginInfo` is provider-agnostic metadata.
+- [x] **III. Test-First Protocol**: Plan includes creating conformance tests before implementation.
+- [x] **IV. Protobuf Backward Compatibility**: Adding a new RPC is a non-breaking change. Existing clients can ignore it; existing servers will return Unimplemented.
+- [x] **V. Comprehensive Documentation**: Plan includes updating documentation and examples.
+- [x] **VI. Performance as a gRPC Requirement**: `GetPluginInfo` is a lightweight metadata call.
+- [x] **VII. Validation at Multiple Levels**: Plan includes SDK validation for metadata fields.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-plugin-info-rpc/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+# Single project structure
+proto/
+└── pulumicost/
+    └── v1/
+        └── costsource.proto # RPC definition
+
+sdk/
+└── go/
+    ├── proto/               # Generated code
+    ├── pluginsdk/           # SDK implementation
+    │   ├── base.go          # Default handler
+    │   └── version.go       # Version constants
+    └── testing/             # Conformance tests
+```
+
+**Structure Decision**: Standard Go SDK structure within the existing monorepo.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| :-------- | :--------- | :----------------------------------- |
+| None      | N/A        | N/A                                  |

--- a/specs/029-plugin-info-rpc/quickstart.md
+++ b/specs/029-plugin-info-rpc/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Add GetPluginInfo RPC
+
+## Prerequisites
+
+- Go 1.25+
+- Protobuf compiler (`protoc`)
+- `buf` CLI
+
+## Steps
+
+1. **Update Proto Definition**:
+   - Modify `proto/pulumicost/v1/costsource.proto` to include `GetPluginInfo` RPC and messages.
+
+2. **Regenerate SDK**:
+   - Run `make generate` (or `buf generate`) to update `sdk/go/proto/`.
+
+3. **Update SDK Implementation**:
+   - In `sdk/go/pluginsdk/`:
+     - Add `SpecVersion` constant (e.g., in `version.go`).
+     - Implement `GetPluginInfo` in the base plugin handler (e.g., `base.go` or `server.go`).
+
+4. **Verify**:
+   - Run `go test ./sdk/go/...` to ensure no regressions.
+   - Create a new conformance test case in `sdk/go/testing/` to call `GetPluginInfo` and validate the response.
+
+## Usage Example (Client)
+
+```go
+client := pbc.NewCostSourceServiceClient(conn)
+resp, err := client.GetPluginInfo(ctx, &pbc.GetPluginInfoRequest{})
+if err != nil {
+    if status.Code(err) == codes.Unimplemented {
+        log.Warn("Plugin does not support GetPluginInfo (legacy version)")
+        // Handle legacy plugin
+    } else {
+        log.Error("Failed to get plugin info", "error", err)
+    }
+} else {
+    fmt.Printf("Plugin: %s %s (Spec: %s)\n", resp.Name, resp.Version, resp.SpecVersion)
+}
+```

--- a/specs/029-plugin-info-rpc/research.md
+++ b/specs/029-plugin-info-rpc/research.md
@@ -1,0 +1,76 @@
+<!-- markdownlint-disable MD013 -->
+# Research: Add GetPluginInfo RPC
+
+**Branch**: `029-plugin-info-rpc` | **Date**: 2025-12-30
+
+## 1. Proto Definition
+
+**Decision**: Add `GetPluginInfo` to `CostSource` service in `proto/pulumicost/v1/costsource.proto`.
+
+**Rationale**:
+
+- `CostSource` is the primary service implemented by plugins.
+- Centralizes metadata retrieval alongside functional RPCs.
+- Avoids creating a separate "MetadataService" for a single method, reducing complexity.
+
+**Proto Definition**:
+
+```protobuf
+message GetPluginInfoRequest {}
+
+message GetPluginInfoResponse {
+  string name = 1;          // Plugin name (e.g., "aws-public")
+  string version = 2;       // Plugin version (e.g., "v1.0.0")
+  string spec_version = 3;  // Spec version plugin was built against (e.g., "v0.4.11")
+  repeated string providers = 4; // Supported providers (e.g., ["aws"])
+  map<string, string> metadata = 5; // Optional additional metadata
+}
+
+service CostSourceService {
+  // ... existing RPCs ...
+  rpc GetPluginInfo(GetPluginInfoRequest) returns (GetPluginInfoResponse);
+}
+```
+
+## 2. SDK Implementation
+
+**Decision**: Implement a default `GetPluginInfo` handler in `pluginsdk.BasePlugin` (or equivalent base struct) that plugins embed.
+
+**Rationale**:
+
+- Reduces boilerplate for plugin developers.
+- Ensures consistent `spec_version` reporting (the SDK knows its own version).
+- Allows plugins to override if dynamic metadata is needed, though the default should suffice for 99% of cases.
+
+**Implementation Details**:
+
+- `pluginsdk` package will export a constant `SpecVersion`.
+- The base implementation will return this constant.
+- `Name` and `Version` will be populated from the plugin's configuration/initialization struct.
+
+## 3. Versioning Strategy
+
+**Decision**: Use SemVer (vX.Y.Z) for `spec_version`.
+
+**Rationale**:
+
+- Standard in the Go ecosystem.
+- Allows for compatibility ranges (e.g., core supports `^1.0.0`).
+- Consistent with the project's existing versioning.
+
+## 4. Compatibility
+
+**Decision**: Handle `Unimplemented` error in Core.
+
+**Rationale**:
+
+- Existing plugins built against older protos will not implement `GetPluginInfo`.
+- gRPC servers return `Unimplemented` (status code 12) for unknown methods.
+- Core must treat this as "Unknown/Legacy Version" rather than a fatal error, logging a warning but proceeding (graceful degradation).
+
+## 5. Alternatives Considered
+
+- **Alternative**: CLI flag for version (e.g., `--version`).
+  - Rejected: Inconsistent with gRPC-first architecture. Requires executing the binary just to check version, which is slower/heavier than an RPC if the connection is already established (or prevents establishing a connection if the binary interface changed).
+- **Alternative**: Metadata in `Register` call (if one existed).
+  - Rejected: We don't have a dynamic registration RPC; plugins are often loaded by path or discovered. An explicit query RPC is more robust.

--- a/specs/029-plugin-info-rpc/spec.md
+++ b/specs/029-plugin-info-rpc/spec.md
@@ -1,0 +1,117 @@
+<!-- markdownlint-disable MD013 -->
+# Feature Specification: Add GetPluginInfo RPC
+
+**Feature Branch**: `029-plugin-info-rpc`  
+**Created**: 2025-12-30  
+**Status**: Draft  
+**Input**: User description: "Add GetPluginInfo() RPC for spec version compatibility checking"
+
+## Clarifications
+
+### Session 2025-12-30
+
+- Q: What is the timeout for the `GetPluginInfo` call? → A: 5 seconds (Option B).
+- Q: What format must `spec_version` follow? → A: SemVer (vX.Y.Z) (Option A).
+- Q: How should malformed metadata be handled? → A: Strict (Option A) - Fail initialization if Name, Version, or SpecVersion are missing/invalid.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Compatibility Verification (Priority: P1)
+
+As the Core System, I want to request metadata from a loaded plugin so that I can verify if its spec version is compatible with my current version.
+
+**Why this priority**: Essential for preventing runtime errors caused by mismatched protocol versions as the ecosystem grows.
+
+**Independent Test**: Can be fully tested by creating a mock plugin implementing the RPC and verifying the Core receives the correct data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plugin that implements `GetPluginInfo`, **When** the Core calls this RPC, **Then** it receives the plugin's name, version, and `spec_version`.
+2. **Given** a plugin returns a `spec_version`, **When** the Core checks it, **Then** it can determine if the version is supported.
+
+---
+
+### User Story 2 - Diagnostic Visibility (Priority: P2)
+
+As a Developer or Operator, I want to see the spec version of installed plugins when listing them, so that I can debug compatibility issues or identify outdated plugins.
+
+**Why this priority**: Provides visibility and easier troubleshooting for users managing multiple plugins.
+
+**Independent Test**: Can be tested by running the plugin list command and verifying output contains spec version info.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple installed plugins, **When** a consumer calls `GetPluginInfo` on each,
+   **Then** the response includes `spec_version` that can be displayed in diagnostic tools.
+
+> **Note**: The actual CLI/list command is a consumer-side implementation detail, not part of this SDK.
+
+---
+
+### User Story 3 - Graceful Degradation (Priority: P3)
+
+As the Core System, I want to handle plugins that do not implement `GetPluginInfo` gracefully, so that existing plugins continue to work without modification.
+
+**Why this priority**: Ensures backward compatibility and prevents breaking changes for existing deployments.
+
+**Independent Test**: Can be tested by attempting to call the RPC on a plugin that does not implement it and asserting the system catches the error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a legacy plugin that does not implement `GetPluginInfo`, **When** the Core calls the RPC, **Then** it receives an "Unimplemented" error (or similar) and treats the spec version as "Unknown" or logs a warning, but does not crash.
+
+---
+
+### Edge Cases
+
+- **Malformed/empty metadata**: Handled by FR-007 (SDK validates SemVer format) and FR-008
+  _(Consumer)_ (Core validates required fields). SDK returns validation error; consumer fails init.
+- **Plugin hangs during call**: Handled by FR-005 _(Consumer)_ with 5-second timeout. SDK has no
+  timeout responsibility; consumers must implement.
+- **spec_version format changes**: Out of scope for this feature. Future spec versions would define
+  migration path. Current implementation uses SemVer (vX.Y.Z) per FR-007.
+
+## Requirements _(mandatory)_
+
+### Scope Clarification
+
+This feature implements the **plugin SDK side** of GetPluginInfo. The following are **consumer-side
+responsibilities** that plugin SDK users (e.g., pulumicost-core) must implement:
+
+- Calling GetPluginInfo with appropriate timeout
+- Handling Unimplemented errors from legacy plugins
+- Validating response fields before use
+- Displaying plugin info in CLI tools
+
+> **Note**: Consumer-side requirements are marked with _(Consumer)_ below. A tracking issue will be
+> created in pulumicost-core to implement these once this spec version is released.
+
+### Functional Requirements
+
+- **FR-001**: The `CostSource` service definition MUST include a `GetPluginInfo` operation.
+- **FR-002**: The `GetPluginInfo` response MUST include the plugin's `name`, `version`, `spec_version`, and a list of supported `providers`.
+- **FR-003**: The plugin SDK MUST provide a default implementation of `GetPluginInfo` that automatically returns the SDK's compiled Spec Version.
+- **FR-004**: The SDK MUST define a constant for the current Spec Version to ensure consistency.
+- **FR-005** _(Consumer)_: The Core System MUST attempt to call `GetPluginInfo` upon plugin
+  initialization with a timeout of **5 seconds**.
+- **FR-006** _(Consumer)_: The Core System MUST handle RPC errors (e.g., Unimplemented) from
+  `GetPluginInfo` by defaulting to a safe state (e.g., assuming compatibility or warning user)
+  rather than terminating.
+- **FR-007**: The `spec_version` returned by the plugin MUST be a valid Semantic Version (vX.Y.Z).
+- **FR-008** _(Consumer)_: The Core System MUST validate that `name`, `version`, and `spec_version`
+  are present and valid in the `GetPluginInfo` response. If any are missing or invalid, plugin
+  initialization MUST fail.
+
+### Key Entities _(include if feature involves data)_
+
+- **Plugin Metadata**: Contains identity and versioning information (Name, Version, Spec Version, Providers).
+- **Spec Version**: A version string identifier (e.g., "v0.4.11") indicating the protocol version used at build time.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Core system successfully retrieves metadata (including spec version) from 100% of compliant plugins.
+- **SC-002** _(Consumer)_: Consumer tools (e.g., `pulumicost plugin list`) can display the spec
+  version for all compliant plugins by calling `GetPluginInfo`.
+- **SC-003**: System successfully initializes 100% of legacy plugins (non-compliant) without crashing, logging a compatibility warning instead.

--- a/specs/029-plugin-info-rpc/tasks.md
+++ b/specs/029-plugin-info-rpc/tasks.md
@@ -1,0 +1,239 @@
+<!-- markdownlint-disable MD013 -->
+# Tasks: Add GetPluginInfo RPC
+
+**Input**: Design documents from `/specs/029-plugin-info-rpc/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Conformance tests are included as they are part of the standard protocol validation pattern
+for this SDK.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of
+each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Proto definitions**: `proto/pulumicost/v1/`
+- **Generated code**: `sdk/go/proto/`
+- **SDK implementation**: `sdk/go/pluginsdk/`
+- **Testing framework**: `sdk/go/testing/`
+
+---
+
+## Phase 1: Setup (Proto & Code Generation)
+
+**Purpose**: Update protocol buffer definitions and regenerate Go SDK
+
+- [x] T001 Add GetPluginInfoRequest message to proto/pulumicost/v1/costsource.proto
+- [x] T002 Add GetPluginInfoResponse message to proto/pulumicost/v1/costsource.proto
+  - Fields: name, version, spec_version, providers, metadata
+- [x] T003 Add GetPluginInfo RPC to CostSourceService in proto/pulumicost/v1/costsource.proto
+- [x] T004 Run `make generate` to regenerate sdk/go/proto/ from updated proto definitions
+- [x] T005 Verify generated code compiles with `go build ./sdk/go/proto/...`
+
+**Checkpoint**: Proto updated and Go SDK regenerated successfully
+
+---
+
+## Phase 2: Foundational (SDK Version Constants)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T006 Create SpecVersion constant in sdk/go/pluginsdk/version.go with current spec version value
+- [x] T007 [P] Add SemVer validation function ValidateSpecVersion(string) error in sdk/go/pluginsdk/version.go
+- [x] T008 [P] Add unit tests for ValidateSpecVersion in sdk/go/pluginsdk/version_test.go
+- [x] T009 Verify all tests pass with `make test`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Compatibility Verification (Priority: P1) MVP
+
+**Goal**: Enable the Core System to request and verify plugin metadata including spec version
+
+**Independent Test**: Create a mock plugin implementing GetPluginInfo RPC and verify the Core
+receives correct data (name, version, spec_version, providers)
+
+### Tests for User Story 1 (Write First, Must FAIL)
+
+> **Constitution III**: Tests MUST be written and FAIL before implementation begins.
+
+- [x] T010 [US1] Add conformance test for GetPluginInfo RPC in sdk/go/testing/conformance_test.go
+- [x] T011 [US1] Add integration test for GetPluginInfo metadata retrieval in sdk/go/testing/integration_test.go
+- [x] T012 [US1] Verify tests FAIL with `make test` (expected: GetPluginInfo not implemented)
+
+### Implementation for User Story 1
+
+- [x] T013 [US1] Update MockPlugin to implement GetPluginInfo in sdk/go/testing/mock_plugin.go
+- [x] T014 [US1] Add PluginInfo struct to hold plugin metadata in sdk/go/pluginsdk/plugin_info.go
+- [x] T015 [US1] Add PluginInfoOption functional options for configuring PluginInfo in sdk/go/pluginsdk/plugin_info.go
+- [x] T016 [US1] Add providers field to PluginInfo struct in sdk/go/pluginsdk/plugin_info.go
+- [x] T017 [US1] Add GetPluginInfo method signature to Plugin interface in sdk/go/pluginsdk/plugin.go
+- [x] T018 [US1] Implement default GetPluginInfo handler in sdk/go/pluginsdk/base.go that returns PluginInfo
+- [x] T019 [US1] Update Serve function to accept PluginInfo configuration in sdk/go/pluginsdk/serve.go
+- [x] T020 [US1] Add server-side validation for required fields (name, version, spec_version) in PluginInfo configuration
+- [x] T021 [US1] Verify tests PASS with `make validate`
+
+**Checkpoint**: User Story 1 complete - Core can retrieve and validate plugin metadata
+
+---
+
+## Phase 4: User Story 2 - Diagnostic Visibility (Priority: P2)
+
+**Goal**: Enable developers/operators to see spec version when listing plugins
+
+**Independent Test**: Call GetPluginInfo on a plugin and verify response includes all diagnostic fields
+
+### Implementation for User Story 2
+
+- [x] T022 [US2] Add optional metadata map field to PluginInfo in sdk/go/pluginsdk/plugin_info.go
+- [x] T023 [US2] Add WithMetadata functional option for additional key-value metadata in sdk/go/pluginsdk/plugin_info.go
+- [x] T024 [US2] Add unit tests for PluginInfo with metadata in sdk/go/pluginsdk/plugin_info_test.go
+- [x] T025 [US2] Add conformance test verifying metadata field in response in sdk/go/testing/conformance_test.go
+- [x] T026 [US2] Run `make validate` to ensure all tests and linting pass
+
+**Checkpoint**: User Story 2 complete - All diagnostic info available via GetPluginInfo
+
+---
+
+## Phase 5: User Story 3 - Graceful Degradation (Priority: P3)
+
+**Goal**: Handle legacy plugins that don't implement GetPluginInfo without crashing
+
+**Independent Test**: Call GetPluginInfo on a plugin that doesn't implement it and verify
+Unimplemented error is handled
+
+### Implementation for User Story 3
+
+- [x] T027 [US3] Document Unimplemented error handling pattern in sdk/go/pluginsdk/README.md or inline comments
+- [x] T028 [US3] Add example code for handling Unimplemented error in client code comments in sdk/go/pluginsdk/base.go
+- [x] T029 [US3] Add conformance test for Unimplemented error scenario in sdk/go/testing/conformance_test.go
+- [x] T030 [US3] Update testing framework to support legacy plugin simulation in sdk/go/testing/mock_plugin.go
+- [x] T031 [US3] Add integration test for graceful degradation with legacy plugin in sdk/go/testing/integration_test.go
+- [x] T032 [US3] Run `make validate` to ensure all tests and linting pass
+
+**Checkpoint**: User Story 3 complete - Legacy plugins handled gracefully
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, documentation, and cleanup
+
+- [x] T033 [P] Update sdk/go/pluginsdk/README.md with GetPluginInfo usage documentation (include 5s timeout recommendation per FR-005)
+- [x] T034 [P] Add benchmark test for GetPluginInfo in sdk/go/testing/benchmark_test.go
+- [x] T035 [P] Update CLAUDE.md with new patterns and files created
+- [x] T036 Run full validation with `make validate`
+- [x] T037 Run quickstart.md validation steps to verify end-to-end flow
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3+)**: All depend on Foundational phase completion
+  - User stories can then proceed in parallel (if staffed)
+  - Or sequentially in priority order (P1 -> P2 -> P3)
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories
+- **User Story 2 (P2)**: Can start after Foundational (Phase 2) - Extends PluginInfo from US1 but
+  is independently testable
+- **User Story 3 (P3)**: Can start after Foundational (Phase 2) - Independent error handling, no
+  US1/US2 dependencies
+
+### Within Each User Story
+
+- **Tests FIRST** (Constitution III - NON-NEGOTIABLE)
+- Tests must FAIL before implementation begins
+- Models/types before handlers
+- Handlers before integration
+- Verify tests PASS after implementation
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- T007 and T008 can run in parallel (different files)
+- T033, T034, T035 can run in parallel (different files)
+- After Phase 2, all three user stories could theoretically run in parallel with separate developers
+
+---
+
+## Parallel Example: Phase 2 Foundation
+
+```bash
+# Launch parallel tasks in Phase 2:
+Task: "Add SemVer validation function in sdk/go/pluginsdk/version.go"
+Task: "Add unit tests for ValidateSpecVersion in sdk/go/pluginsdk/version_test.go"
+```
+
+---
+
+## Parallel Example: Polish Phase
+
+```bash
+# Launch all Polish tasks together:
+Task: "Update sdk/go/pluginsdk/README.md with GetPluginInfo usage"
+Task: "Add benchmark test in sdk/go/testing/benchmark_test.go"
+Task: "Update CLAUDE.md with new patterns"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (proto changes)
+2. Complete Phase 2: Foundational (version constants)
+3. Complete Phase 3: User Story 1 (core GetPluginInfo)
+   - Tests first (T010-T012) - must FAIL
+   - Implementation (T013-T020)
+   - Verify tests PASS (T021)
+4. **STOP and VALIDATE**: Test GetPluginInfo independently
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational -> Proto and SDK foundation ready
+2. Add User Story 1 -> Test independently -> Deploy (MVP!)
+3. Add User Story 2 -> Test independently -> Deploy (enhanced diagnostics)
+4. Add User Story 3 -> Test independently -> Deploy (full backward compatibility)
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 (core functionality)
+   - Developer B: User Story 2 (diagnostics) - can start in parallel
+   - Developer C: User Story 3 (graceful degradation) - can start in parallel
+3. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- **Tests must be written and FAIL before implementation** (Constitution III)
+- Run `make validate` at each checkpoint to catch issues early
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Proto changes (Phase 1) must complete before any SDK work


### PR DESCRIPTION
## Summary

Enables plugin compatibility verification and diagnostics by exposing plugin metadata including name, version, spec version, supported providers, and optional key-value metadata.

The SDK provides three levels of configuration:

- Dynamic metadata via `PluginInfoProvider` interface for runtime values
- Static metadata via `ServeConfig.PluginInfo` for compile-time config
- Graceful degradation returning `Unimplemented` for legacy plugins

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes
- [x] Unit tests for `PluginInfo` struct and validation
- [x] Unit tests for `SpecVersion` constant and `ValidateSpecVersion()`
- [x] Integration tests for `GetPluginInfo` RPC
- [x] Concurrent access tests for thread safety
- [x] Benchmarks for performance validation

## Changes

### New files

- `sdk/go/pluginsdk/plugin_info.go` - PluginInfo struct with functional options and validation
- `sdk/go/pluginsdk/plugin_info_test.go` - Comprehensive tests including nil-safety and edge cases
- `sdk/go/pluginsdk/version.go` - SpecVersion constant and semver validation functions
- `sdk/go/pluginsdk/version_test.go` - Tests for version validation
- `specs/029-plugin-info-rpc/` - Feature specification and task tracking

### Modified files

- `proto/pulumicost/v1/costsource.proto` - Added GetPluginInfo RPC with request/response messages
- `sdk/go/proto/pulumicost/v1/costsource.pb.go` - Regenerated protobuf
- `sdk/go/proto/pulumicost/v1/costsource_grpc.pb.go` - Regenerated gRPC
- `sdk/go/pluginsdk/sdk.go` - Added Server.GetPluginInfo implementation with priority-based resolution
- `sdk/go/pluginsdk/sdk_test.go` - Added test for invalid PluginInfo
- `sdk/go/testing/harness.go` - Added IsValidSemVer helper function
- `sdk/go/testing/mock_plugin.go` - Added GetPluginInfo to MockPlugin
- `sdk/go/testing/integration_test.go` - Added integration and concurrency tests
- `sdk/go/testing/benchmark_test.go` - Added GetPluginInfo benchmarks
- `sdk/go/testing/conformance_test.go` - Added conformance tests
- `sdk/go/pluginsdk/README.md` - Added PluginInfo usage documentation

Closes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can now report name, version, spec version, providers, and metadata via GetPluginInfo; SDK exposes PluginInfo APIs and spec-version validation.

* **Documentation**
  * Expanded SDK and guides with Plugin Info usage, ServeConfig examples, and testing/conformance guidance.

* **Tests**
  * Added unit, integration, conformance, and benchmark tests for GetPluginInfo, metadata, timing, and concurrency.

* **Chores**
  * Added npm ignore file for package publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->