### PR TITLE
test: Adding in SetFieldStatus test

### DIFF
--- a/sdk/go/pluginsdk/dry_run.go
+++ b/sdk/go/pluginsdk/dry_run.go
@@ -209,6 +209,7 @@ func AllFieldsWithStatus(status pbc.FieldSupportStatus) []*pbc.FieldMapping {
 
 // SetFieldStatus finds a field by name in the mappings slice and updates its status.
 // If the field is not found, the slice is returned unchanged.
+// If mappings is nil, nil is returned.
 // Options can be used to set condition_description or expected_type.
 func SetFieldStatus(
 	mappings []*pbc.FieldMapping,
@@ -216,6 +217,9 @@ func SetFieldStatus(
 	status pbc.FieldSupportStatus,
 	opts ...FieldMappingOption,
 ) []*pbc.FieldMapping {
+	if mappings == nil {
+		return nil
+	}
 	for _, fm := range mappings {
 		if fm.GetFieldName() == fieldName {
 			fm.SupportStatus = status


### PR DESCRIPTION
This pull request improves the robustness and test coverage of the `SetFieldStatus` function in the `pluginsdk` package. It adds a nil check to handle cases when the input mappings are nil, and introduces comprehensive unit and benchmark tests to validate the function's behavior and performance under various scenarios.

**Functionality and robustness improvements:**

* Added a nil check to `SetFieldStatus` in `dry_run.go` to ensure it safely returns nil when the input `mappings` is nil.

**Testing improvements:**

* Added multiple unit tests in `dry_run_test.go` to cover:
  - Handling of nil mappings
  - Successful status updates
  - Application of functional options
  - Behavior when the field is not found
  - Handling of empty mappings
  - Chaining multiple updates

**Performance testing:**

* Introduced benchmark tests in `dry_run_test.go` to measure the performance of `SetFieldStatus` under different conditions, including with and without options, and when the field is not found.