### PR TITLE
refactor(sdk): Improve ARN provider type safety

### DIFF
--- a/sdk/go/pluginsdk/arn_test.go
+++ b/sdk/go/pluginsdk/arn_test.go
@@ -12,62 +12,62 @@ func TestDetectARNProvider(t *testing.T) {
 	tests := []struct {
 		name     string
 		arn      string
-		provider string
+		provider pluginsdk.Provider
 	}{
 		{
 			name:     "AWS ARN returns aws",
 			arn:      "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
-			provider: "aws",
+			provider: pluginsdk.ProviderAWS,
 		},
 		{
 			name:     "Azure subscription ID returns azure",
 			arn:      "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVM",
-			provider: "azure",
+			provider: pluginsdk.ProviderAzure,
 		},
 		{
 			name:     "GCP full resource name returns gcp",
 			arn:      "//compute.googleapis.com/projects/my-project/zones/us-central1-a/instances/my-instance",
-			provider: "gcp",
+			provider: pluginsdk.ProviderGCP,
 		},
 		{
 			name:     "non-GCP URL-like string returns empty",
 			arn:      "//example.com/some/path",
-			provider: "",
+			provider: pluginsdk.ProviderUnknown,
 		},
 		{
 			name:     "Kubernetes format returns kubernetes",
 			arn:      "my-cluster/my-namespace/pod/my-pod",
-			provider: "kubernetes",
+			provider: pluginsdk.ProviderKubernetes,
 		},
 		{
 			name:     "absolute file path returns empty string",
 			arn:      "/etc/passwd",
-			provider: "",
+			provider: pluginsdk.ProviderUnknown,
 		},
 		{
 			name:     "short relative path returns empty string",
 			arn:      "foo/bar",
-			provider: "",
+			provider: pluginsdk.ProviderUnknown,
 		},
 		{
 			name:     "path with uppercase returns empty string",
 			arn:      "File/Path/To/Resource",
-			provider: "",
+			provider: pluginsdk.ProviderUnknown,
 		},
 		{
 			name:     "path with underscores returns empty string",
 			arn:      "file/path/to/resource_name",
-			provider: "",
+			provider: pluginsdk.ProviderUnknown,
 		},
 		{
 			name:     "unrecognized format returns empty string",
 			arn:      "custom:identifier:format",
-			provider: "",
+			provider: pluginsdk.ProviderUnknown,
 		},
 		{
 			name:     "empty string returns empty string",
 			arn:      "",
-			provider: "",
+			provider: pluginsdk.ProviderUnknown,
 		},
 	}
 

--- a/specs/001-sdk-polish-release/contracts/README.md
+++ b/specs/001-sdk-polish-release/contracts/README.md
@@ -48,13 +48,13 @@ type HealthChecker interface {
 
 **Error Handling**:
 
-| Scenario | SDK Behavior | HTTP Status | gRPC Status |
-|----------|--------------|-------------|---------------|
-| `Check()` returns nil | Healthy | 200 | OK |
-| `Check()` returns error | Unhealthy | 503 | Unavailable |
-| `Check()` times out | Unhealthy | 503 | Unavailable |
-| `Check()` panics | Unhealthy | 503 | Unavailable |
-| Plugin doesn't implement `HealthChecker` | Healthy (default) | 200 | OK |
+| Scenario                                 | SDK Behavior      | HTTP Status | gRPC Status |
+| ---------------------------------------- | ----------------- | ----------- | ----------- |
+| `Check()` returns nil                    | Healthy           | 200         | OK          |
+| `Check()` returns error                  | Unhealthy         | 503         | Unavailable |
+| `Check()` times out                      | Unhealthy         | 503         | Unavailable |
+| `Check()` panics                         | Unhealthy         | 503         | Unavailable |
+| Plugin doesn't implement `HealthChecker` | Healthy (default) | 200         | OK          |
 
 ### Example Implementation
 
@@ -191,7 +191,7 @@ if hasDeadline {
 #### DetectARNProvider
 
 ```go
-func DetectARNProvider(arn string) string
+func DetectARNProvider(arn string) Provider
 ```
 
 **Contract Guarantees**:
@@ -208,18 +208,18 @@ func DetectARNProvider(arn string) string
 
 **Examples**:
 
-| Input | Output |
-|-----------------------------------------------------|---------|
-| `"arn:aws:ec2:us-east-1:123:instance/i-abc"` | `"aws"` |
-| `"/subscriptions/sub-123/resourceGroups/rg/..."` | `"azure"`|
-| `"//compute.googleapis.com/projects/proj/instances/i"` | `"gcp"` |
-| `"my-cluster/namespace/pod/my-pod"` | `"kubernetes"` |
-| `"custom:format"` | `""` |
+| Input                                                  | Output         |
+| ------------------------------------------------------ | -------------- |
+| `"arn:aws:ec2:us-east-1:123:instance/i-abc"`           | `"aws"`        |
+| `"/subscriptions/sub-123/resourceGroups/rg/..."`       | `"azure"`      |
+| `"//compute.googleapis.com/projects/proj/instances/i"` | `"gcp"`        |
+| `"my-cluster/namespace/pod/my-pod"`                    | `"kubernetes"` |
+| `"custom:format"`                                      | `""`           |
 
 #### ValidateARNConsistency
 
 ```go
-func ValidateARNConsistency(arn, expectedProvider string) error
+func ValidateARNConsistency(arn string, expectedProvider Provider) error
 ```
 
 **Contract Guarantees**:


### PR DESCRIPTION
## Summary

Refactors `DetectARNProvider` and `ValidateARNConsistency` in `sdk/go/pluginsdk/arn.go` to use a strong `Provider` type instead of raw strings. This enhances type safety, reduces the risk of "magic string" errors, and provides better compile-time checks for ARN provider detection logic.

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes
- [x] Verified `arn_test.go` covers all `Provider` enum cases

## Changes

### Modified files

- `sdk/go/pluginsdk/arn.go` - Changed return type of `DetectARNProvider` to `Provider` and updated `ValidateARNConsistency` signature.
- `sdk/go/pluginsdk/arn_test.go` - Updated test cases to use `pluginsdk.Provider` constants.
- `specs/001-sdk-polish-release/contracts/README.md` - Updated documentation signatures to match the new type safety improvements.

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety in the plugin SDK by converting provider detection from string-based values to a strongly-typed enumeration system. This change significantly reduces potential type-related errors and improves code consistency and maintainability throughout the entire SDK.

* **Tests**
  * Updated all related test cases and assertions to fully support the new strongly-typed provider enumeration system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->