### PR TITLE
fix(pluginsdk): use zerolog in health handler

### DIFF
--- a/sdk/go/pluginsdk/health.go
+++ b/sdk/go/pluginsdk/health.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"runtime/debug"
 	"time"
 
@@ -101,8 +100,8 @@ func HealthHandler(checker HealthChecker) http.Handler {
 
 		if r.Method == http.MethodGet {
 			if encodeErr := json.NewEncoder(w).Encode(status); encodeErr != nil {
-				// Log encoding error to standard error since we don't have a logger context here
-				_, _ = fmt.Fprintf(os.Stderr, "pluginsdk: failed to encode health status: %v\n", encodeErr)
+				// Log encoding error
+				log.Error().Err(encodeErr).Msg("pluginsdk: failed to encode health status")
 			}
 		}
 	})


### PR DESCRIPTION
## Summary

- Replaces standard library `fmt.Fprintf` with `log.Error()` in `HealthHandler`
- Ensures consistent structured logging output across the SDK
- Fixes a case where health check encoding errors were written to stderr unstructured

## Test plan

- [x] `make lint` passes with zero issues
- [ ] `make test` passes

## Changes

### Modified files

- `sdk/go/pluginsdk/health.go` - Replaced `fmt.Fprintf` with `zerolog` call

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Error logging implementation updated to improve consistency with application standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->