### PR TITLE
chore: fix release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,7 +37,7 @@
           "jsonpath": "$.packages[''].version"
         },
         {
-          "type": "go",
+          "type": "txt",
           "path": "sdk/go/pluginsdk/version.go",
           "pattern": "const SpecVersion = \"{version}\""
         }


### PR DESCRIPTION
This pull request updates the release configuration for the Go SDK. The main change is switching the file type used to detect version updates for the Go SDK from `go` to `txt`.

* Release configuration: Changed the file type for the Go SDK version detection from `go` to `txt` in `release-please-config.json` to ensure correct version parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration for improved version handling in the Go SDK.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->