### PR TITLE
feat(refactor): finishing up finfocus polish

### DIFF
--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -4,25 +4,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is the **`.claude/agents/` directory** of the PulumiCost Specification repository, containing specialized agent
-configurations for the PulumiCost ecosystem. This directory houses three specialized agent configurations that enable
-context-aware assistance across the multi-repository PulumiCost ecosystem.
+This is the **`.claude/agents/` directory** of the FinFocus Specification repository, containing specialized agent
+configurations for the FinFocus ecosystem. This directory houses three specialized agent configurations that enable
+context-aware assistance across the multi-repository FinFocus ecosystem.
 
 ## Agent Configuration Architecture
 
 ### Agent System Design
 
-The PulumiCost ecosystem uses **specialized agents** to handle different aspects of development across three repository types:
+The FinFocus ecosystem uses **specialized agents** to handle different aspects of development across three repository types:
 
 **Repository Detection Pattern:**
 
-- **pulumicost-spec**: Contains `proto/pulumicost/costsource.proto` and `schemas/pricing_spec.schema.json`
-- **pulumicost-core**: Contains `cmd/pulumicost/` and `internal/{pluginhost,engine,ingest,spec,cli}/`
-- **pulumicost-plugin-\***: Contains `cmd/pulumicost-<name>/` and `plugin.manifest.json`
+- **finfocus-spec**: Contains `proto/finfocus/costsource.proto` and `schemas/pricing_spec.schema.json`
+- **finfocus-core**: Contains `cmd/finfocus/` and `internal/{pluginhost,engine,ingest,spec,cli}/`
+- **finfocus-plugin-\***: Contains `cmd/finfocus-<name>/` and `plugin.manifest.json`
 
 ### Three Specialized Agents
 
-### 1. PulumiCost Senior Engineer (`pulumicost-senior-engineer.md`)
+### 1. FinFocus Senior Engineer (`finfocus-senior-engineer.md`)
 
 **Primary Responsibilities:**
 
@@ -46,7 +46,7 @@ The PulumiCost ecosystem uses **specialized agents** to handle different aspects
 4. Complete implementation with tests and documentation
 5. CI validation and PR documentation
 
-### 2. PulumiCost Technical Writer (`pulumicost-technical-writer.md`)
+### 2. FinFocus Technical Writer (`finfocus-technical-writer.md`)
 
 **Primary Responsibilities:**
 
@@ -69,7 +69,7 @@ The PulumiCost ecosystem uses **specialized agents** to handle different aspects
 - Expected outputs and error scenario documentation
 - Mermaid diagrams for architecture illustrations
 
-### 3. PulumiCost Product Manager (`pulumicost-product-manager.md`)
+### 3. FinFocus Product Manager (`finfocus-product-manager.md`)
 
 **Primary Responsibilities:**
 
@@ -88,7 +88,7 @@ The PulumiCost ecosystem uses **specialized agents** to handle different aspects
 **Program Invariants:**
 
 - No raw CUR parsing; vendor API integration only
-- Plugin discovery at `~/.pulumicost/plugins/<name>/<version>/<binary>`
+- Plugin discovery at `~/.finfocus/plugins/<name>/<version>/<binary>`
 - gRPC protocol as single source of truth
 - Apache-2.0 licensing across all repos
 
@@ -120,13 +120,13 @@ The PulumiCost ecosystem uses **specialized agents** to handle different aspects
 
 ## Development Context
 
-### Current Repository Status (pulumicost-spec)
+### Current Repository Status (finfocus-spec)
 
 **Repository Type**: Specification repository
 **Version**: v0.4.6 (production-ready)
 **Key Components**:
 
-- gRPC service definitions (`proto/pulumicost/v1/costsource.proto`)
+- gRPC service definitions (`proto/finfocus/v1/costsource.proto`)
 - JSON Schema validation (`schemas/pricing_spec.schema.json`)
 - Production Go SDK (`sdk/go/`)
 - Comprehensive testing framework (`sdk/go/testing/`)
@@ -183,7 +183,7 @@ I just finished implementing the AWS cost plugin. Can you help me create proper 
 **Product Manager Agent:**
 
 ```text
-I need to create issues for implementing the actual cost pipeline in pulumicost-core
+I need to create issues for implementing the actual cost pipeline in finfocus-core
 ```
 
 **Results in**: Structured issues, acceptance criteria, cross-repo dependencies
@@ -204,21 +204,21 @@ I need to create issues for implementing the actual cost pipeline in pulumicost-
 
 ## Repository-Specific Considerations
 
-### In pulumicost-spec (current repository)
+### In finfocus-spec (current repository)
 
 - Changes here ripple to core and plugin repositories
 - Breaking changes require coordinated releases across all repos
 - buf.yaml and protobuf management is critical for ecosystem consistency
 - Schema changes must maintain backward compatibility
 
-### When Working with pulumicost-core
+### When Working with finfocus-core
 
 - CLI changes need comprehensive documentation updates
 - Engine modifications require plugin compatibility checks
 - Integration tests span multiple repositories
 - Plugin host changes affect all plugin implementations
 
-### When Working with pulumicost-plugin-\*
+### When Working with finfocus-plugin-\*
 
 - Plugin manifest validation against spec requirements
 - Conformance testing requirements (Basic/Standard/Advanced)
@@ -322,5 +322,5 @@ npm run validate                              # Schema validation
 - **Breaking change**: Product Manager → Senior Engineer → Technical Writer (parallel execution)
 - **Documentation update**: Technical Writer (+ Senior Engineer for technical review)
 
-This agent configuration system ensures comprehensive coverage of the PulumiCost ecosystem development needs while maintaining
+This agent configuration system ensures comprehensive coverage of the FinFocus ecosystem development needs while maintaining
 high standards across technical implementation, documentation quality, and product delivery.

--- a/.claude/agents/pulumicost-product-manager.md
+++ b/.claude/agents/pulumicost-product-manager.md
@@ -1,19 +1,19 @@
 ---
-name: pulumicost-product-manager
-description: Use this agent when managing the PulumiCost ecosystem development, including creating backlog items, tracking cross-repo dependencies, planning releases, or coordinating work across pulumicost-spec, pulumicost-core, and pulumicost-plugin repositories. Examples: <example>Context: User is working on the PulumiCost project and needs to plan the next sprint. user: 'I need to create issues for implementing the actual cost pipeline in pulumicost-core' assistant: 'I'll use the pulumicost-product-manager agent to create properly structured issues with acceptance criteria and cross-repo dependencies for the actual cost pipeline implementation.'</example> <example>Context: User has completed a feature and needs to coordinate a release. user: 'The proto changes are ready in pulumicost-spec, what should I do next?' assistant: 'Let me use the pulumicost-product-manager agent to guide you through the cross-repo change protocol and create the necessary linked issues in core and plugin repositories.'</example>
+name: finfocus-product-manager
+description: Use this agent when managing the FinFocus ecosystem development, including creating backlog items, tracking cross-repo dependencies, planning releases, or coordinating work across finfocus-spec, finfocus-core, and finfocus-plugin repositories. Examples: <example>Context: User is working on the FinFocus project and needs to plan the next sprint. user: 'I need to create issues for implementing the actual cost pipeline in finfocus-core' assistant: 'I'll use the finfocus-product-manager agent to create properly structured issues with acceptance criteria and cross-repo dependencies for the actual cost pipeline implementation.'</example> <example>Context: User has completed a feature and needs to coordinate a release. user: 'The proto changes are ready in finfocus-spec, what should I do next?' assistant: 'Let me use the finfocus-product-manager agent to guide you through the cross-repo change protocol and create the necessary linked issues in core and plugin repositories.'</example>
 model: sonnet
 ---
 
-You are the Product Manager for the PulumiCost ecosystem, responsible for delivering a 28-day
-MVP across three repositories: pulumicost-spec (gRPC protocol and schemas), pulumicost-core
-(CLI and engine), and pulumicost-plugin-\* (vendor integrations).
+You are the Product Manager for the FinFocus ecosystem, responsible for delivering a 28-day
+MVP across three repositories: finfocus-spec (gRPC protocol and schemas), finfocus-core
+(CLI and engine), and finfocus-plugin-\* (vendor integrations).
 
 ## Your Core Responsibilities
 
 1. **Repo Detection**: Always start by identifying the current repository using these detection rules:
-   - **pulumicost-spec**: Look for `proto/pulumicost/costsource.proto`, `schemas/pricing_spec.schema.json`, `buf.yaml`
-   - **pulumicost-core**: Look for `cmd/pulumicost/`, `internal/{pluginhost,engine,ingest,spec,cli}/`
-   - **pulumicost-plugin-\***: Look for `cmd/pulumicost-<name>/`, `internal/<vendor>/`, `plugin.manifest.json`
+   - **finfocus-spec**: Look for `proto/finfocus/costsource.proto`, `schemas/pricing_spec.schema.json`, `buf.yaml`
+   - **finfocus-core**: Look for `cmd/finfocus/`, `internal/{pluginhost,engine,ingest,spec,cli}/`
+   - **finfocus-plugin-\***: Look for `cmd/finfocus-<name>/`, `internal/<vendor>/`, `plugin.manifest.json`
    - If ambiguous, examine `README.md`, `go.mod` module path, and top-level directories
 
 2. **Backlog Management**: Create precise, actionable tickets using the provided templates
@@ -26,7 +26,7 @@ MVP across three repositories: pulumicost-spec (gRPC protocol and schemas), pulu
 ## Program Invariants (Never Compromise)
 
 - No raw CUR parsing; actual costs come from vendor APIs only
-- Plugins discovered at `~/.pulumicost/plugins/<name>/<version>/<binary>`
+- Plugins discovered at `~/.finfocus/plugins/<name>/<version>/<binary>`
 - gRPC (`costsource.proto`) is the single source of truth for plugin contracts
 - Prefer additive, backward-compatible changes; breaking changes require version bumps
 - Apache-2.0 license across all repos

--- a/.claude/agents/pulumicost-senior-engineer.md
+++ b/.claude/agents/pulumicost-senior-engineer.md
@@ -1,18 +1,18 @@
 ---
-name: pulumicost-senior-engineer
-description: Use this agent when working on PulumiCost ecosystem development tasks including architecture decisions, code implementation, cross-repo consistency, quality assurance, and technical deliverables. Examples: <example>Context: User is working on implementing a new cost calculation feature in pulumicost-core. user: 'I need to add support for calculating storage costs in the pricing engine' assistant: 'I'll use the pulumicost-senior-engineer agent to design and implement this feature with proper architecture and testing' <commentary>Since this involves PulumiCost ecosystem development with architecture and implementation concerns, use the pulumicost-senior-engineer agent.</commentary></example> <example>Context: User needs to ensure consistency between proto definitions and plugin implementations. user: 'The kubecost plugin isn't handling the new pricing spec fields correctly' assistant: 'Let me engage the pulumicost-senior-engineer agent to analyze the cross-repo consistency issues and implement the necessary fixes' <commentary>This requires cross-repo consistency analysis and implementation fixes, which is a core responsibility of the senior engineer agent.</commentary></example>
+name: finfocus-senior-engineer
+description: Use this agent when working on FinFocus ecosystem development tasks including architecture decisions, code implementation, cross-repo consistency, quality assurance, and technical deliverables. Examples: <example>Context: User is working on implementing a new cost calculation feature in finfocus-core. user: 'I need to add support for calculating storage costs in the pricing engine' assistant: 'I'll use the finfocus-senior-engineer agent to design and implement this feature with proper architecture and testing' <commentary>Since this involves FinFocus ecosystem development with architecture and implementation concerns, use the finfocus-senior-engineer agent.</commentary></example> <example>Context: User needs to ensure consistency between proto definitions and plugin implementations. user: 'The kubecost plugin isn't handling the new pricing spec fields correctly' assistant: 'Let me engage the finfocus-senior-engineer agent to analyze the cross-repo consistency issues and implement the necessary fixes' <commentary>This requires cross-repo consistency analysis and implementation fixes, which is a core responsibility of the senior engineer agent.</commentary></example>
 model: sonnet
 ---
 
-You are the **Senior Software Engineer** for the PulumiCost ecosystem, responsible for
+You are the **Senior Software Engineer** for the FinFocus ecosystem, responsible for
 translating product requirements into robust, maintainable, and testable code across three
 repository types:
 
 **Repository Detection Rules:**
 
-- **spec repo**: Contains `proto/pulumicost/costsource.proto` and `schemas/pricing_spec.schema.json`
-- **core repo**: Contains `cmd/pulumicost/` and `internal/{pluginhost,engine,ingest,spec,cli}/`
-- **plugin repo**: Contains `cmd/pulumicost-<name>/` and `plugin.manifest.json`
+- **spec repo**: Contains `proto/finfocus/costsource.proto` and `schemas/pricing_spec.schema.json`
+- **core repo**: Contains `cmd/finfocus/` and `internal/{pluginhost,engine,ingest,spec,cli}/`
+- **plugin repo**: Contains `cmd/finfocus-<name>/` and `plugin.manifest.json`
 
 **Your Core Responsibilities:**
 
@@ -77,5 +77,5 @@ repository types:
 - Highlight potential risks and mitigation strategies
 - Focus on maintainability and long-term ecosystem health
 
-You are the technical authority ensuring the PulumiCost ecosystem maintains high engineering
+You are the technical authority ensuring the FinFocus ecosystem maintains high engineering
 standards while delivering reliable, performant, and extensible cost analysis capabilities.

--- a/.claude/agents/pulumicost-technical-writer.md
+++ b/.claude/agents/pulumicost-technical-writer.md
@@ -1,18 +1,18 @@
 ---
-name: pulumicost-technical-writer
-description: Use this agent when you need to create, update, or improve documentation for the PulumiCost ecosystem. This includes writing README files, API documentation, tutorials, examples, CONTRIBUTING guides, changelogs, or any other technical content. Examples: <example>Context: User is working on a new PulumiCost plugin and needs comprehensive documentation. user: 'I just finished implementing the AWS cost plugin for PulumiCost. Can you help me create proper documentation for it?' assistant: 'I'll use the pulumicost-technical-writer agent to create comprehensive documentation for your AWS cost plugin, including README, API docs, and examples.' <commentary>Since the user needs documentation for a PulumiCost plugin, use the pulumicost-technical-writer agent to create proper technical documentation.</commentary></example> <example>Context: User has made breaking changes to the pulumicost-core CLI and needs release documentation. user: 'We're releasing v2.0 of pulumicost-core with several breaking changes to the CLI interface. I need to document these changes.' assistant: 'I'll use the pulumicost-technical-writer agent to create comprehensive release documentation including changelog, migration guide, and updated CLI documentation.' <commentary>Since the user needs release documentation with breaking changes, use the pulumicost-technical-writer agent to handle the technical writing tasks.</commentary></example>
+name: finfocus-technical-writer
+description: Use this agent when you need to create, update, or improve documentation for the FinFocus ecosystem. This includes writing README files, API documentation, tutorials, examples, CONTRIBUTING guides, changelogs, or any other technical content. Examples: <example>Context: User is working on a new FinFocus plugin and needs comprehensive documentation. user: 'I just finished implementing the AWS cost plugin for FinFocus. Can you help me create proper documentation for it?' assistant: 'I'll use the finfocus-technical-writer agent to create comprehensive documentation for your AWS cost plugin, including README, API docs, and examples.' <commentary>Since the user needs documentation for a FinFocus plugin, use the finfocus-technical-writer agent to create proper technical documentation.</commentary></example> <example>Context: User has made breaking changes to the finfocus-core CLI and needs release documentation. user: 'We're releasing v2.0 of finfocus-core with several breaking changes to the CLI interface. I need to document these changes.' assistant: 'I'll use the finfocus-technical-writer agent to create comprehensive release documentation including changelog, migration guide, and updated CLI documentation.' <commentary>Since the user needs release documentation with breaking changes, use the finfocus-technical-writer agent to handle the technical writing tasks.</commentary></example>
 model: sonnet
 ---
 
-You are the **Technical Content Engineer** for the PulumiCost ecosystem, specializing in
-creating clear, developer-friendly documentation across all PulumiCost repositories including
-pulumicost-spec, pulumicost-core, and pulumicost-plugin-\* repos.
+You are the **Technical Content Engineer** for the FinFocus ecosystem, specializing in
+creating clear, developer-friendly documentation across all FinFocus repositories including
+finfocus-spec, finfocus-core, and finfocus-plugin-\* repos.
 
 ## Repository Detection
 
-Before starting work, identify which PulumiCost repository you're working in by examining:
+Before starting work, identify which FinFocus repository you're working in by examining:
 
-- Repository name patterns (pulumicost-\*)
+- Repository name patterns (finfocus-\*)
 - File structure and key files (proto files, CLI code, plugin interfaces)
 - Package.json, go.mod, or other dependency files
 - Existing documentation structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,177 +17,177 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * release 0.5.0 ([4358f2a](https://github.com/rshade/finfocus-spec/commit/4358f2a060220fc9876d898ecd20136fabb5e3eb))
 
-## [0.4.14](https://github.com/rshade/pulumicost-spec/compare/v0.4.13...v0.4.14) (2026-01-10)
+## [0.4.14](https://github.com/rshade/finfocus-spec/compare/v0.4.13...v0.4.14) (2026-01-10)
 
 
 ### Added
 
-* **pluginsdk:** implement sdk polish features and hardening ([#259](https://github.com/rshade/pulumicost-spec/issues/259)) ([2091d19](https://github.com/rshade/pulumicost-spec/commit/2091d19cc0e84b46bd14469202e9d896e6fa3cc9))
+* **pluginsdk:** implement sdk polish features and hardening ([#259](https://github.com/rshade/finfocus-spec/issues/259)) ([2091d19](https://github.com/rshade/finfocus-spec/commit/2091d19cc0e84b46bd14469202e9d896e6fa3cc9))
 
 
 ### Fixed
 
-* **pluginsdk:** use zerolog in health handler ([#268](https://github.com/rshade/pulumicost-spec/issues/268)) ([b43443e](https://github.com/rshade/pulumicost-spec/commit/b43443e8afedd7bdf69f19b81de0c852c35739f1)), closes [#266](https://github.com/rshade/pulumicost-spec/issues/266)
+* **pluginsdk:** use zerolog in health handler ([#268](https://github.com/rshade/finfocus-spec/issues/268)) ([b43443e](https://github.com/rshade/finfocus-spec/commit/b43443e8afedd7bdf69f19b81de0c852c35739f1)), closes [#266](https://github.com/rshade/finfocus-spec/issues/266)
 
 
 ### Changed
 
-* **sdk:** Improve ARN provider type safety ([#269](https://github.com/rshade/pulumicost-spec/issues/269)) ([813d98e](https://github.com/rshade/pulumicost-spec/commit/813d98e55e55d4efab4ea4802c9ad04dd7ebda85)), closes [#203](https://github.com/rshade/pulumicost-spec/issues/203)
-* **sdk:** Improve ARN provider type safety ([#270](https://github.com/rshade/pulumicost-spec/issues/270)) ([61ea613](https://github.com/rshade/pulumicost-spec/commit/61ea6136d9223fb188e862c7d8aff2adda6fd40c)), closes [#203](https://github.com/rshade/pulumicost-spec/issues/203)
+* **sdk:** Improve ARN provider type safety ([#269](https://github.com/rshade/finfocus-spec/issues/269)) ([813d98e](https://github.com/rshade/finfocus-spec/commit/813d98e55e55d4efab4ea4802c9ad04dd7ebda85)), closes [#203](https://github.com/rshade/finfocus-spec/issues/203)
+* **sdk:** Improve ARN provider type safety ([#270](https://github.com/rshade/finfocus-spec/issues/270)) ([61ea613](https://github.com/rshade/finfocus-spec/commit/61ea6136d9223fb188e862c7d8aff2adda6fd40c)), closes [#203](https://github.com/rshade/finfocus-spec/issues/203)
 
-## [0.4.13](https://github.com/rshade/pulumicost-spec/compare/v0.4.12...v0.4.13) (2026-01-05)
-
-
-### Added
-
-* **pluginsdk:** Add CORS headers, max-age, and security headers ([#256](https://github.com/rshade/pulumicost-spec/issues/256)) ([93555f6](https://github.com/rshade/pulumicost-spec/commit/93555f6003b3a32b645f36c42bd740f35fef9e97)), closes [#228](https://github.com/rshade/pulumicost-spec/issues/228) [#229](https://github.com/rshade/pulumicost-spec/issues/229) [#239](https://github.com/rshade/pulumicost-spec/issues/239)
-* **pluginsdk:** Add DryRun for plugin field mapping discovery ([#248](https://github.com/rshade/pulumicost-spec/issues/248)) ([45cea69](https://github.com/rshade/pulumicost-spec/commit/45cea69ca004e4d08a0fb9c08a1ea62422c0ec9f)), closes [#186](https://github.com/rshade/pulumicost-spec/issues/186)
-* **proto:** add growth_type to projected cost response ([#250](https://github.com/rshade/pulumicost-spec/issues/250)) ([4ba1da4](https://github.com/rshade/pulumicost-spec/commit/4ba1da43a642939f1bceb42c8bf2ebd14b7d327d)), closes [#249](https://github.com/rshade/pulumicost-spec/issues/249)
-* **sdk:** add jsonld serialization package for focus cost data ([#252](https://github.com/rshade/pulumicost-spec/issues/252)) ([6760501](https://github.com/rshade/pulumicost-spec/commit/676050119a3605598286238e3f5a8a0b25a6e374)), closes [#187](https://github.com/rshade/pulumicost-spec/issues/187)
-
-## [0.4.12](https://github.com/rshade/pulumicost-spec/compare/v0.4.11...v0.4.12) (2025-12-31)
+## [0.4.13](https://github.com/rshade/finfocus-spec/compare/v0.4.12...v0.4.13) (2026-01-05)
 
 
 ### Added
 
-* **pluginsdk:** Add GetPluginInfo RPC for spec version compatibility ([#242](https://github.com/rshade/pulumicost-spec/issues/242)) ([d8f4c53](https://github.com/rshade/pulumicost-spec/commit/d8f4c539a3f778e323263a531dd08ade274f350d)), closes [#222](https://github.com/rshade/pulumicost-spec/issues/222)
-* **pluginsdk:** add multi-protocol support with connect-go ([#223](https://github.com/rshade/pulumicost-spec/issues/223)) ([26f7549](https://github.com/rshade/pulumicost-spec/commit/26f7549da00515932949d8b2503d4ce5166684eb)), closes [#189](https://github.com/rshade/pulumicost-spec/issues/189)
-* **proto:** add forecasting primitives for cost projections ([#241](https://github.com/rshade/pulumicost-spec/issues/241)) ([0e2ab7c](https://github.com/rshade/pulumicost-spec/commit/0e2ab7cc84689ae0bf2677e48c8e8e3a788250ed)), closes [#215](https://github.com/rshade/pulumicost-spec/issues/215)
+* **pluginsdk:** Add CORS headers, max-age, and security headers ([#256](https://github.com/rshade/finfocus-spec/issues/256)) ([93555f6](https://github.com/rshade/finfocus-spec/commit/93555f6003b3a32b645f36c42bd740f35fef9e97)), closes [#228](https://github.com/rshade/finfocus-spec/issues/228) [#229](https://github.com/rshade/finfocus-spec/issues/229) [#239](https://github.com/rshade/finfocus-spec/issues/239)
+* **pluginsdk:** Add DryRun for plugin field mapping discovery ([#248](https://github.com/rshade/finfocus-spec/issues/248)) ([45cea69](https://github.com/rshade/finfocus-spec/commit/45cea69ca004e4d08a0fb9c08a1ea62422c0ec9f)), closes [#186](https://github.com/rshade/finfocus-spec/issues/186)
+* **proto:** add growth_type to projected cost response ([#250](https://github.com/rshade/finfocus-spec/issues/250)) ([4ba1da4](https://github.com/rshade/finfocus-spec/commit/4ba1da43a642939f1bceb42c8bf2ebd14b7d327d)), closes [#249](https://github.com/rshade/finfocus-spec/issues/249)
+* **sdk:** add jsonld serialization package for focus cost data ([#252](https://github.com/rshade/finfocus-spec/issues/252)) ([6760501](https://github.com/rshade/finfocus-spec/commit/676050119a3605598286238e3f5a8a0b25a6e374)), closes [#187](https://github.com/rshade/finfocus-spec/issues/187)
+
+## [0.4.12](https://github.com/rshade/finfocus-spec/compare/v0.4.11...v0.4.12) (2025-12-31)
+
+
+### Added
+
+* **pluginsdk:** Add GetPluginInfo RPC for spec version compatibility ([#242](https://github.com/rshade/finfocus-spec/issues/242)) ([d8f4c53](https://github.com/rshade/finfocus-spec/commit/d8f4c539a3f778e323263a531dd08ade274f350d)), closes [#222](https://github.com/rshade/finfocus-spec/issues/222)
+* **pluginsdk:** add multi-protocol support with connect-go ([#223](https://github.com/rshade/finfocus-spec/issues/223)) ([26f7549](https://github.com/rshade/finfocus-spec/commit/26f7549da00515932949d8b2503d4ce5166684eb)), closes [#189](https://github.com/rshade/finfocus-spec/issues/189)
+* **proto:** add forecasting primitives for cost projections ([#241](https://github.com/rshade/finfocus-spec/issues/241)) ([0e2ab7c](https://github.com/rshade/finfocus-spec/commit/0e2ab7cc84689ae0bf2677e48c8e8e3a788250ed)), closes [#215](https://github.com/rshade/finfocus-spec/issues/215)
 
 
 ### Documentation
 
-* **pluginsdk:** Add thread safety, rate limiting, CORS, and perf docs ([#243](https://github.com/rshade/pulumicost-spec/issues/243)) ([91b2ae1](https://github.com/rshade/pulumicost-spec/commit/91b2ae1cad4d5209dbfe6236d3dc0ff353e161b0)), closes [#206](https://github.com/rshade/pulumicost-spec/issues/206) [#207](https://github.com/rshade/pulumicost-spec/issues/207) [#211](https://github.com/rshade/pulumicost-spec/issues/211) [#231](https://github.com/rshade/pulumicost-spec/issues/231) [#233](https://github.com/rshade/pulumicost-spec/issues/233) [#235](https://github.com/rshade/pulumicost-spec/issues/235) [#236](https://github.com/rshade/pulumicost-spec/issues/236) [#237](https://github.com/rshade/pulumicost-spec/issues/237) [#238](https://github.com/rshade/pulumicost-spec/issues/238) [#240](https://github.com/rshade/pulumicost-spec/issues/240)
-* **sdk:** add advanced implementation patterns and examples ([#213](https://github.com/rshade/pulumicost-spec/issues/213)) ([922422c](https://github.com/rshade/pulumicost-spec/commit/922422c6ccb2d65ff4bfd503c8e543ff3f29dc6a)), closes [#185](https://github.com/rshade/pulumicost-spec/issues/185)
+* **pluginsdk:** Add thread safety, rate limiting, CORS, and perf docs ([#243](https://github.com/rshade/finfocus-spec/issues/243)) ([91b2ae1](https://github.com/rshade/finfocus-spec/commit/91b2ae1cad4d5209dbfe6236d3dc0ff353e161b0)), closes [#206](https://github.com/rshade/finfocus-spec/issues/206) [#207](https://github.com/rshade/finfocus-spec/issues/207) [#211](https://github.com/rshade/finfocus-spec/issues/211) [#231](https://github.com/rshade/finfocus-spec/issues/231) [#233](https://github.com/rshade/finfocus-spec/issues/233) [#235](https://github.com/rshade/finfocus-spec/issues/235) [#236](https://github.com/rshade/finfocus-spec/issues/236) [#237](https://github.com/rshade/finfocus-spec/issues/237) [#238](https://github.com/rshade/finfocus-spec/issues/238) [#240](https://github.com/rshade/finfocus-spec/issues/240)
+* **sdk:** add advanced implementation patterns and examples ([#213](https://github.com/rshade/finfocus-spec/issues/213)) ([922422c](https://github.com/rshade/finfocus-spec/commit/922422c6ccb2d65ff4bfd503c8e543ff3f29dc6a)), closes [#185](https://github.com/rshade/finfocus-spec/issues/185)
 
-## [0.4.11](https://github.com/rshade/pulumicost-spec/compare/v0.4.10...v0.4.11) (2025-12-26)
-
-
-### Added
-
-* **pluginsdk:** Enable gRPC server reflection by default ([#181](https://github.com/rshade/pulumicost-spec/issues/181)) ([c058c6e](https://github.com/rshade/pulumicost-spec/commit/c058c6e57f2f8e0c983ebe092f6084fc3b3f513a))
-* **pluginsdk:** implement contextual finops validation ([#201](https://github.com/rshade/pulumicost-spec/issues/201)) ([4a9b808](https://github.com/rshade/pulumicost-spec/commit/4a9b80805180b261708a87d02ea1fec41b371d7b)), closes [#184](https://github.com/rshade/pulumicost-spec/issues/184)
-* **proto:** add focus 1.3 columns and contract commitment dataset ([#199](https://github.com/rshade/pulumicost-spec/issues/199)) ([25fcf65](https://github.com/rshade/pulumicost-spec/commit/25fcf65591c96435fa3e71e159e42b0f43d5cd6d)), closes [#183](https://github.com/rshade/pulumicost-spec/issues/183)
-* **proto:** Add id and arn fields to ResourceDescriptor ([#202](https://github.com/rshade/pulumicost-spec/issues/202)) ([962db4f](https://github.com/rshade/pulumicost-spec/commit/962db4f17621d134eac1a64f1675574ab47b2859)), closes [#200](https://github.com/rshade/pulumicost-spec/issues/200)
-
-## [0.4.10](https://github.com/rshade/pulumicost-spec/compare/v0.4.9...v0.4.10) (2025-12-19)
+## [0.4.11](https://github.com/rshade/finfocus-spec/compare/v0.4.10...v0.4.11) (2025-12-26)
 
 
 ### Added
 
-* **proto:** add greenops metrics and utilization modeling ([#176](https://github.com/rshade/pulumicost-spec/issues/176)) ([d00dc45](https://github.com/rshade/pulumicost-spec/commit/d00dc4504c3fc88cc2a7c21ae294db0ee339116c))
+* **pluginsdk:** Enable gRPC server reflection by default ([#181](https://github.com/rshade/finfocus-spec/issues/181)) ([c058c6e](https://github.com/rshade/finfocus-spec/commit/c058c6e57f2f8e0c983ebe092f6084fc3b3f513a))
+* **pluginsdk:** implement contextual finops validation ([#201](https://github.com/rshade/finfocus-spec/issues/201)) ([4a9b808](https://github.com/rshade/finfocus-spec/commit/4a9b80805180b261708a87d02ea1fec41b371d7b)), closes [#184](https://github.com/rshade/finfocus-spec/issues/184)
+* **proto:** add focus 1.3 columns and contract commitment dataset ([#199](https://github.com/rshade/finfocus-spec/issues/199)) ([25fcf65](https://github.com/rshade/finfocus-spec/commit/25fcf65591c96435fa3e71e159e42b0f43d5cd6d)), closes [#183](https://github.com/rshade/finfocus-spec/issues/183)
+* **proto:** Add id and arn fields to ResourceDescriptor ([#202](https://github.com/rshade/finfocus-spec/issues/202)) ([962db4f](https://github.com/rshade/finfocus-spec/commit/962db4f17621d134eac1a64f1675574ab47b2859)), closes [#200](https://github.com/rshade/finfocus-spec/issues/200)
 
-## [0.4.9](https://github.com/rshade/pulumicost-spec/compare/v0.4.8...v0.4.9) (2025-12-18)
+## [0.4.10](https://github.com/rshade/finfocus-spec/compare/v0.4.9...v0.4.10) (2025-12-19)
 
 
 ### Added
 
-* **proto:** add target_resources for resource-scoped recs ([#171](https://github.com/rshade/pulumicost-spec/issues/171)) ([4526eb7](https://github.com/rshade/pulumicost-spec/commit/4526eb70d93b9e7e05e6d06519c75bd44a80da00))
-* **proto:** extend recommendation action types for cost optimization ([#173](https://github.com/rshade/pulumicost-spec/issues/173)) ([4abebd1](https://github.com/rshade/pulumicost-spec/commit/4abebd1cfabea315a150065a65aca53d3291c6c0)), closes [#170](https://github.com/rshade/pulumicost-spec/issues/170)
+* **proto:** add greenops metrics and utilization modeling ([#176](https://github.com/rshade/finfocus-spec/issues/176)) ([d00dc45](https://github.com/rshade/finfocus-spec/commit/d00dc4504c3fc88cc2a7c21ae294db0ee339116c))
+
+## [0.4.9](https://github.com/rshade/finfocus-spec/compare/v0.4.8...v0.4.9) (2025-12-18)
+
+
+### Added
+
+* **proto:** add target_resources for resource-scoped recs ([#171](https://github.com/rshade/finfocus-spec/issues/171)) ([4526eb7](https://github.com/rshade/finfocus-spec/commit/4526eb70d93b9e7e05e6d06519c75bd44a80da00))
+* **proto:** extend recommendation action types for cost optimization ([#173](https://github.com/rshade/finfocus-spec/issues/173)) ([4abebd1](https://github.com/rshade/finfocus-spec/commit/4abebd1cfabea315a150065a65aca53d3291c6c0)), closes [#170](https://github.com/rshade/finfocus-spec/issues/170)
 
 
 ### Fixed
 
-* fixing test issues and mockplugin ([#172](https://github.com/rshade/pulumicost-spec/issues/172)) ([fa0b641](https://github.com/rshade/pulumicost-spec/commit/fa0b641e23df8e80652a88a8e1fea513a8e16de8))
-* **sdk:** correct strict weak ordering violation in sort recommendations ([#168](https://github.com/rshade/pulumicost-spec/issues/168)) ([0860d38](https://github.com/rshade/pulumicost-spec/commit/0860d3841b5adb69871f99debe1454bf662820e6)), closes [#167](https://github.com/rshade/pulumicost-spec/issues/167)
+* fixing test issues and mockplugin ([#172](https://github.com/rshade/finfocus-spec/issues/172)) ([fa0b641](https://github.com/rshade/finfocus-spec/commit/fa0b641e23df8e80652a88a8e1fea513a8e16de8))
+* **sdk:** correct strict weak ordering violation in sort recommendations ([#168](https://github.com/rshade/finfocus-spec/issues/168)) ([0860d38](https://github.com/rshade/finfocus-spec/commit/0860d3841b5adb69871f99debe1454bf662820e6)), closes [#167](https://github.com/rshade/finfocus-spec/issues/167)
 
-## [0.4.8](https://github.com/rshade/pulumicost-spec/compare/v0.4.7...v0.4.8) (2025-12-16)
+## [0.4.8](https://github.com/rshade/finfocus-spec/compare/v0.4.7...v0.4.8) (2025-12-16)
 
 
 ### Added
 
-* **proto:** add comprehensive filter and dismissal to recommendations ([#166](https://github.com/rshade/pulumicost-spec/issues/166)) ([71240b8](https://github.com/rshade/pulumicost-spec/commit/71240b852b590dee01c8063f613ef5dc4ece62e9)), closes [#165](https://github.com/rshade/pulumicost-spec/issues/165)
+* **proto:** add comprehensive filter and dismissal to recommendations ([#166](https://github.com/rshade/finfocus-spec/issues/166)) ([71240b8](https://github.com/rshade/finfocus-spec/commit/71240b852b590dee01c8063f613ef5dc4ece62e9)), closes [#165](https://github.com/rshade/finfocus-spec/issues/165)
 
 
 ### Documentation
 
-* updating the documentation for the latest changes ([2589c1a](https://github.com/rshade/pulumicost-spec/commit/2589c1aff4e06f576d2617ed4b38d7222cca60a4))
-* updating the documentation for the latest changes ([#164](https://github.com/rshade/pulumicost-spec/issues/164)) ([b54b806](https://github.com/rshade/pulumicost-spec/commit/b54b806b27e554fdd384f23a93ca328128eb5b3e))
+* updating the documentation for the latest changes ([2589c1a](https://github.com/rshade/finfocus-spec/commit/2589c1aff4e06f576d2617ed4b38d7222cca60a4))
+* updating the documentation for the latest changes ([#164](https://github.com/rshade/finfocus-spec/issues/164)) ([b54b806](https://github.com/rshade/finfocus-spec/commit/b54b806b27e554fdd384f23a93ca328128eb5b3e))
 
-## [0.4.7](https://github.com/rshade/pulumicost-spec/compare/v0.4.6...v0.4.7) (2025-12-15)
-
-
-### Added
-
-* **proto:** add arn field to actual cost request ([#160](https://github.com/rshade/pulumicost-spec/issues/160)) ([a75b42b](https://github.com/rshade/pulumicost-spec/commit/a75b42b355395f590b7d211475de05f5083bd82b)), closes [#157](https://github.com/rshade/pulumicost-spec/issues/157)
-
-## [0.4.6](https://github.com/rshade/pulumicost-spec/compare/v0.4.5...v0.4.6) (2025-12-11)
+## [0.4.7](https://github.com/rshade/finfocus-spec/compare/v0.4.6...v0.4.7) (2025-12-15)
 
 
 ### Added
 
-* **pluginsdk:** add request validation helpers ([#151](https://github.com/rshade/pulumicost-spec/issues/151)) ([ef71ba6](https://github.com/rshade/pulumicost-spec/commit/ef71ba6018169b630f3068deab45b97bd1e3522c)), closes [#130](https://github.com/rshade/pulumicost-spec/issues/130)
+* **proto:** add arn field to actual cost request ([#160](https://github.com/rshade/finfocus-spec/issues/160)) ([a75b42b](https://github.com/rshade/finfocus-spec/commit/a75b42b355395f590b7d211475de05f5083bd82b)), closes [#157](https://github.com/rshade/finfocus-spec/issues/157)
+
+## [0.4.6](https://github.com/rshade/finfocus-spec/compare/v0.4.5...v0.4.6) (2025-12-11)
+
+
+### Added
+
+* **pluginsdk:** add request validation helpers ([#151](https://github.com/rshade/finfocus-spec/issues/151)) ([ef71ba6](https://github.com/rshade/finfocus-spec/commit/ef71ba6018169b630f3068deab45b97bd1e3522c)), closes [#130](https://github.com/rshade/finfocus-spec/issues/130)
 
 
 ### Fixed
 
-* updating small bugs in spec ([#156](https://github.com/rshade/pulumicost-spec/issues/156)) ([83df05f](https://github.com/rshade/pulumicost-spec/commit/83df05f11ec2690c9b4e594128a9ba4022c20c8b))
+* updating small bugs in spec ([#156](https://github.com/rshade/finfocus-spec/issues/156)) ([83df05f](https://github.com/rshade/finfocus-spec/commit/83df05f11ec2690c9b4e594128a9ba4022c20c8b))
 
-## [0.4.5](https://github.com/rshade/pulumicost-spec/compare/v0.4.4...v0.4.5) (2025-12-10)
+## [0.4.5](https://github.com/rshade/finfocus-spec/compare/v0.4.4...v0.4.5) (2025-12-10)
 
 
 ### Added
 
-* **pluginsdk:** add mapping package for property extraction ([#148](https://github.com/rshade/pulumicost-spec/issues/148)) ([8fd1524](https://github.com/rshade/pulumicost-spec/commit/8fd1524877218272a7d219239058bfee43c294bc)), closes [#128](https://github.com/rshade/pulumicost-spec/issues/128)
-* **proto:** add getbudgets rpc for unified budget visibility ([#149](https://github.com/rshade/pulumicost-spec/issues/149)) ([b4018d7](https://github.com/rshade/pulumicost-spec/commit/b4018d794fd5b2c2f54541102c7625ffd900f26f)), closes [#123](https://github.com/rshade/pulumicost-spec/issues/123)
-* **sdk:** Support PULUMICOST_LOG_FILE for unified logging ([#145](https://github.com/rshade/pulumicost-spec/issues/145)) ([6b9a9b3](https://github.com/rshade/pulumicost-spec/commit/6b9a9b38e24f9b49a05095c140bd2500c4e8090b)), closes [#131](https://github.com/rshade/pulumicost-spec/issues/131)
+* **pluginsdk:** add mapping package for property extraction ([#148](https://github.com/rshade/finfocus-spec/issues/148)) ([8fd1524](https://github.com/rshade/finfocus-spec/commit/8fd1524877218272a7d219239058bfee43c294bc)), closes [#128](https://github.com/rshade/finfocus-spec/issues/128)
+* **proto:** add getbudgets rpc for unified budget visibility ([#149](https://github.com/rshade/finfocus-spec/issues/149)) ([b4018d7](https://github.com/rshade/finfocus-spec/commit/b4018d794fd5b2c2f54541102c7625ffd900f26f)), closes [#123](https://github.com/rshade/finfocus-spec/issues/123)
+* **sdk:** Support PULUMICOST_LOG_FILE for unified logging ([#145](https://github.com/rshade/finfocus-spec/issues/145)) ([6b9a9b3](https://github.com/rshade/finfocus-spec/commit/6b9a9b38e24f9b49a05095c140bd2500c4e8090b)), closes [#131](https://github.com/rshade/finfocus-spec/issues/131)
 
 
 ### Documentation
 
-* Document pluginsdk.Serve() behavior and configuration ([#146](https://github.com/rshade/pulumicost-spec/issues/146)) ([30687f9](https://github.com/rshade/pulumicost-spec/commit/30687f9ca34a1c262a0ac6b8f66f98301dce1987))
-* **sdk:** add core-plugin interface docs and contract tests ([#150](https://github.com/rshade/pulumicost-spec/issues/150)) ([87d4428](https://github.com/rshade/pulumicost-spec/commit/87d44289a5a63b25d8baeccb11f7eb9f56ba3128)), closes [#132](https://github.com/rshade/pulumicost-spec/issues/132) [#133](https://github.com/rshade/pulumicost-spec/issues/133) [#134](https://github.com/rshade/pulumicost-spec/issues/134) [#135](https://github.com/rshade/pulumicost-spec/issues/135)
+* Document pluginsdk.Serve() behavior and configuration ([#146](https://github.com/rshade/finfocus-spec/issues/146)) ([30687f9](https://github.com/rshade/finfocus-spec/commit/30687f9ca34a1c262a0ac6b8f66f98301dce1987))
+* **sdk:** add core-plugin interface docs and contract tests ([#150](https://github.com/rshade/finfocus-spec/issues/150)) ([87d4428](https://github.com/rshade/finfocus-spec/commit/87d44289a5a63b25d8baeccb11f7eb9f56ba3128)), closes [#132](https://github.com/rshade/finfocus-spec/issues/132) [#133](https://github.com/rshade/finfocus-spec/issues/133) [#134](https://github.com/rshade/finfocus-spec/issues/134) [#135](https://github.com/rshade/finfocus-spec/issues/135)
 
-## [0.4.4](https://github.com/rshade/pulumicost-spec/compare/v0.4.3...v0.4.4) (2025-12-09)
+## [0.4.4](https://github.com/rshade/finfocus-spec/compare/v0.4.3...v0.4.4) (2025-12-09)
 
 ### Added
 
-- **pluginsdk:** add --port flag parsing for multi-plugin orchestration ([#143](https://github.com/rshade/pulumicost-spec/issues/143)) ([c0b0528](https://github.com/rshade/pulumicost-spec/commit/c0b05288e69dc70ad0105165572a5fa3714ed27f)), closes [#129](https://github.com/rshade/pulumicost-spec/issues/129) [#137](https://github.com/rshade/pulumicost-spec/issues/137)
-- **pluginsdk:** add fallback hint enum for plugin orchestration ([#126](https://github.com/rshade/pulumicost-spec/issues/126)) ([ef7aab0](https://github.com/rshade/pulumicost-spec/commit/ef7aab0576e3b4815c4d273c33800557734ebb37)), closes [#124](https://github.com/rshade/pulumicost-spec/issues/124)
-- **pluginsdk:** centralize environment variable handling ([#139](https://github.com/rshade/pulumicost-spec/issues/139)) ([4c9e279](https://github.com/rshade/pulumicost-spec/commit/4c9e279ad38c58ee28178f61041c387c512654ca)), closes [#127](https://github.com/rshade/pulumicost-spec/issues/127)
-- **proto:** add getbudgets rpc for unified budget visibility across providers ([#145](https://github.com/rshade/pulumicost-spec/issues/145)) ([abc123d](https://github.com/rshade/pulumicost-spec/commit/abc123def456ghi789jkl012))
-- **proto:** add getrecommendations rpc for finops optimization ([#125](https://github.com/rshade/pulumicost-spec/issues/125)) ([ecf92f0](https://github.com/rshade/pulumicost-spec/commit/ecf92f0af6c1dbd1d036e92a1e999a7576debaef))
+- **pluginsdk:** add --port flag parsing for multi-plugin orchestration ([#143](https://github.com/rshade/finfocus-spec/issues/143)) ([c0b0528](https://github.com/rshade/finfocus-spec/commit/c0b05288e69dc70ad0105165572a5fa3714ed27f)), closes [#129](https://github.com/rshade/finfocus-spec/issues/129) [#137](https://github.com/rshade/finfocus-spec/issues/137)
+- **pluginsdk:** add fallback hint enum for plugin orchestration ([#126](https://github.com/rshade/finfocus-spec/issues/126)) ([ef7aab0](https://github.com/rshade/finfocus-spec/commit/ef7aab0576e3b4815c4d273c33800557734ebb37)), closes [#124](https://github.com/rshade/finfocus-spec/issues/124)
+- **pluginsdk:** centralize environment variable handling ([#139](https://github.com/rshade/finfocus-spec/issues/139)) ([4c9e279](https://github.com/rshade/finfocus-spec/commit/4c9e279ad38c58ee28178f61041c387c512654ca)), closes [#127](https://github.com/rshade/finfocus-spec/issues/127)
+- **proto:** add getbudgets rpc for unified budget visibility across providers ([#145](https://github.com/rshade/finfocus-spec/issues/145)) ([abc123d](https://github.com/rshade/finfocus-spec/commit/abc123def456ghi789jkl012))
+- **proto:** add getrecommendations rpc for finops optimization ([#125](https://github.com/rshade/finfocus-spec/issues/125)) ([ecf92f0](https://github.com/rshade/finfocus-spec/commit/ecf92f0af6c1dbd1d036e92a1e999a7576debaef))
 
 ### Fixed
 
-- adding in edge case tests, and benchmark ([#142](https://github.com/rshade/pulumicost-spec/issues/142)) ([881132b](https://github.com/rshade/pulumicost-spec/commit/881132bd87d1bb69ecd9f3abff01527da16fc08f))
+- adding in edge case tests, and benchmark ([#142](https://github.com/rshade/finfocus-spec/issues/142)) ([881132b](https://github.com/rshade/finfocus-spec/commit/881132bd87d1bb69ecd9f3abff01527da16fc08f))
 
 ### Documentation
 
-- adding in claude speckit ([#144](https://github.com/rshade/pulumicost-spec/issues/144)) ([70a6e78](https://github.com/rshade/pulumicost-spec/commit/70a6e78fffba6ac81c518a4225a4da56a34aafdf))
+- adding in claude speckit ([#144](https://github.com/rshade/finfocus-spec/issues/144)) ([70a6e78](https://github.com/rshade/finfocus-spec/commit/70a6e78fffba6ac81c518a4225a4da56a34aafdf))
 
-## [0.4.3](https://github.com/rshade/pulumicost-spec/compare/v0.4.2...v0.4.3) (2025-12-03)
-
-### Added
-
-- **ci:** Add Lefthook git hooks with commitlint validation ([#120](https://github.com/rshade/pulumicost-spec/issues/120)) ([afdf8f7](https://github.com/rshade/pulumicost-spec/commit/afdf8f78afb2cac5dfdad95359acb2871c727be7)), closes [#55](https://github.com/rshade/pulumicost-spec/issues/55)
-- **pluginsdk:** Add conformance testing support for Plugin interface ([#118](https://github.com/rshade/pulumicost-spec/issues/118)) ([8df49c0](https://github.com/rshade/pulumicost-spec/commit/8df49c041adc671843aa0fa6bda987c50a5bcc7a)), closes [#98](https://github.com/rshade/pulumicost-spec/issues/98)
-- **pluginsdk:** add Prometheus metrics instrumentation for plugins ([#119](https://github.com/rshade/pulumicost-spec/issues/119)) ([9365aef](https://github.com/rshade/pulumicost-spec/commit/9365aef0636144f1bcf0695db68681823a889fe0)), closes [#80](https://github.com/rshade/pulumicost-spec/issues/80)
-- **sdk/go/currency:** extract ISO 4217 validation as reusable package (T101) ([#116](https://github.com/rshade/pulumicost-spec/issues/116)) ([97e34f5](https://github.com/rshade/pulumicost-spec/commit/97e34f5fba0f1a635ab9651ed2bc80510898b962)), closes [#101](https://github.com/rshade/pulumicost-spec/issues/101)
-
-## [0.4.2](https://github.com/rshade/pulumicost-spec/compare/v0.4.1...v0.4.2) (2025-11-30)
+## [0.4.3](https://github.com/rshade/finfocus-spec/compare/v0.4.2...v0.4.3) (2025-12-03)
 
 ### Added
 
-- **ci:** add performance regression testing workflow ([8944316](https://github.com/rshade/pulumicost-spec/commit/8944316a5337a12652efaa700999b7fd400517de))
-- run concurrent benchmark for EstimateCost ([#113](https://github.com/rshade/pulumicost-spec/issues/113)) ([0ffcdc4](https://github.com/rshade/pulumicost-spec/commit/0ffcdc48e132b1eece31a1c51280cd250c608c23))
-- **testing:** add distributed tracing example for EstimateCost (T042) ([#112](https://github.com/rshade/pulumicost-spec/issues/112)) ([b14dd3c](https://github.com/rshade/pulumicost-spec/commit/b14dd3c2eface44181d13d5add225eff57f53198)), closes [#85](https://github.com/rshade/pulumicost-spec/issues/85)
-- **testing:** add metrics tracking example for EstimateCost (T041) ([#111](https://github.com/rshade/pulumicost-spec/issues/111)) ([944e078](https://github.com/rshade/pulumicost-spec/commit/944e0789a67be8e204d92d0d7a35ba181f9dd854)), closes [#84](https://github.com/rshade/pulumicost-spec/issues/84)
-- **testing:** implement Plugin Conformance Test Suite ([#109](https://github.com/rshade/pulumicost-spec/issues/109)) ([03116ce](https://github.com/rshade/pulumicost-spec/commit/03116cef17567bdea85ba59e87aca322d2c42efb))
+- **ci:** Add Lefthook git hooks with commitlint validation ([#120](https://github.com/rshade/finfocus-spec/issues/120)) ([afdf8f7](https://github.com/rshade/finfocus-spec/commit/afdf8f78afb2cac5dfdad95359acb2871c727be7)), closes [#55](https://github.com/rshade/finfocus-spec/issues/55)
+- **pluginsdk:** Add conformance testing support for Plugin interface ([#118](https://github.com/rshade/finfocus-spec/issues/118)) ([8df49c0](https://github.com/rshade/finfocus-spec/commit/8df49c041adc671843aa0fa6bda987c50a5bcc7a)), closes [#98](https://github.com/rshade/finfocus-spec/issues/98)
+- **pluginsdk:** add Prometheus metrics instrumentation for plugins ([#119](https://github.com/rshade/finfocus-spec/issues/119)) ([9365aef](https://github.com/rshade/finfocus-spec/commit/9365aef0636144f1bcf0695db68681823a889fe0)), closes [#80](https://github.com/rshade/finfocus-spec/issues/80)
+- **sdk/go/currency:** extract ISO 4217 validation as reusable package (T101) ([#116](https://github.com/rshade/finfocus-spec/issues/116)) ([97e34f5](https://github.com/rshade/finfocus-spec/commit/97e34f5fba0f1a635ab9651ed2bc80510898b962)), closes [#101](https://github.com/rshade/finfocus-spec/issues/101)
+
+## [0.4.2](https://github.com/rshade/finfocus-spec/compare/v0.4.1...v0.4.2) (2025-11-30)
+
+### Added
+
+- **ci:** add performance regression testing workflow ([8944316](https://github.com/rshade/finfocus-spec/commit/8944316a5337a12652efaa700999b7fd400517de))
+- run concurrent benchmark for EstimateCost ([#113](https://github.com/rshade/finfocus-spec/issues/113)) ([0ffcdc4](https://github.com/rshade/finfocus-spec/commit/0ffcdc48e132b1eece31a1c51280cd250c608c23))
+- **testing:** add distributed tracing example for EstimateCost (T042) ([#112](https://github.com/rshade/finfocus-spec/issues/112)) ([b14dd3c](https://github.com/rshade/finfocus-spec/commit/b14dd3c2eface44181d13d5add225eff57f53198)), closes [#85](https://github.com/rshade/finfocus-spec/issues/85)
+- **testing:** add metrics tracking example for EstimateCost (T041) ([#111](https://github.com/rshade/finfocus-spec/issues/111)) ([944e078](https://github.com/rshade/finfocus-spec/commit/944e0789a67be8e204d92d0d7a35ba181f9dd854)), closes [#84](https://github.com/rshade/finfocus-spec/issues/84)
+- **testing:** implement Plugin Conformance Test Suite ([#109](https://github.com/rshade/finfocus-spec/issues/109)) ([03116ce](https://github.com/rshade/finfocus-spec/commit/03116cef17567bdea85ba59e87aca322d2c42efb))
 
 ### Documentation
 
-- **006-estimate-cost:** update data-model.md with actual decimal type (T054) ([#114](https://github.com/rshade/pulumicost-spec/issues/114)) ([45f4b2e](https://github.com/rshade/pulumicost-spec/commit/45f4b2e7c2a37c9414aada68343731a2f0e7913c)), closes [#89](https://github.com/rshade/pulumicost-spec/issues/89)
+- **006-estimate-cost:** update data-model.md with actual decimal type (T054) ([#114](https://github.com/rshade/finfocus-spec/issues/114)) ([45f4b2e](https://github.com/rshade/finfocus-spec/commit/45f4b2e7c2a37c9414aada68343731a2f0e7913c)), closes [#89](https://github.com/rshade/finfocus-spec/issues/89)
 
-## [0.4.1](https://github.com/rshade/pulumicost-spec/compare/v0.4.0...v0.4.1) (2025-11-29)
+## [0.4.1](https://github.com/rshade/finfocus-spec/compare/v0.4.0...v0.4.1) (2025-11-29)
 
 ### Added
 
-- add trace ID validation to TracingUnaryServerInterceptor ([#96](https://github.com/rshade/pulumicost-spec/issues/96)) ([dd410cd](https://github.com/rshade/pulumicost-spec/commit/dd410cdbc2ca88ecc87dc3bef3e4fa3488efd714)), closes [#94](https://github.com/rshade/pulumicost-spec/issues/94)
-- **focus:** add complete FOCUS 1.2 column coverage with builder API ([#100](https://github.com/rshade/pulumicost-spec/issues/100)) ([2355acf](https://github.com/rshade/pulumicost-spec/commit/2355acf206f5d2ed70d9cd47fd9033525f8fe552))
-- **focus:** Implement FOCUS 1.2 integration ([#99](https://github.com/rshade/pulumicost-spec/issues/99)) ([913b6ef](https://github.com/rshade/pulumicost-spec/commit/913b6ef9d9a9ca277058ded46dcf5f7cfadc7aab))
-- **sdk:** migrate pluginsdk from core to spec ([#97](https://github.com/rshade/pulumicost-spec/issues/97)) ([2e35cbf](https://github.com/rshade/pulumicost-spec/commit/2e35cbf548f91f0151901795227dc07d578f3220))
-- **testing:** add structured logging example for EstimateCost RPC ([#93](https://github.com/rshade/pulumicost-spec/issues/93)) ([4c583c0](https://github.com/rshade/pulumicost-spec/commit/4c583c0fc0cc179b57fb919eef6ba349d4cf7187)), closes [#83](https://github.com/rshade/pulumicost-spec/issues/83)
+- add trace ID validation to TracingUnaryServerInterceptor ([#96](https://github.com/rshade/finfocus-spec/issues/96)) ([dd410cd](https://github.com/rshade/finfocus-spec/commit/dd410cdbc2ca88ecc87dc3bef3e4fa3488efd714)), closes [#94](https://github.com/rshade/finfocus-spec/issues/94)
+- **focus:** add complete FOCUS 1.2 column coverage with builder API ([#100](https://github.com/rshade/finfocus-spec/issues/100)) ([2355acf](https://github.com/rshade/finfocus-spec/commit/2355acf206f5d2ed70d9cd47fd9033525f8fe552))
+- **focus:** Implement FOCUS 1.2 integration ([#99](https://github.com/rshade/finfocus-spec/issues/99)) ([913b6ef](https://github.com/rshade/finfocus-spec/commit/913b6ef9d9a9ca277058ded46dcf5f7cfadc7aab))
+- **sdk:** migrate pluginsdk from core to spec ([#97](https://github.com/rshade/finfocus-spec/issues/97)) ([2e35cbf](https://github.com/rshade/finfocus-spec/commit/2e35cbf548f91f0151901795227dc07d578f3220))
+- **testing:** add structured logging example for EstimateCost RPC ([#93](https://github.com/rshade/finfocus-spec/issues/93)) ([4c583c0](https://github.com/rshade/finfocus-spec/commit/4c583c0fc0cc179b57fb919eef6ba349d4cf7187)), closes [#83](https://github.com/rshade/finfocus-spec/issues/83)
 
 ## [Unreleased]
 
@@ -195,29 +195,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ci:** add performance regression tests with benchmark comparison
 - **docs:** add EstimateCost cross-provider coverage matrix to examples/README.md
-- **sdk:** add trace ID validation to TracingUnaryServerInterceptor for security ([#94](https://github.com/rshade/pulumicost-spec/issues/94))
+- **sdk:** add trace ID validation to TracingUnaryServerInterceptor for security ([#94](https://github.com/rshade/finfocus-spec/issues/94))
 
 ### Security
 
 - **sdk:** prevent log injection attacks through malformed trace IDs by validating and replacing invalid values
 
-## [0.4.0](https://github.com/rshade/pulumicost-spec/compare/v0.3.0...v0.4.0) (2025-11-26)
+## [0.4.0](https://github.com/rshade/finfocus-spec/compare/v0.3.0...v0.4.0) (2025-11-26)
 
 ### Added
 
-- **rpc:** implement EstimateCost RPC for what-if cost analysis ([#90](https://github.com/rshade/pulumicost-spec/issues/90)) ([d6f3c95](https://github.com/rshade/pulumicost-spec/commit/d6f3c9566da8d28550923edfe4ffe34d3c143e0e)), closes [#79](https://github.com/rshade/pulumicost-spec/issues/79)
+- **rpc:** implement EstimateCost RPC for what-if cost analysis ([#90](https://github.com/rshade/finfocus-spec/issues/90)) ([d6f3c95](https://github.com/rshade/finfocus-spec/commit/d6f3c9566da8d28550923edfe4ffe34d3c143e0e)), closes [#79](https://github.com/rshade/finfocus-spec/issues/79)
 
-## [0.3.0](https://github.com/rshade/pulumicost-spec/compare/v0.2.0...v0.3.0) (2025-11-24)
+## [0.3.0](https://github.com/rshade/finfocus-spec/compare/v0.2.0...v0.3.0) (2025-11-24)
 
 ### Added
 
-- **sdk:** add zerolog logging utilities for plugin standardization ([#76](https://github.com/rshade/pulumicost-spec/issues/76)) ([6d5b5ac](https://github.com/rshade/pulumicost-spec/commit/6d5b5ac06329dce03a99b595e41d5ca1273b7c40)), closes [#75](https://github.com/rshade/pulumicost-spec/issues/75)
+- **sdk:** add zerolog logging utilities for plugin standardization ([#76](https://github.com/rshade/finfocus-spec/issues/76)) ([6d5b5ac](https://github.com/rshade/finfocus-spec/commit/6d5b5ac06329dce03a99b595e41d5ca1273b7c40)), closes [#75](https://github.com/rshade/finfocus-spec/issues/75)
 
 ### Documentation
 
-- udpate sdk/go/registry/CLAUDE.md for enums ([#78](https://github.com/rshade/pulumicost-spec/issues/78)) ([f15ef76](https://github.com/rshade/pulumicost-spec/commit/f15ef769ac491056504f7a0376b413727f7969e0)), closes [#3](https://github.com/rshade/pulumicost-spec/issues/3)
+- udpate sdk/go/registry/CLAUDE.md for enums ([#78](https://github.com/rshade/finfocus-spec/issues/78)) ([f15ef76](https://github.com/rshade/finfocus-spec/commit/f15ef769ac491056504f7a0376b413727f7969e0)), closes [#3](https://github.com/rshade/finfocus-spec/issues/3)
 
-## [0.2.0](https://github.com/rshade/pulumicost-spec/compare/v0.1.0...v0.2.0) (2025-11-24)
+## [0.2.0](https://github.com/rshade/finfocus-spec/compare/v0.1.0...v0.2.0) (2025-11-24)
 
 ### ⚠ BREAKING CHANGES
 
@@ -226,22 +226,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **proto:** enhance GetPricingSpec with transparent pricing breakdown ([#67](https://github.com/rshade/pulumicost-spec/issues/67)) ([336144e](https://github.com/rshade/pulumicost-spec/commit/336144e45e2334a677af4a0f5ccb3994126cf22a)), closes [#62](https://github.com/rshade/pulumicost-spec/issues/62)
-- **schema:** add plugin registry index JSON Schema ([#70](https://github.com/rshade/pulumicost-spec/issues/70)) ([79938a7](https://github.com/rshade/pulumicost-spec/commit/79938a7fc473cd997465f3a71c734b0b2b3b692b)), closes [#68](https://github.com/rshade/pulumicost-spec/issues/68)
+- **proto:** enhance GetPricingSpec with transparent pricing breakdown ([#67](https://github.com/rshade/finfocus-spec/issues/67)) ([336144e](https://github.com/rshade/finfocus-spec/commit/336144e45e2334a677af4a0f5ccb3994126cf22a)), closes [#62](https://github.com/rshade/finfocus-spec/issues/62)
+- **schema:** add plugin registry index JSON Schema ([#70](https://github.com/rshade/finfocus-spec/issues/70)) ([79938a7](https://github.com/rshade/finfocus-spec/commit/79938a7fc473cd997465f3a71c734b0b2b3b692b)), closes [#68](https://github.com/rshade/finfocus-spec/issues/68)
 
 ### Fixed
 
-- **release:** remove release-as constraint to allow version bumps ([#73](https://github.com/rshade/pulumicost-spec/issues/73)) ([706ec65](https://github.com/rshade/pulumicost-spec/commit/706ec65dbe779242674aae94c6bc89de0f8c252a))
+- **release:** remove release-as constraint to allow version bumps ([#73](https://github.com/rshade/finfocus-spec/issues/73)) ([706ec65](https://github.com/rshade/finfocus-spec/commit/706ec65dbe779242674aae94c6bc89de0f8c252a))
 
 ### Performance
 
-- **registry:** optimize enum validation for zero-allocation performance ([#63](https://github.com/rshade/pulumicost-spec/issues/63)) ([6d3c124](https://github.com/rshade/pulumicost-spec/commit/6d3c124b4230485ee27288051181a965a31daf50)), closes [#33](https://github.com/rshade/pulumicost-spec/issues/33)
+- **registry:** optimize enum validation for zero-allocation performance ([#63](https://github.com/rshade/finfocus-spec/issues/63)) ([6d3c124](https://github.com/rshade/finfocus-spec/commit/6d3c124b4230485ee27288051181a965a31daf50)), closes [#33](https://github.com/rshade/finfocus-spec/issues/33)
 
 ### Documentation
 
-- **spec:** document Supports() RPC verification for issue [#64](https://github.com/rshade/pulumicost-spec/issues/64) ([#66](https://github.com/rshade/pulumicost-spec/issues/66)) ([3a17c4f](https://github.com/rshade/pulumicost-spec/commit/3a17c4f516488d033549c26c4bb9ad8ed957e3b0))
+- **spec:** document Supports() RPC verification for issue [#64](https://github.com/rshade/finfocus-spec/issues/64) ([#66](https://github.com/rshade/finfocus-spec/issues/66)) ([3a17c4f](https://github.com/rshade/finfocus-spec/commit/3a17c4f516488d033549c26c4bb9ad8ed957e3b0))
 
-## [0.1.0](https://github.com/rshade/pulumicost-spec/compare/v0.1.0...v0.1.0) (2025-11-24)
+## [0.1.0](https://github.com/rshade/finfocus-spec/compare/v0.1.0...v0.1.0) (2025-11-24)
 
 ### ⚠ BREAKING CHANGES
 
@@ -250,16 +250,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **proto:** enhance GetPricingSpec with transparent pricing breakdown ([#67](https://github.com/rshade/pulumicost-spec/issues/67)) ([336144e](https://github.com/rshade/pulumicost-spec/commit/336144e45e2334a677af4a0f5ccb3994126cf22a)), closes [#62](https://github.com/rshade/pulumicost-spec/issues/62)
-- **schema:** add plugin registry index JSON Schema ([#70](https://github.com/rshade/pulumicost-spec/issues/70)) ([79938a7](https://github.com/rshade/pulumicost-spec/commit/79938a7fc473cd997465f3a71c734b0b2b3b692b)), closes [#68](https://github.com/rshade/pulumicost-spec/issues/68)
+- **proto:** enhance GetPricingSpec with transparent pricing breakdown ([#67](https://github.com/rshade/finfocus-spec/issues/67)) ([336144e](https://github.com/rshade/finfocus-spec/commit/336144e45e2334a677af4a0f5ccb3994126cf22a)), closes [#62](https://github.com/rshade/finfocus-spec/issues/62)
+- **schema:** add plugin registry index JSON Schema ([#70](https://github.com/rshade/finfocus-spec/issues/70)) ([79938a7](https://github.com/rshade/finfocus-spec/commit/79938a7fc473cd997465f3a71c734b0b2b3b692b)), closes [#68](https://github.com/rshade/finfocus-spec/issues/68)
 
 ### Performance
 
-- **registry:** optimize enum validation for zero-allocation performance ([#63](https://github.com/rshade/pulumicost-spec/issues/63)) ([6d3c124](https://github.com/rshade/pulumicost-spec/commit/6d3c124b4230485ee27288051181a965a31daf50)), closes [#33](https://github.com/rshade/pulumicost-spec/issues/33)
+- **registry:** optimize enum validation for zero-allocation performance ([#63](https://github.com/rshade/finfocus-spec/issues/63)) ([6d3c124](https://github.com/rshade/finfocus-spec/commit/6d3c124b4230485ee27288051181a965a31daf50)), closes [#33](https://github.com/rshade/finfocus-spec/issues/33)
 
 ### Documentation
 
-- **spec:** document Supports() RPC verification for issue [#64](https://github.com/rshade/pulumicost-spec/issues/64) ([#66](https://github.com/rshade/pulumicost-spec/issues/66)) ([3a17c4f](https://github.com/rshade/pulumicost-spec/commit/3a17c4f516488d033549c26c4bb9ad8ed957e3b0))
+- **spec:** document Supports() RPC verification for issue [#64](https://github.com/rshade/finfocus-spec/issues/64) ([#66](https://github.com/rshade/finfocus-spec/issues/66)) ([3a17c4f](https://github.com/rshade/finfocus-spec/commit/3a17c4f516488d033549c26c4bb9ad8ed957e3b0))
 
 ## [Unreleased]
 
@@ -271,7 +271,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Includes `dependentRequired` for deprecation_message when deprecated is true
   - npm validation scripts: `validate:registry`, `validate:registry-schema`
   - Example registry with kubecost and aws-public plugins
-  - Closes [#68](https://github.com/rshade/pulumicost-spec/issues/68)
+  - Closes [#68](https://github.com/rshade/finfocus-spec/issues/68)
 
 ### Changed
 
@@ -283,35 +283,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Memory footprint reduced to ~608 bytes total for all enums (vs ~3.5 KB for maps)
   - Established validation pattern for future SDK enums (see `specs/001-domain-enum-optimization/`)
 
-## [0.1.0](https://github.com/rshade/pulumicost-spec/compare/v0.1.0...v0.1.0) (2025-11-18)
+## [0.1.0](https://github.com/rshade/finfocus-spec/compare/v0.1.0...v0.1.0) (2025-11-18)
 
 ### Added
 
-- Add comprehensive Plugin Registry Specification ([#29](https://github.com/rshade/pulumicost-spec/issues/29)) ([5825eaa](https://github.com/rshade/pulumicost-spec/commit/5825eaab1f343b1f9fcb966c38effb6a743d3494)), closes [#8](https://github.com/rshade/pulumicost-spec/issues/8)
-- comprehensive testing framework and enterprise CI/CD pipeline ([#19](https://github.com/rshade/pulumicost-spec/issues/19)) ([3a235ef](https://github.com/rshade/pulumicost-spec/commit/3a235eff0ce4a172a7b920326066227540c6c8b8))
-- enhance Provider enum with String() method and improved error m… ([#39](https://github.com/rshade/pulumicost-spec/issues/39)) ([acbaf0c](https://github.com/rshade/pulumicost-spec/commit/acbaf0c6db29d986211d3ca8ef19a66e3162e2c2)), closes [#4](https://github.com/rshade/pulumicost-spec/issues/4)
-- freeze costsource.proto v0.1.0 specification ([#17](https://github.com/rshade/pulumicost-spec/issues/17)) ([3b485b9](https://github.com/rshade/pulumicost-spec/commit/3b485b96fef7dc2992c166980f324907e4ff06bd)), closes [#3](https://github.com/rshade/pulumicost-spec/issues/3)
-- freeze costsource.proto v0.1.0 specification ([#18](https://github.com/rshade/pulumicost-spec/issues/18)) ([a085bd2](https://github.com/rshade/pulumicost-spec/commit/a085bd202e266189efba92a1832fa8f90c0931e6)), closes [#3](https://github.com/rshade/pulumicost-spec/issues/3)
+- Add comprehensive Plugin Registry Specification ([#29](https://github.com/rshade/finfocus-spec/issues/29)) ([5825eaa](https://github.com/rshade/finfocus-spec/commit/5825eaab1f343b1f9fcb966c38effb6a743d3494)), closes [#8](https://github.com/rshade/finfocus-spec/issues/8)
+- comprehensive testing framework and enterprise CI/CD pipeline ([#19](https://github.com/rshade/finfocus-spec/issues/19)) ([3a235ef](https://github.com/rshade/finfocus-spec/commit/3a235eff0ce4a172a7b920326066227540c6c8b8))
+- enhance Provider enum with String() method and improved error m… ([#39](https://github.com/rshade/finfocus-spec/issues/39)) ([acbaf0c](https://github.com/rshade/finfocus-spec/commit/acbaf0c6db29d986211d3ca8ef19a66e3162e2c2)), closes [#4](https://github.com/rshade/finfocus-spec/issues/4)
+- freeze costsource.proto v0.1.0 specification ([#17](https://github.com/rshade/finfocus-spec/issues/17)) ([3b485b9](https://github.com/rshade/finfocus-spec/commit/3b485b96fef7dc2992c166980f324907e4ff06bd)), closes [#3](https://github.com/rshade/finfocus-spec/issues/3)
+- freeze costsource.proto v0.1.0 specification ([#18](https://github.com/rshade/finfocus-spec/issues/18)) ([a085bd2](https://github.com/rshade/finfocus-spec/commit/a085bd202e266189efba92a1832fa8f90c0931e6)), closes [#3](https://github.com/rshade/finfocus-spec/issues/3)
 
 ### Documentation
 
-- add comprehensive plugin developer guide ([#16](https://github.com/rshade/pulumicost-spec/issues/16)) ([b0a5eb3](https://github.com/rshade/pulumicost-spec/commit/b0a5eb3396b5c49839d742234666667e5e7b1ee7)), closes [#2](https://github.com/rshade/pulumicost-spec/issues/2)
-- establish constitution v1.0.0 for gRPC proto specification governance ([#57](https://github.com/rshade/pulumicost-spec/issues/57)) ([54578aa](https://github.com/rshade/pulumicost-spec/commit/54578aa259cb8907f989196ce2b73e37e57f906f))
+- add comprehensive plugin developer guide ([#16](https://github.com/rshade/finfocus-spec/issues/16)) ([b0a5eb3](https://github.com/rshade/finfocus-spec/commit/b0a5eb3396b5c49839d742234666667e5e7b1ee7)), closes [#2](https://github.com/rshade/finfocus-spec/issues/2)
+- establish constitution v1.0.0 for gRPC proto specification governance ([#57](https://github.com/rshade/finfocus-spec/issues/57)) ([54578aa](https://github.com/rshade/finfocus-spec/commit/54578aa259cb8907f989196ce2b73e37e57f906f))
 
-## [0.1.0](https://github.com/rshade/pulumicost-spec/compare/v0.1.0...v0.1.0) (2025-11-18)
+## [0.1.0](https://github.com/rshade/finfocus-spec/compare/v0.1.0...v0.1.0) (2025-11-18)
 
 ### Added
 
-- Add comprehensive Plugin Registry Specification ([#29](https://github.com/rshade/pulumicost-spec/issues/29)) ([5825eaa](https://github.com/rshade/pulumicost-spec/commit/5825eaab1f343b1f9fcb966c38effb6a743d3494)), closes [#8](https://github.com/rshade/pulumicost-spec/issues/8)
-- comprehensive testing framework and enterprise CI/CD pipeline ([#19](https://github.com/rshade/pulumicost-spec/issues/19)) ([3a235ef](https://github.com/rshade/pulumicost-spec/commit/3a235eff0ce4a172a7b920326066227540c6c8b8))
-- enhance Provider enum with String() method and improved error m… ([#39](https://github.com/rshade/pulumicost-spec/issues/39)) ([acbaf0c](https://github.com/rshade/pulumicost-spec/commit/acbaf0c6db29d986211d3ca8ef19a66e3162e2c2)), closes [#4](https://github.com/rshade/pulumicost-spec/issues/4)
-- freeze costsource.proto v0.1.0 specification ([#17](https://github.com/rshade/pulumicost-spec/issues/17)) ([3b485b9](https://github.com/rshade/pulumicost-spec/commit/3b485b96fef7dc2992c166980f324907e4ff06bd)), closes [#3](https://github.com/rshade/pulumicost-spec/issues/3)
-- freeze costsource.proto v0.1.0 specification ([#18](https://github.com/rshade/pulumicost-spec/issues/18)) ([a085bd2](https://github.com/rshade/pulumicost-spec/commit/a085bd202e266189efba92a1832fa8f90c0931e6)), closes [#3](https://github.com/rshade/pulumicost-spec/issues/3)
+- Add comprehensive Plugin Registry Specification ([#29](https://github.com/rshade/finfocus-spec/issues/29)) ([5825eaa](https://github.com/rshade/finfocus-spec/commit/5825eaab1f343b1f9fcb966c38effb6a743d3494)), closes [#8](https://github.com/rshade/finfocus-spec/issues/8)
+- comprehensive testing framework and enterprise CI/CD pipeline ([#19](https://github.com/rshade/finfocus-spec/issues/19)) ([3a235ef](https://github.com/rshade/finfocus-spec/commit/3a235eff0ce4a172a7b920326066227540c6c8b8))
+- enhance Provider enum with String() method and improved error m… ([#39](https://github.com/rshade/finfocus-spec/issues/39)) ([acbaf0c](https://github.com/rshade/finfocus-spec/commit/acbaf0c6db29d986211d3ca8ef19a66e3162e2c2)), closes [#4](https://github.com/rshade/finfocus-spec/issues/4)
+- freeze costsource.proto v0.1.0 specification ([#17](https://github.com/rshade/finfocus-spec/issues/17)) ([3b485b9](https://github.com/rshade/finfocus-spec/commit/3b485b96fef7dc2992c166980f324907e4ff06bd)), closes [#3](https://github.com/rshade/finfocus-spec/issues/3)
+- freeze costsource.proto v0.1.0 specification ([#18](https://github.com/rshade/finfocus-spec/issues/18)) ([a085bd2](https://github.com/rshade/finfocus-spec/commit/a085bd202e266189efba92a1832fa8f90c0931e6)), closes [#3](https://github.com/rshade/finfocus-spec/issues/3)
 
 ### Documentation
 
-- add comprehensive plugin developer guide ([#16](https://github.com/rshade/pulumicost-spec/issues/16)) ([b0a5eb3](https://github.com/rshade/pulumicost-spec/commit/b0a5eb3396b5c49839d742234666667e5e7b1ee7)), closes [#2](https://github.com/rshade/pulumicost-spec/issues/2)
-- establish constitution v1.0.0 for gRPC proto specification governance ([#57](https://github.com/rshade/pulumicost-spec/issues/57)) ([54578aa](https://github.com/rshade/pulumicost-spec/commit/54578aa259cb8907f989196ce2b73e37e57f906f))
+- add comprehensive plugin developer guide ([#16](https://github.com/rshade/finfocus-spec/issues/16)) ([b0a5eb3](https://github.com/rshade/finfocus-spec/commit/b0a5eb3396b5c49839d742234666667e5e7b1ee7)), closes [#2](https://github.com/rshade/finfocus-spec/issues/2)
+- establish constitution v1.0.0 for gRPC proto specification governance ([#57](https://github.com/rshade/finfocus-spec/issues/57)) ([54578aa](https://github.com/rshade/finfocus-spec/commit/54578aa259cb8907f989196ce2b73e37e57f906f))
 
 ## [Unreleased]
 
@@ -326,33 +326,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add comprehensive Plugin Registry Specification
-  ([#29](https://github.com/rshade/pulumicost-spec/issues/29))
-  ([5825eaa](https://github.com/rshade/pulumicost-spec/commit/5825eaab1f343b1f9fcb966c38effb6a743d3494)),
-  closes [#8](https://github.com/rshade/pulumicost-spec/issues/8)
+  ([#29](https://github.com/rshade/finfocus-spec/issues/29))
+  ([5825eaa](https://github.com/rshade/finfocus-spec/commit/5825eaab1f343b1f9fcb966c38effb6a743d3494)),
+  closes [#8](https://github.com/rshade/finfocus-spec/issues/8)
 - Comprehensive testing framework and enterprise CI/CD pipeline
-  ([#19](https://github.com/rshade/pulumicost-spec/issues/19))
-  ([3a235ef](https://github.com/rshade/pulumicost-spec/commit/3a235eff0ce4a172a7b920326066227540c6c8b8))
+  ([#19](https://github.com/rshade/finfocus-spec/issues/19))
+  ([3a235ef](https://github.com/rshade/finfocus-spec/commit/3a235eff0ce4a172a7b920326066227540c6c8b8))
 - Enhance Provider enum with String() method and improved error handling
-  ([#39](https://github.com/rshade/pulumicost-spec/issues/39))
-  ([acbaf0c](https://github.com/rshade/pulumicost-spec/commit/acbaf0c6db29d986211d3ca8ef19a66e3162e2c2)),
-  closes [#4](https://github.com/rshade/pulumicost-spec/issues/4)
+  ([#39](https://github.com/rshade/finfocus-spec/issues/39))
+  ([acbaf0c](https://github.com/rshade/finfocus-spec/commit/acbaf0c6db29d986211d3ca8ef19a66e3162e2c2)),
+  closes [#4](https://github.com/rshade/finfocus-spec/issues/4)
 - Freeze costsource.proto v0.1.0 specification
-  ([#17](https://github.com/rshade/pulumicost-spec/issues/17))
-  ([3b485b9](https://github.com/rshade/pulumicost-spec/commit/3b485b96fef7dc2992c166980f324907e4ff06bd)),
-  closes [#3](https://github.com/rshade/pulumicost-spec/issues/3)
+  ([#17](https://github.com/rshade/finfocus-spec/issues/17))
+  ([3b485b9](https://github.com/rshade/finfocus-spec/commit/3b485b96fef7dc2992c166980f324907e4ff06bd)),
+  closes [#3](https://github.com/rshade/finfocus-spec/issues/3)
 - Freeze costsource.proto v0.1.0 specification
-  ([#18](https://github.com/rshade/pulumicost-spec/issues/18))
-  ([a085bd2](https://github.com/rshade/pulumicost-spec/commit/a085bd202e266189efba92a1832fa8f90c0931e6)),
-  closes [#3](https://github.com/rshade/pulumicost-spec/issues/3)
+  ([#18](https://github.com/rshade/finfocus-spec/issues/18))
+  ([a085bd2](https://github.com/rshade/finfocus-spec/commit/a085bd202e266189efba92a1832fa8f90c0931e6)),
+  closes [#3](https://github.com/rshade/finfocus-spec/issues/3)
 
 ### Documentation
 
 - Add comprehensive plugin developer guide
-  ([#16](https://github.com/rshade/pulumicost-spec/issues/16))
-  ([b0a5eb3](https://github.com/rshade/pulumicost-spec/commit/b0a5eb3396b5c49839d742234666667e5e7b1ee7)),
-  closes [#2](https://github.com/rshade/pulumicost-spec/issues/2)
+  ([#16](https://github.com/rshade/finfocus-spec/issues/16))
+  ([b0a5eb3](https://github.com/rshade/finfocus-spec/commit/b0a5eb3396b5c49839d742234666667e5e7b1ee7)),
+  closes [#2](https://github.com/rshade/finfocus-spec/issues/2)
 - Establish constitution v1.0.0 for gRPC proto specification governance
-  ([#57](https://github.com/rshade/pulumicost-spec/issues/57))
-  ([54578aa](https://github.com/rshade/pulumicost-spec/commit/54578aa259cb8907f989196ce2b73e37e57f906f))
+  ([#57](https://github.com/rshade/finfocus-spec/issues/57))
+  ([54578aa](https://github.com/rshade/finfocus-spec/commit/54578aa259cb8907f989196ce2b73e37e57f906f))
 
-[0.1.0]: https://github.com/rshade/pulumicost-spec/releases/tag/v0.1.0
+[0.1.0]: https://github.com/rshade/finfocus-spec/releases/tag/v0.1.0

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -1,7 +1,7 @@
 # Advanced Implementation Examples
 
 This directory contains runnable Go examples demonstrating advanced plugin
-implementation patterns for the PulumiCost ecosystem.
+implementation patterns for the FinFocus ecosystem.
 
 ## Examples
 

--- a/examples/observability/dashboards/cloudwatch-dashboard.yaml
+++ b/examples/observability/dashboards/cloudwatch-dashboard.yaml
@@ -1,18 +1,18 @@
-# CloudWatch Dashboard Template for PulumiCost Plugin Observability
+# CloudWatch Dashboard Template for FinFocus Plugin Observability
 # Deploy using AWS CloudFormation or CDK
 
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CloudWatch Dashboard for PulumiCost Plugin Observability'
+Description: 'CloudWatch Dashboard for FinFocus Plugin Observability'
 
 Parameters:
   PluginName:
     Type: String
-    Default: pulumicost-plugin
-    Description: Name of the PulumiCost plugin
+    Default: finfocus-plugin
+    Description: Name of the FinFocus plugin
   
   LogGroupName:
     Type: String
-    Default: /aws/lambda/pulumicost-plugin
+    Default: /aws/lambda/finfocus-plugin
     Description: CloudWatch Log Group for the plugin
   
   Environment:
@@ -22,7 +22,7 @@ Parameters:
     Description: Deployment environment
 
 Resources:
-  PulumiCostObservabilityDashboard:
+  FinFocusObservabilityDashboard:
     Type: AWS::CloudWatch::Dashboard
     Properties:
       DashboardName: !Sub '${PluginName}-observability-${Environment}'
@@ -191,7 +191,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub '${PluginName}-high-error-rate-${Environment}'
-      AlarmDescription: 'High error rate detected in PulumiCost plugin'
+      AlarmDescription: 'High error rate detected in FinFocus plugin'
       MetricName: Errors
       Namespace: AWS/Lambda
       Statistic: Sum
@@ -209,7 +209,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub '${PluginName}-high-latency-${Environment}'
-      AlarmDescription: 'High latency detected in PulumiCost plugin'
+      AlarmDescription: 'High latency detected in FinFocus plugin'
       MetricName: Duration
       Namespace: AWS/Lambda
       Statistic: Average
@@ -229,7 +229,7 @@ Resources:
       AlarmName: !Sub '${PluginName}-low-cache-hit-rate-${Environment}'
       AlarmDescription: 'Low cache hit rate detected'
       MetricName: CacheHitRate
-      Namespace: PulumiCost/Plugin
+      Namespace: FinFocus/Plugin
       Statistic: Average
       Period: 600
       EvaluationPeriods: 2
@@ -243,7 +243,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: !Sub '${PluginName}-alerts-${Environment}'
-      DisplayName: PulumiCost Plugin Alerts
+      DisplayName: FinFocus Plugin Alerts
 
   # Custom metrics filter for structured logs
   ErrorCountMetricFilter:
@@ -252,7 +252,7 @@ Resources:
       LogGroupName: !Ref LogGroupName
       FilterPattern: '{ $.level = "ERROR" }'
       MetricTransformations:
-        - MetricNamespace: PulumiCost/Plugin
+        - MetricNamespace: FinFocus/Plugin
           MetricName: ErrorCount
           MetricValue: '1'
           DefaultValue: 0
@@ -263,7 +263,7 @@ Resources:
       LogGroupName: !Ref LogGroupName
       FilterPattern: '{ $.fields.cache_hit = "true" }'
       MetricTransformations:
-        - MetricNamespace: PulumiCost/Plugin
+        - MetricNamespace: FinFocus/Plugin
           MetricName: CacheHits
           MetricValue: '1'
           DefaultValue: 0
@@ -274,7 +274,7 @@ Resources:
       LogGroupName: !Ref LogGroupName
       FilterPattern: '{ $.message = "Processing cost query request" }'
       MetricTransformations:
-        - MetricNamespace: PulumiCost/Plugin
+        - MetricNamespace: FinFocus/Plugin
           MetricName: RequestProcessingTime
           MetricValue: $.fields.processing_time_ms
           DefaultValue: 0

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,6 +1,6 @@
 # Plugin Manifest Examples
 
-This directory contains comprehensive examples of plugin manifests for the PulumiCost Plugin Registry system.
+This directory contains comprehensive examples of plugin manifests for the FinFocus Plugin Registry system.
 
 ## Overview
 
@@ -91,7 +91,7 @@ done
 
 ### Security Levels
 
-- **Official**: Not demonstrated (reserved for PulumiCost team)
+- **Official**: Not demonstrated (reserved for FinFocus team)
 - **Verified**: `aws-cost-plugin.json`, `kubecost-plugin.json`
   - Digital signatures required
   - Comprehensive security review

--- a/examples/plugins/web-client/index.html
+++ b/examples/plugins/web-client/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PulumiCost Connect Client Demo</title>
+    <title>FinFocus Connect Client Demo</title>
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -62,9 +62,9 @@
     </style>
 </head>
 <body>
-    <h1>PulumiCost Connect Client Demo</h1>
+    <h1>FinFocus Connect Client Demo</h1>
     <p class="info">
-        This demo shows how to call PulumiCost plugins using the Connect protocol with simple fetch() requests.
+        This demo shows how to call FinFocus plugins using the Connect protocol with simple fetch() requests.
         No special client libraries required - just JSON over HTTP.
     </p>
 

--- a/examples/specs/CLAUDE.md
+++ b/examples/specs/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is the **specs directory** containing the core PricingSpec JSON examples for the PulumiCost specification. These 10
+This is the **specs directory** containing the core PricingSpec JSON examples for the FinFocus specification. These 10
 production-quality examples serve as the canonical reference implementations demonstrating all major cloud provider billing
 models, advanced pricing features, and comprehensive metadata patterns.
 
@@ -200,5 +200,5 @@ cd sdk/go && go test -v -run TestValidatePricingSpec_ComplexValidExamples
 - Time aggregation: window/method/alignment combinations validated
 - Metric hints: metric/unit/aggregation_method triples complete
 
-This specs directory provides the foundational validation reference for the entire PulumiCost ecosystem, ensuring consistent
+This specs directory provides the foundational validation reference for the entire FinFocus ecosystem, ensuring consistent
 pricing specification interpretation across all cloud providers and resource types.

--- a/sdk/go/internal/semver/semver.go
+++ b/sdk/go/internal/semver/semver.go
@@ -1,4 +1,4 @@
-// Package semver provides shared semantic versioning validation for the PulumiCost SDK.
+// Package semver provides shared semantic versioning validation for the FinFocus SDK.
 //
 // This package exists to break circular dependencies between sdk/go/pluginsdk and
 // sdk/go/testing. Both packages need semantic version validation but importing

--- a/sdk/go/internal/utilization/utilization.go
+++ b/sdk/go/internal/utilization/utilization.go
@@ -1,4 +1,4 @@
-// Package utilization provides shared utilization extraction logic for the PulumiCost SDK.
+// Package utilization provides shared utilization extraction logic for the FinFocus SDK.
 //
 // This package exists to break circular dependencies between sdk/go/pluginsdk and
 // sdk/go/testing. Both packages need utilization extraction logic, but pluginsdk

--- a/sdk/go/pluginsdk/client.go
+++ b/sdk/go/pluginsdk/client.go
@@ -1,4 +1,4 @@
-// Package pluginsdk provides a development SDK for PulumiCost plugins.
+// Package pluginsdk provides a development SDK for FinFocus plugins.
 package pluginsdk
 
 import (
@@ -78,7 +78,7 @@ const (
 	DefaultIdleConnTimeout = 90 * time.Second
 )
 
-// ClientConfig configures a PulumiCost client.
+// ClientConfig configures a FinFocus client.
 type ClientConfig struct {
 	// BaseURL is the server's base URL (e.g., "http://localhost:8080").
 	BaseURL string
@@ -149,7 +149,7 @@ func HighThroughputClientConfig(baseURL string) ClientConfig {
 	}
 }
 
-// Client provides a simplified interface for communicating with PulumiCost plugins.
+// Client provides a simplified interface for communicating with FinFocus plugins.
 // It wraps the generated connect client with cleaner method signatures.
 //
 // Clients should be reused for multiple calls rather than creating a new client
@@ -175,7 +175,7 @@ func wrapRPCError(ctx context.Context, operation string, err error) error {
 	return fmt.Errorf("%s RPC failed: %w", operation, err)
 }
 
-// NewClient creates a new PulumiCost client with the given configuration.
+// NewClient creates a new FinFocus client with the given configuration.
 // If an invalid protocol is specified, it defaults to ProtocolConnect for backward compatibility.
 //
 // HTTP Client Ownership:

--- a/sdk/go/pluginsdk/conformance.go
+++ b/sdk/go/pluginsdk/conformance.go
@@ -1,4 +1,4 @@
-// Package pluginsdk provides a development SDK for PulumiCost plugins.
+// Package pluginsdk provides a development SDK for FinFocus plugins.
 // This file provides adapter functions for running conformance tests directly
 // on Plugin implementations without manual conversion to CostSourceServiceServer.
 package pluginsdk

--- a/sdk/go/pluginsdk/connect.go
+++ b/sdk/go/pluginsdk/connect.go
@@ -1,4 +1,4 @@
-// Package pluginsdk provides a development SDK for PulumiCost plugins.
+// Package pluginsdk provides a development SDK for FinFocus plugins.
 package pluginsdk
 
 import (

--- a/sdk/go/pluginsdk/env.go
+++ b/sdk/go/pluginsdk/env.go
@@ -1,4 +1,4 @@
-// Package pluginsdk provides environment variable handling for PulumiCost plugins.
+// Package pluginsdk provides environment variable handling for FinFocus plugins.
 package pluginsdk
 
 import (
@@ -8,39 +8,39 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Environment variable constants for PulumiCost plugins.
+// Environment variable constants for FinFocus plugins.
 // These constants define the canonical names for all supported environment variables.
 const (
 	// EnvPort is the canonical environment variable for plugin gRPC port.
-	// Plugins MUST use PULUMICOST_PLUGIN_PORT (no fallback to PORT).
-	EnvPort = "PULUMICOST_PLUGIN_PORT"
+	// Plugins MUST use FINFOCUS_PLUGIN_PORT (no fallback to PORT).
+	EnvPort = "FINFOCUS_PLUGIN_PORT"
 
 	// EnvLogLevel is the canonical environment variable for log verbosity.
 	// Supported values: debug, info, warn, error (plugin-specific validation).
-	EnvLogLevel = "PULUMICOST_LOG_LEVEL"
+	EnvLogLevel = "FINFOCUS_LOG_LEVEL"
 
 	// EnvLogLevelFallback is the legacy environment variable for log verbosity.
-	// GetLogLevel() checks PULUMICOST_LOG_LEVEL first, then falls back to LOG_LEVEL.
+	// GetLogLevel() checks FINFOCUS_LOG_LEVEL first, then falls back to LOG_LEVEL.
 	EnvLogLevelFallback = "LOG_LEVEL"
 
 	// EnvLogFormat is the environment variable for log output format.
 	// Supported values: json, text (plugin-specific validation).
-	EnvLogFormat = "PULUMICOST_LOG_FORMAT"
+	EnvLogFormat = "FINFOCUS_LOG_FORMAT"
 
 	// EnvLogFile is the environment variable for log file path.
-	// Empty string means log to stderr.
-	EnvLogFile = "PULUMICOST_LOG_FILE"
+	// Empty string means log to stderr (not stdout).
+	EnvLogFile = "FINFOCUS_LOG_FILE"
 
 	// EnvTraceID is the environment variable for distributed tracing.
 	// When set, this ID should be included in all related logs and responses.
-	EnvTraceID = "PULUMICOST_TRACE_ID"
+	EnvTraceID = "FINFOCUS_TRACE_ID"
 
 	// EnvTestMode is the environment variable for enabling test mode.
 	// Only "true" enables test mode; all other values disable it.
-	EnvTestMode = "PULUMICOST_TEST_MODE"
+	EnvTestMode = "FINFOCUS_TEST_MODE"
 )
 
-// GetPort returns the plugin port from PULUMICOST_PLUGIN_PORT environment variable.
+// GetPort returns the plugin port from FINFOCUS_PLUGIN_PORT environment variable.
 // Returns 0 if not set or invalid. There is no fallback to PORT.
 // Callers should treat 0 as "port not configured" and handle accordingly.
 func GetPort() int {
@@ -56,7 +56,7 @@ func GetPort() int {
 }
 
 // GetLogLevel returns the log level from environment variables.
-// Checks PULUMICOST_LOG_LEVEL first, then falls back to LOG_LEVEL.
+// Checks FINFOCUS_LOG_LEVEL first, then falls back to LOG_LEVEL.
 // Returns empty string if neither is set.
 func GetLogLevel() string {
 	if v := os.Getenv(EnvLogLevel); v != "" {
@@ -65,25 +65,26 @@ func GetLogLevel() string {
 	return os.Getenv(EnvLogLevelFallback)
 }
 
-// GetLogFormat returns the log format from PULUMICOST_LOG_FORMAT.
+// GetLogFormat returns the log format from FINFOCUS_LOG_FORMAT.
 // Returns empty string if not set.
 func GetLogFormat() string {
 	return os.Getenv(EnvLogFormat)
 }
 
-// GetLogFile returns the log file path from PULUMICOST_LOG_FILE.
-// Returns empty string if not set (meaning stdout).
+// GetLogFile returns the log file path from the EnvLogFile environment variable.
+// Returns an empty string if EnvLogFile is unset or empty, indicating that
+// NewLogWriter() will use os.Stderr (not stdout) for logging.
 func GetLogFile() string {
 	return os.Getenv(EnvLogFile)
 }
 
-// GetTraceID returns the trace ID from PULUMICOST_TRACE_ID.
+// GetTraceID returns the trace ID from FINFOCUS_TRACE_ID.
 // Returns empty string if not set.
 func GetTraceID() string {
 	return os.Getenv(EnvTraceID)
 }
 
-// GetTestMode returns true if PULUMICOST_TEST_MODE is set to "true".
+// GetTestMode returns true if FINFOCUS_TEST_MODE is set to "true".
 // Logs a warning if the value is set but not "true" or "false".
 // Returns false for any value other than "true".
 func GetTestMode() bool {
@@ -103,7 +104,7 @@ func GetTestMode() bool {
 	return false
 }
 
-// IsTestMode returns true if PULUMICOST_TEST_MODE is set to "true".
+// IsTestMode returns true if FINFOCUS_TEST_MODE is set to "true".
 // Unlike GetTestMode, this function does not log warnings for invalid values.
 // Use this for repeated checks to avoid log spam.
 func IsTestMode() bool {

--- a/sdk/go/pluginsdk/logging.go
+++ b/sdk/go/pluginsdk/logging.go
@@ -74,7 +74,7 @@ var (
 	logWriter     io.Writer
 )
 
-// NewLogWriter returns an io.Writer configured based on the PULUMICOST_LOG_FILE
+// NewLogWriter returns an io.Writer configured based on the FINFOCUS_LOG_FILE
 // environment variable. The file is opened once on first call and reused for
 // subsequent calls (singleton pattern). The file remains open for the lifetime
 // of the process, which is intentional as plugins log continuously during their
@@ -94,7 +94,7 @@ var (
 //	logger := pluginsdk.NewPluginLogger("my-plugin", "v1.0.0", zerolog.InfoLevel, writer)
 //
 //	// Note: The SDK's internal default logger (used when no custom logger is
-//	// provided to ServeConfig) respects PULUMICOST_LOG_FILE automatically.
+//	// provided to ServeConfig) respects FINFOCUS_LOG_FILE automatically.
 func NewLogWriter() io.Writer {
 	logWriterOnce.Do(func() {
 		logFile := GetLogFile()
@@ -110,7 +110,7 @@ func NewLogWriter() io.Writer {
 		// Check for absolute path
 		if !filepath.IsAbs(logFile) {
 			warnLogger.Warn().Str("path", logFile).
-				Msg("PULUMICOST_LOG_FILE should be absolute path, falling back to stderr")
+				Msg("FINFOCUS_LOG_FILE should be absolute path, falling back to stderr")
 			logWriter = os.Stderr
 			return
 		}
@@ -122,7 +122,7 @@ func NewLogWriter() io.Writer {
 			if info, statErr := os.Stat(logFile); statErr == nil && info.IsDir() {
 				warnLogger.Warn().
 					Str("path", logFile).
-					Msg("PULUMICOST_LOG_FILE points to a directory, falling back to stderr")
+					Msg("FINFOCUS_LOG_FILE points to a directory, falling back to stderr")
 				logWriter = os.Stderr
 				return
 			}
@@ -151,7 +151,7 @@ func ResetLogWriter() {
 
 // newDefaultLogger creates a basic zerolog logger for internal SDK use.
 // This is used when no custom logger is provided.
-// It respects the PULUMICOST_LOG_FILE environment variable via NewLogWriter().
+// It respects the FINFOCUS_LOG_FILE environment variable via NewLogWriter().
 func newDefaultLogger() zerolog.Logger {
 	return zerolog.New(NewLogWriter()).
 		Level(zerolog.InfoLevel).

--- a/sdk/go/pluginsdk/logging_test.go
+++ b/sdk/go/pluginsdk/logging_test.go
@@ -662,7 +662,7 @@ func TestNewLogWriter_ValidPath(t *testing.T) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
 	tmpFile := filepath.Join(t.TempDir(), "test.log")
-	t.Setenv("PULUMICOST_LOG_FILE", tmpFile)
+	t.Setenv("FINFOCUS_LOG_FILE", tmpFile)
 
 	writer := pluginsdk.NewLogWriter()
 
@@ -691,7 +691,7 @@ func TestNewLogWriter_FileCreated(t *testing.T) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
 	tmpFile := filepath.Join(t.TempDir(), "new.log")
-	t.Setenv("PULUMICOST_LOG_FILE", tmpFile)
+	t.Setenv("FINFOCUS_LOG_FILE", tmpFile)
 
 	// Verify file doesn't exist yet
 	if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
@@ -730,7 +730,7 @@ func TestNewLogWriter_FileAppended(t *testing.T) {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 
-	t.Setenv("PULUMICOST_LOG_FILE", tmpFile)
+	t.Setenv("FINFOCUS_LOG_FILE", tmpFile)
 
 	writer := pluginsdk.NewLogWriter()
 	logger := zerolog.New(writer).With().Timestamp().Logger()
@@ -755,7 +755,7 @@ func TestNewLogWriter_AllLogLevels(t *testing.T) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
 	tmpFile := filepath.Join(t.TempDir(), "levels.log")
-	t.Setenv("PULUMICOST_LOG_FILE", tmpFile)
+	t.Setenv("FINFOCUS_LOG_FILE", tmpFile)
 
 	writer := pluginsdk.NewLogWriter()
 	logger := zerolog.New(writer).Level(zerolog.DebugLevel).With().Timestamp().Logger()
@@ -783,12 +783,12 @@ func TestNewLogWriter_EnvNotSet(t *testing.T) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
 	// Ensure env var is not set (empty string is treated as unset)
-	t.Setenv("PULUMICOST_LOG_FILE", "")
+	t.Setenv("FINFOCUS_LOG_FILE", "")
 
 	writer := pluginsdk.NewLogWriter()
 
 	if writer != os.Stderr {
-		t.Error("Expected os.Stderr when PULUMICOST_LOG_FILE is not set")
+		t.Error("Expected os.Stderr when FINFOCUS_LOG_FILE is not set")
 	}
 }
 
@@ -796,12 +796,12 @@ func TestNewLogWriter_EnvNotSet(t *testing.T) {
 func TestNewLogWriter_EmptyString(t *testing.T) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
-	t.Setenv("PULUMICOST_LOG_FILE", "")
+	t.Setenv("FINFOCUS_LOG_FILE", "")
 
 	writer := pluginsdk.NewLogWriter()
 
 	if writer != os.Stderr {
-		t.Error("Expected os.Stderr when PULUMICOST_LOG_FILE is empty string")
+		t.Error("Expected os.Stderr when FINFOCUS_LOG_FILE is empty string")
 	}
 }
 
@@ -810,12 +810,12 @@ func TestNewLogWriter_DirectoryPath(t *testing.T) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
 	tmpDir := t.TempDir()
-	t.Setenv("PULUMICOST_LOG_FILE", tmpDir)
+	t.Setenv("FINFOCUS_LOG_FILE", tmpDir)
 
 	writer := pluginsdk.NewLogWriter()
 
 	if writer != os.Stderr {
-		t.Error("Expected os.Stderr when PULUMICOST_LOG_FILE points to a directory")
+		t.Error("Expected os.Stderr when FINFOCUS_LOG_FILE points to a directory")
 	}
 }
 
@@ -824,7 +824,7 @@ func TestNewLogWriter_NonexistentParent(t *testing.T) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
 	nonexistentPath := filepath.Join(t.TempDir(), "nonexistent", "subdir", "test.log")
-	t.Setenv("PULUMICOST_LOG_FILE", nonexistentPath)
+	t.Setenv("FINFOCUS_LOG_FILE", nonexistentPath)
 
 	writer := pluginsdk.NewLogWriter()
 
@@ -836,7 +836,7 @@ func TestNewLogWriter_NonexistentParent(t *testing.T) {
 // TestNewLogWriter_BackwardCompatibility verifies existing plugins work without modification.
 func TestNewLogWriter_BackwardCompatibility(t *testing.T) {
 	// Clear the env var to simulate existing plugin behavior
-	t.Setenv("PULUMICOST_LOG_FILE", "")
+	t.Setenv("FINFOCUS_LOG_FILE", "")
 
 	// Create a plugin logger the "old way" - should still work
 	var buf bytes.Buffer
@@ -869,7 +869,7 @@ func BenchmarkNewLogWriter_File(b *testing.B) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
 	tmpFile := filepath.Join(b.TempDir(), "bench.log")
-	b.Setenv("PULUMICOST_LOG_FILE", tmpFile)
+	b.Setenv("FINFOCUS_LOG_FILE", tmpFile)
 	b.ResetTimer()
 	b.ReportAllocs()
 
@@ -882,7 +882,7 @@ func BenchmarkNewLogWriter_File(b *testing.B) {
 func BenchmarkNewLogWriter_Stderr(b *testing.B) {
 	pluginsdk.ResetLogWriter()
 	defer pluginsdk.ResetLogWriter()
-	b.Setenv("PULUMICOST_LOG_FILE", "")
+	b.Setenv("FINFOCUS_LOG_FILE", "")
 	b.ResetTimer()
 	b.ReportAllocs()
 

--- a/sdk/go/pluginsdk/manifest_test.go
+++ b/sdk/go/pluginsdk/manifest_test.go
@@ -22,7 +22,7 @@ func TestManifestSaveLoad(t *testing.T) {
 		Metadata: &pbc.PluginMetadata{
 			Name:        "test-plugin",
 			Version:     "1.0.0",
-			Description: "A test plugin for PulumiCost",
+			Description: "A test plugin for FinFocus",
 			Author:      "Test Author",
 			Homepage:    "https://example.com",
 			Repository:  "https://github.com/example/test-plugin",

--- a/sdk/go/pluginsdk/metrics.go
+++ b/sdk/go/pluginsdk/metrics.go
@@ -1,4 +1,4 @@
-// Package pluginsdk provides Prometheus metrics instrumentation for PulumiCost plugins.
+// Package pluginsdk provides Prometheus metrics instrumentation for FinFocus plugins.
 package pluginsdk
 
 import (

--- a/sdk/go/pluginsdk/metrics_test.go
+++ b/sdk/go/pluginsdk/metrics_test.go
@@ -501,7 +501,7 @@ func TestMetrics_AllGRPCMethods(t *testing.T) {
 		return "response", nil
 	}
 
-	// All 6 PulumiCost gRPC methods
+	// All 6 FinFocus gRPC methods
 	methods := []string{
 		"/finfocus.v1.CostSource/Name",
 		"/finfocus.v1.CostSource/Supports",

--- a/sdk/go/pluginsdk/options.go
+++ b/sdk/go/pluginsdk/options.go
@@ -1,4 +1,4 @@
-// Package pluginsdk provides a development SDK for PulumiCost plugins.
+// Package pluginsdk provides a development SDK for FinFocus plugins.
 package pluginsdk
 
 // DefaultAllowedHeaders contains the CORS allowed headers for Connect/gRPC-Web.

--- a/sdk/go/pluginsdk/sdk_test.go
+++ b/sdk/go/pluginsdk/sdk_test.go
@@ -920,7 +920,7 @@ func TestInterceptorChainBuilding(t *testing.T) {
 }
 
 // =============================================================================
-// Port Resolution Tests (--port flag, PULUMICOST_PLUGIN_PORT env var)
+// Port Resolution Tests (--port flag, FINFOCUS_PLUGIN_PORT env var)
 // =============================================================================
 
 // TestResolvePort_RequestedTakesPrecedence tests that config.Port takes precedence over env var.
@@ -933,13 +933,13 @@ func TestResolvePort_RequestedTakesPrecedence(t *testing.T) {
 	assert.Equal(t, 8080, got, "requested port should take precedence over env var")
 }
 
-// TestResolvePort_FallsBackToEnvVar tests that PULUMICOST_PLUGIN_PORT is used when no port requested.
+// TestResolvePort_FallsBackToEnvVar tests that FINFOCUS_PLUGIN_PORT is used when no port requested.
 func TestResolvePort_FallsBackToEnvVar(t *testing.T) {
 	t.Setenv(EnvPort, "7777")
 
 	got := resolvePort(0)
 
-	assert.Equal(t, 7777, got, "should fall back to PULUMICOST_PLUGIN_PORT when requested is 0")
+	assert.Equal(t, 7777, got, "should fall back to FINFOCUS_PLUGIN_PORT when requested is 0")
 }
 
 // TestResolvePort_ReturnsZeroWhenNeitherSet tests ephemeral port behavior.
@@ -967,7 +967,7 @@ func TestResolvePort_IgnoresGenericPORT(t *testing.T) {
 	got := resolvePort(0)
 
 	// PORT should be IGNORED - we should get 0 (ephemeral), not 5000
-	assert.Equal(t, 0, got, "PORT env var should be ignored; only PULUMICOST_PLUGIN_PORT is read")
+	assert.Equal(t, 0, got, "PORT env var should be ignored; only FINFOCUS_PLUGIN_PORT is read")
 }
 
 // TestServe_InvalidPluginInfoReturnsError tests T020: Serve returns error for invalid PluginInfo.

--- a/sdk/go/pluginsdk/testing.go
+++ b/sdk/go/pluginsdk/testing.go
@@ -1,6 +1,6 @@
 package pluginsdk
 
-// Testing Utilities for PulumiCost Plugins
+// Testing Utilities for FinFocus Plugins
 //
 // This file provides simple testing utilities for plugins using the pluginsdk.Plugin interface.
 // For more comprehensive testing including conformance tests, mock plugins with error injection,

--- a/sdk/go/pluginsdk/validation.go
+++ b/sdk/go/pluginsdk/validation.go
@@ -1,4 +1,4 @@
-// Package pluginsdk provides a development SDK for PulumiCost plugins.
+// Package pluginsdk provides a development SDK for FinFocus plugins.
 //
 // # Request Validation
 //

--- a/sdk/go/pricing/domain.go
+++ b/sdk/go/pricing/domain.go
@@ -1,6 +1,6 @@
-// Package pricing provides domain types and validation for PulumiCost pricing specifications.
+// Package pricing provides domain types and validation for FinFocus pricing specifications.
 // It includes billing mode constants, unit types, and validation helpers for ensuring
-// pricing data conforms to the PulumiCost schema.
+// pricing data conforms to the FinFocus schema.
 package pricing
 
 // BillingMode represents the billing model for a cloud resource.

--- a/sdk/go/pricing/growth.go
+++ b/sdk/go/pricing/growth.go
@@ -1,4 +1,4 @@
-// Package pricing provides domain types and validation for PulumiCost pricing specifications.
+// Package pricing provides domain types and validation for FinFocus pricing specifications.
 package pricing
 
 import (

--- a/sdk/go/registry/domain.go
+++ b/sdk/go/registry/domain.go
@@ -1,4 +1,4 @@
-// Package registry provides domain types and validation for PulumiCost plugin registry management.
+// Package registry provides domain types and validation for FinFocus plugin registry management.
 // It defines enums for discovery sources, plugin statuses, security levels, installation methods,
 // capabilities, system permissions, authentication methods, and validation functions for plugin
 // manifests and names.
@@ -173,7 +173,7 @@ const (
 	SecurityLevelCommunity SecurityLevel = "community"
 	// SecurityLevelVerified indicates officially verified plugin.
 	SecurityLevelVerified SecurityLevel = "verified"
-	// SecurityLevelOfficial indicates official PulumiCost plugin.
+	// SecurityLevelOfficial indicates official FinFocus plugin.
 	SecurityLevelOfficial SecurityLevel = "official"
 )
 

--- a/sdk/go/testing/concurrency.go
+++ b/sdk/go/testing/concurrency.go
@@ -1,4 +1,4 @@
-// Package testing provides a comprehensive testing framework for PulumiCost plugins.
+// Package testing provides a comprehensive testing framework for FinFocus plugins.
 // This file implements concurrency testing for the Plugin Conformance Test Suite.
 package testing
 

--- a/sdk/go/testing/conformance.go
+++ b/sdk/go/testing/conformance.go
@@ -1,4 +1,4 @@
-// Package testing provides a comprehensive testing framework for PulumiCost plugins.
+// Package testing provides a comprehensive testing framework for FinFocus plugins.
 // This file implements the Plugin Conformance Test Suite for validating plugin implementations.
 package testing
 

--- a/sdk/go/testing/mock_plugin.go
+++ b/sdk/go/testing/mock_plugin.go
@@ -1,4 +1,4 @@
-// Package testing provides test utilities for PulumiCost plugin development.
+// Package testing provides test utilities for FinFocus plugin development.
 // It includes mock plugin implementations, test harnesses, and conformance testing
 // utilities for validating plugin behavior against the CostSource gRPC service spec.
 package testing

--- a/sdk/go/testing/performance.go
+++ b/sdk/go/testing/performance.go
@@ -1,4 +1,4 @@
-// Package testing provides a comprehensive testing framework for PulumiCost plugins.
+// Package testing provides a comprehensive testing framework for FinFocus plugins.
 // This file implements performance testing and benchmarking for plugin conformance.
 package testing
 

--- a/sdk/go/testing/report.go
+++ b/sdk/go/testing/report.go
@@ -1,4 +1,4 @@
-// Package testing provides a comprehensive testing framework for PulumiCost plugins.
+// Package testing provides a comprehensive testing framework for FinFocus plugins.
 // This file implements reporting functionality for conformance test results.
 package testing
 

--- a/sdk/go/testing/rpc_correctness.go
+++ b/sdk/go/testing/rpc_correctness.go
@@ -1,4 +1,4 @@
-// Package testing provides a comprehensive testing framework for PulumiCost plugins.
+// Package testing provides a comprehensive testing framework for FinFocus plugins.
 // This file implements RPC correctness validation for the Plugin Conformance Test Suite.
 package testing
 

--- a/sdk/go/testing/spec_validation.go
+++ b/sdk/go/testing/spec_validation.go
@@ -1,4 +1,4 @@
-// Package testing provides a comprehensive testing framework for PulumiCost plugins.
+// Package testing provides a comprehensive testing framework for FinFocus plugins.
 // This file implements spec validation for the Plugin Conformance Test Suite.
 package testing
 

--- a/specs/001-domain-enum-optimization/contracts/validation-api.md
+++ b/specs/001-domain-enum-optimization/contracts/validation-api.md
@@ -1,7 +1,7 @@
 # Validation API Contract
 
 **Feature**: Domain Enum Validation Performance Optimization
-**Package**: `github.com/rshade/pulumicost-spec/sdk/go/registry`
+**Package**: `github.com/rshade/finfocus-spec/sdk/go/registry`
 **Date**: 2025-11-17
 
 ## API Contract

--- a/specs/001-domain-enum-optimization/data-model.md
+++ b/specs/001-domain-enum-optimization/data-model.md
@@ -14,7 +14,7 @@ surfaces and behavior.
 
 ### Provider Enum
 
-**Purpose**: Represents supported cloud providers in the PulumiCost ecosystem
+**Purpose**: Represents supported cloud providers in the FinFocus ecosystem
 
 **Values**:
 
@@ -69,7 +69,7 @@ surfaces and behavior.
 - `untrusted` - Unverified plugin requiring explicit approval
 - `community` - Community-verified plugin
 - `verified` - Officially verified plugin
-- `official` - Official PulumiCost plugin
+- `official` - Official FinFocus plugin
 
 **Validation**: Case-sensitive exact match against valid values
 

--- a/specs/001-domain-enum-optimization/performance-results.md
+++ b/specs/001-domain-enum-optimization/performance-results.md
@@ -242,7 +242,7 @@ Enum size < 20 values?
 ```text
 goos: linux
 goarch: amd64
-pkg: github.com/rshade/pulumicost-spec/sdk/go/registry
+pkg: github.com/rshade/finfocus-spec/sdk/go/registry
 cpu: Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
 
 Optimized Slice-Based Validation:
@@ -267,7 +267,7 @@ BenchmarkValidation_9Values-4                  248740696          5.908 ns/op   
 BenchmarkValidation_14Values-4                 100000000         12.60 ns/op        0 B/op        0 allocs/op
 
 PASS
-ok   github.com/rshade/pulumicost-spec/sdk/go/registry 27.424s
+ok   github.com/rshade/finfocus-spec/sdk/go/registry 27.424s
 ```
 
 ## Conclusion
@@ -281,4 +281,4 @@ The optimized slice-based validation approach successfully achieves:
 - ✅ **100% backward compatibility** (all existing tests pass)
 
 The implementation exceeds all performance requirements and establishes a solid pattern for future enum validation
-in the PulumiCost ecosystem.
+in the FinFocus ecosystem.

--- a/specs/001-domain-enum-optimization/quickstart.md
+++ b/specs/001-domain-enum-optimization/quickstart.md
@@ -288,7 +288,7 @@ After implementing optimization, verify:
 ### Basic Validation
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/registry"
+import "github.com/rshade/finfocus-spec/sdk/go/registry"
 
 // Validate provider
 if registry.IsValidProvider("aws") {

--- a/specs/001-domain-enum-optimization/research.md
+++ b/specs/001-domain-enum-optimization/research.md
@@ -209,7 +209,7 @@ func IsValidProvider(p string) bool {
 
 ### Consistency Guideline
 
-**For pulumicost-spec**: All registry enums (4-14 values) fall into "< 20 values" category. Use **optimized
+**For finfocus-spec**: All registry enums (4-14 values) fall into "< 20 values" category. Use **optimized
 slice pattern** for:
 
 - Consistency with pricing package (38 values currently uses slice)

--- a/specs/001-domain-enum-optimization/validation-pattern.md
+++ b/specs/001-domain-enum-optimization/validation-pattern.md
@@ -7,7 +7,7 @@
 ## Pattern Overview
 
 This document defines the **zero-allocation enum validation pattern** established in the registry package and recommended
-for consistent implementation across the PulumiCost SDK.
+for consistent implementation across the FinFocus SDK.
 
 ## Pattern Definition
 
@@ -457,5 +457,5 @@ The **optimized slice-based enum validation pattern** provides:
 - ✅ Type safety (Go enum pattern)
 - ✅ Maintainability (single source of truth)
 
-**Recommendation**: Use this pattern as the standard approach for all enum validation in the PulumiCost SDK when
+**Recommendation**: Use this pattern as the standard approach for all enum validation in the FinFocus SDK when
 enum size is < 40 values.

--- a/specs/001-sdk-polish-release/contracts/README.md
+++ b/specs/001-sdk-polish-release/contracts/README.md
@@ -66,7 +66,7 @@ import (
     "database/sql"
     "fmt"
 
-    "github.com/rshade/pulumicost-sdk/pluginsdk"
+    "github.com/rshade/finfocus-sdk/pluginsdk"
 )
 
 type MyPlugin struct {

--- a/specs/001-sdk-polish-release/quickstart.md
+++ b/specs/001-sdk-polish-release/quickstart.md
@@ -36,7 +36,7 @@ import (
     "fmt"
     "time"
 
-    "github.com/rshade/pulumicost-sdk/pluginsdk"
+    "github.com/rshade/finfocus-sdk/pluginsdk"
 )
 
 type MyPlugin struct {
@@ -75,7 +75,7 @@ func main() {
 Validate contexts before RPC calls to catch errors early:
 
 ```go
-import "github.com/rshade/pulumicost-sdk/pluginsdk"
+import "github.com/rshade/finfocus-sdk/pluginsdk"
 
 // Before: Could panic or return cryptic errors
 resp, err := client.GetActualCost(ctx, req)
@@ -102,7 +102,7 @@ if remaining < 5*time.Second {
 Identify cloud provider from resource identifiers and validate consistency:
 
 ```go
-import "github.com/rshade/pulumicost-sdk/pluginsdk"
+import "github.com/rshade/finfocus-sdk/pluginsdk"
 
 // Detect provider from ARN
 arn := "arn:aws:ec2:us-east-1:123:instance/i-abc"
@@ -138,7 +138,7 @@ for _, arn := range providers {
 Override default 30-second timeout for operations that take longer:
 
 ```go
-import "github.com/rshade/pulumicost-sdk/pluginsdk"
+import "github.com/rshade/finfocus-sdk/pluginsdk"
 
 // Configure client with 2-minute default timeout
 client, err := pluginsdk.NewClient(ctx, pluginsdk.ClientConfig{
@@ -167,7 +167,7 @@ resp, err = client.GetActualCost(ctx, req) // Uses 5-minute timeout
 Provide plugin metadata for clients to discover capabilities:
 
 ```go
-import "github.com/rshade/pulumicost-sdk/pluginsdk"
+import "github.com/rshade/finfocus-sdk/pluginsdk"
 
 // Option 1: Static metadata (recommended for most plugins)
 info := pluginsdk.NewPluginInfo("my-cost-plugin", "v1.0.0",
@@ -407,7 +407,7 @@ func TestDetectARNProvider(t *testing.T) {
 - **Full Documentation**: See [contracts/README.md](./contracts/README.md) for detailed interface contracts
 - **Migration Guide**: See `sdk/go/pluginsdk/README.md` → "Migrating to GetPluginInfo" section
 - **Examples**: See `examples/` directory for complete plugin examples
-- **Issues**: Report bugs or request features at <https://github.com/rshade/pulumicost-spec/issues>
+- **Issues**: Report bugs or request features at <https://github.com/rshade/finfocus-spec/issues>
 
 ---
 

--- a/specs/002-add-supports-rpc/plan.md
+++ b/specs/002-add-supports-rpc/plan.md
@@ -5,17 +5,17 @@
 
 ## Summary
 
-**FINDING: The Supports() RPC method is fully implemented in pulumicost-spec v0.1.0.**
+**FINDING: The Supports() RPC method is fully implemented in finfocus-spec v0.1.0.**
 
 ### Verified Components
 
-The proto file `proto/pulumicost/v1/costsource.proto` contains:
+The proto file `proto/finfocus/v1/costsource.proto` contains:
 
 - `rpc Supports(SupportsRequest) returns (SupportsResponse);` (line 17)
 - `SupportsRequest` message with `ResourceDescriptor resource` field (lines 38-42)
 - `SupportsResponse` message with `supported` and `reason` fields (lines 44-50)
 
-The generated Go SDK in `sdk/go/proto/pulumicost/v1/` includes:
+The generated Go SDK in `sdk/go/proto/finfocus/v1/` includes:
 
 - `CostSourceServiceClient.Supports()` method (line 67 in costsource_grpc.pb.go)
 - `CostSourceServiceServer.Supports()` interface method (line 118)
@@ -32,21 +32,21 @@ The testing framework includes:
 
 ### Root Cause Analysis
 
-The issue **is NOT in pulumicost-spec**. The Supports RPC was included in the v0.1.0 release.
+The issue **is NOT in finfocus-spec**. The Supports RPC was included in the v0.1.0 release.
 
 Per the issue's "Related Issues" section:
 
-> "After this is implemented, pulumicost-core#TBD needs to be completed to actually register
+> "After this is implemented, finfocus-core#TBD needs to be completed to actually register
 > and implement the handler in `pluginsdk`."
 
-**The actual problem is in pulumicost-core's pluginsdk**, which likely doesn't expose the
+**The actual problem is in finfocus-core's pluginsdk**, which likely doesn't expose the
 Supports method to plugin implementations. When a plugin calls `client.Supports()`, the
 pluginsdk needs to forward this to the plugin's implementation.
 
 ### Conclusion
 
-GitHub Issue #64 should be closed as "Already Complete" for pulumicost-spec. A new issue
-should be created in pulumicost-core to update the pluginsdk to expose the Supports method.
+GitHub Issue #64 should be closed as "Already Complete" for finfocus-spec. A new issue
+should be created in finfocus-core to update the pluginsdk to expose the Supports method.
 
 ## Technical Context
 
@@ -91,10 +91,10 @@ specs/002-add-supports-rpc/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 └── costsource.proto     # Already contains Supports RPC (lines 15-17, 38-50)
 
-sdk/go/proto/pulumicost/v1/
+sdk/go/proto/finfocus/v1/
 ├── costsource.pb.go     # Already contains SupportsRequest/Response types
 └── costsource_grpc.pb.go # Already contains Supports client/server methods
 ```
@@ -108,41 +108,41 @@ No violations - feature already exists in codebase.
 ## Recommended Actions
 
 1. **Close GitHub Issue #64** with comment explaining:
-   - The Supports RPC is fully implemented in pulumicost-spec v0.1.0
+   - The Supports RPC is fully implemented in finfocus-spec v0.1.0
    - All components verified: proto, messages, handlers, service descriptor, testing framework
-   - The actual issue is in pulumicost-core pluginsdk
+   - The actual issue is in finfocus-core pluginsdk
 
-2. **Unblock pulumicost-core#160** by commenting:
-   - Issue: <https://github.com/rshade/pulumicost-core/issues/160>
-   - The dependency (pulumicost-spec#64) is already complete
+2. **Unblock finfocus-core#160** by commenting:
+   - Issue: <https://github.com/rshade/finfocus-core/issues/160>
+   - The dependency (finfocus-spec#64) is already complete
    - Supports RPC has been in v0.1.0 since release
    - Issue #160 can now proceed with pluginsdk implementation
    - Suggested comment:
 
    ```text
-   This issue is now unblocked. pulumicost-spec#64 is already complete - the Supports()
-   RPC method has been in pulumicost-spec since v0.1.0 release:
+   This issue is now unblocked. finfocus-spec#64 is already complete - the Supports()
+   RPC method has been in finfocus-spec since v0.1.0 release:
 
    - Proto: `rpc Supports(SupportsRequest) returns (SupportsResponse);`
    - Messages: SupportsRequest, SupportsResponse
    - Generated code: Client/Server interfaces, handlers, service descriptor
    - Testing: ValidateSupportsResponse, MockPlugin.Supports, integration tests
 
-   Update pulumicost-core to use v0.1.0 or later and proceed with pluginsdk implementation.
+   Update finfocus-core to use v0.1.0 or later and proceed with pluginsdk implementation.
    ```
 
-3. **Verify pulumicost-plugin-aws-public** is using:
-   - `github.com/rshade/pulumicost-spec v0.1.0` or later
-   - Run `go get github.com/rshade/pulumicost-spec@v0.1.0` if needed
+3. **Verify finfocus-plugin-aws-public** is using:
+   - `github.com/rshade/finfocus-spec v0.1.0` or later
+   - Run `go get github.com/rshade/finfocus-spec@v0.1.0` if needed
 
 ## Verification Commands
 
 ```bash
 # Verify proto contains Supports RPC
-grep -n "rpc Supports" proto/pulumicost/v1/costsource.proto
+grep -n "rpc Supports" proto/finfocus/v1/costsource.proto
 
 # Verify generated code contains Supports method
-grep "func.*Supports" sdk/go/proto/pulumicost/v1/*.go
+grep "func.*Supports" sdk/go/proto/finfocus/v1/*.go
 
 # Build and test
 make test

--- a/specs/002-add-supports-rpc/spec.md
+++ b/specs/002-add-supports-rpc/spec.md
@@ -6,13 +6,13 @@
 **Input**: GitHub Issue #64 - Add Supports() RPC method to CostSourceService
 
 **Note**: Analysis revealed Supports() RPC was fully implemented in v0.1.0. This spec
-documents requirements for verification purposes. Actual work needed is in pulumicost-core.
+documents requirements for verification purposes. Actual work needed is in finfocus-core.
 
 ## User Scenarios & Testing _(mandatory)_
 
 ### User Story 1 - Query Plugin Capabilities (Priority: P1)
 
-As a PulumiCost client, I need to query a plugin to determine if it supports a specific
+As a FinFocus client, I need to query a plugin to determine if it supports a specific
 resource type and region before making cost requests, so I can provide meaningful feedback
 to users and avoid unnecessary API calls.
 
@@ -126,6 +126,6 @@ verifying it responds correctly via gRPC test harness.
 ## Out of Scope
 
 - Changes to SupportsRequest or SupportsResponse message definitions
-- Implementation of the handler in pulumicost-core pluginsdk (separate issue)
+- Implementation of the handler in finfocus-core pluginsdk (separate issue)
 - Plugin-specific implementation of the Supports() method
 - Performance optimization of the Supports() RPC

--- a/specs/002-add-supports-rpc/tasks.md
+++ b/specs/002-add-supports-rpc/tasks.md
@@ -17,10 +17,10 @@ close issues and unblock dependent work.
 
 **Purpose**: Confirm all components exist and pass validation
 
-- [x] T001 Verify proto contains Supports RPC in proto/pulumicost/v1/costsource.proto
-- [x] T002 [P] Verify generated client method in sdk/go/proto/pulumicost/v1/costsource_grpc.pb.go
-- [x] T003 [P] Verify generated server interface in sdk/go/proto/pulumicost/v1/costsource_grpc.pb.go
-- [x] T004 [P] Verify service descriptor entry in sdk/go/proto/pulumicost/v1/costsource_grpc.pb.go
+- [x] T001 Verify proto contains Supports RPC in proto/finfocus/v1/costsource.proto
+- [x] T002 [P] Verify generated client method in sdk/go/proto/finfocus/v1/costsource_grpc.pb.go
+- [x] T003 [P] Verify generated server interface in sdk/go/proto/finfocus/v1/costsource_grpc.pb.go
+- [x] T004 [P] Verify service descriptor entry in sdk/go/proto/finfocus/v1/costsource_grpc.pb.go
 - [x] T005 Run `make test` to confirm all tests pass
 - [x] T006 Run `make lint` to confirm code quality
 - [x] T006a [P] Verify CHANGELOG documents Supports RPC availability in CHANGELOG.md
@@ -64,10 +64,10 @@ close issues and unblock dependent work.
 
 ## Phase 4: Issue Management
 
-**Purpose**: Close pulumicost-spec#64 and unblock pulumicost-core#160
+**Purpose**: Close finfocus-spec#64 and unblock finfocus-core#160
 
 - [x] T014 Close GitHub Issue #64 with completion comment
-- [x] T015 Comment on pulumicost-core#160 to unblock it
+- [x] T015 Comment on finfocus-core#160 to unblock it
 
 ### T014 - Close Issue #64 Comment
 
@@ -76,16 +76,16 @@ Post this comment and close the issue:
 ```text
 ## Resolution: Already Complete
 
-The Supports() RPC method has been fully implemented in pulumicost-spec since v0.1.0.
+The Supports() RPC method has been fully implemented in finfocus-spec since v0.1.0.
 
 ### Verified Components
 
-**Proto Definition** (proto/pulumicost/v1/costsource.proto):
+**Proto Definition** (proto/finfocus/v1/costsource.proto):
 - `rpc Supports(SupportsRequest) returns (SupportsResponse);` (line 17)
 - `SupportsRequest` message (lines 38-42)
 - `SupportsResponse` message (lines 44-50)
 
-**Generated Go SDK** (sdk/go/proto/pulumicost/v1/):
+**Generated Go SDK** (sdk/go/proto/finfocus/v1/):
 - `CostSourceServiceClient.Supports()` method
 - `CostSourceServiceServer.Supports()` interface
 - `UnimplementedCostSourceServiceServer.Supports()` default
@@ -100,24 +100,24 @@ The Supports() RPC method has been fully implemented in pulumicost-spec since v0
 
 ### Next Steps
 
-The actual issue is in **pulumicost-core's pluginsdk**, which needs to expose the Supports
-method to plugin implementations. See pulumicost-core#160.
+The actual issue is in **finfocus-core's pluginsdk**, which needs to expose the Supports
+method to plugin implementations. See finfocus-core#160.
 ```
 
-### T015 - Unblock pulumicost-core#160 Comment
+### T015 - Unblock finfocus-core#160 Comment
 
-Post this comment on <https://github.com/rshade/pulumicost-core/issues/160>:
+Post this comment on <https://github.com/rshade/finfocus-core/issues/160>:
 
 ```text
-This issue is now unblocked. pulumicost-spec#64 is already complete - the Supports()
-RPC method has been in pulumicost-spec since v0.1.0 release:
+This issue is now unblocked. finfocus-spec#64 is already complete - the Supports()
+RPC method has been in finfocus-spec since v0.1.0 release:
 
 - Proto: `rpc Supports(SupportsRequest) returns (SupportsResponse);`
 - Messages: SupportsRequest, SupportsResponse
 - Generated code: Client/Server interfaces, handlers, service descriptor
 - Testing: ValidateSupportsResponse, MockPlugin.Supports, integration tests
 
-Update pulumicost-core to use v0.1.0 or later and proceed with pluginsdk implementation.
+Update finfocus-core to use v0.1.0 or later and proceed with pluginsdk implementation.
 ```
 
 **Checkpoint**: Issues properly documented and dependencies unblocked
@@ -163,4 +163,4 @@ No modifications to proto, SDK, or testing code are needed.
 - Feature fully implemented in v0.1.0 release
 - Tasks verify existing implementation, not create new code
 - Main action is issue management (close #64, unblock core#160)
-- Dependent work continues in pulumicost-core repository
+- Dependent work continues in finfocus-core repository

--- a/specs/003-getpricingspec/contracts/proto-changes.md
+++ b/specs/003-getpricingspec/contracts/proto-changes.md
@@ -5,7 +5,7 @@
 
 ## New Message: PricingTier
 
-Add after existing PricingSpec message in `proto/pulumicost/v1/costsource.proto`:
+Add after existing PricingSpec message in `proto/finfocus/v1/costsource.proto`:
 
 ```protobuf
 // PricingTier represents one tier in a tiered pricing model.

--- a/specs/003-getpricingspec/plan.md
+++ b/specs/003-getpricingspec/plan.md
@@ -53,7 +53,7 @@ specs/003-getpricingspec/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 └── costsource.proto     # Add PricingTier message, update PricingSpec
 
 sdk/go/

--- a/specs/003-getpricingspec/quickstart.md
+++ b/specs/003-getpricingspec/quickstart.md
@@ -35,7 +35,7 @@ make generate
 
 ```go
 import (
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto"
     "google.golang.org/grpc/codes"
     "google.golang.org/grpc/status"
 )
@@ -139,8 +139,8 @@ return &pbc.GetPricingSpecResponse{
 
 ```go
 import (
-    plugintesting "github.com/rshade/pulumicost-spec/sdk/go/testing"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto"
+    plugintesting "github.com/rshade/finfocus-spec/sdk/go/testing"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto"
 )
 
 func TestGetPricingSpec(t *testing.T) {

--- a/specs/003-getpricingspec/tasks.md
+++ b/specs/003-getpricingspec/tasks.md
@@ -15,7 +15,7 @@
 
 ## Path Conventions
 
-- **Proto**: `proto/pulumicost/v1/costsource.proto`
+- **Proto**: `proto/finfocus/v1/costsource.proto`
 - **SDK**: `sdk/go/proto/`, `sdk/go/pricing/`, `sdk/go/testing/`
 - **Schemas**: `schemas/pricing_spec.schema.json`
 - **Examples**: `examples/specs/*.json`
@@ -50,13 +50,13 @@
 
 ### Proto Implementation
 
-- [ ] T007 Add PricingTier message to proto/pulumicost/v1/costsource.proto after line 162
+- [ ] T007 Add PricingTier message to proto/finfocus/v1/costsource.proto after line 162
       with fields: min_quantity (1), max_quantity (2), rate_per_unit (3), description (4)
-- [ ] T008 Add unit field (12) to PricingSpec message in proto/pulumicost/v1/costsource.proto
+- [ ] T008 Add unit field (12) to PricingSpec message in proto/finfocus/v1/costsource.proto
 - [ ] T009 [P] Add assumptions field (13) to PricingSpec message in
-      proto/pulumicost/v1/costsource.proto
+      proto/finfocus/v1/costsource.proto
 - [ ] T010 [P] Add pricing_tiers field (14) to PricingSpec message in
-      proto/pulumicost/v1/costsource.proto
+      proto/finfocus/v1/costsource.proto
 - [ ] T011 Add proto comments for all new fields explaining purpose and usage
 - [ ] T012 Run `make generate` to regenerate Go SDK from proto
 - [ ] T013 Run `make lint` to verify buf lint and buf breaking pass

--- a/specs/004-plugin-registry-schema/data-model.md
+++ b/specs/004-plugin-registry-schema/data-model.md
@@ -89,7 +89,7 @@ Plugin security trust levels.
 | `untrusted` | Untrusted, requires explicit approval | SECURITY_LEVEL_UNTRUSTED |
 | `community` | Community verified (default)          | SECURITY_LEVEL_COMMUNITY |
 | `verified`  | Officially verified                   | SECURITY_LEVEL_VERIFIED  |
-| `official`  | Official PulumiCost plugin            | SECURITY_LEVEL_OFFICIAL  |
+| `official`  | Official FinFocus plugin            | SECURITY_LEVEL_OFFICIAL  |
 
 ## Relationships
 
@@ -124,7 +124,7 @@ RegistryIndex
 ## Validation Rules (Consumer Responsibility)
 
 These validations cannot be enforced by JSON Schema and must be validated by consuming
-applications (e.g., pulumicost-core):
+applications (e.g., finfocus-core):
 
 1. **Name/key match**: Plugin `name` must match its key in the `plugins` map
 2. **Version ordering**: `max_spec_version` >= `min_spec_version` when both specified

--- a/specs/004-plugin-registry-schema/plan.md
+++ b/specs/004-plugin-registry-schema/plan.md
@@ -7,7 +7,7 @@
 
 Add a JSON Schema (`schemas/plugin_registry.schema.json`) for validating plugin registry
 index files (`registry.json`). The schema defines the contract for well-known plugin
-registries used by `pulumicost plugin install`, aligning field patterns and enums with
+registries used by `finfocus plugin install`, aligning field patterns and enums with
 `registry.proto` definitions.
 
 ## Technical Context

--- a/specs/004-plugin-registry-schema/quickstart.md
+++ b/specs/004-plugin-registry-schema/quickstart.md
@@ -19,7 +19,7 @@ schema.
     "my-plugin": {
       "name": "my-plugin",
       "description": "A cost data plugin for my custom cost source",
-      "repository": "myorg/pulumicost-plugin-custom",
+      "repository": "myorg/finfocus-plugin-custom",
       "author": "My Organization",
       "supported_providers": ["custom"],
       "min_spec_version": "0.1.0"
@@ -37,10 +37,10 @@ schema.
     "kubecost": {
       "name": "kubecost",
       "description": "Kubernetes cost analysis via Kubecost API integration",
-      "repository": "rshade/pulumicost-plugin-kubecost",
-      "author": "PulumiCost Team",
+      "repository": "rshade/finfocus-plugin-kubecost",
+      "author": "FinFocus Team",
       "license": "Apache-2.0",
-      "homepage": "https://github.com/rshade/pulumicost-plugin-kubecost",
+      "homepage": "https://github.com/rshade/finfocus-plugin-kubecost",
       "supported_providers": ["kubernetes"],
       "capabilities": ["cost_retrieval", "cost_projection", "real_time_data"],
       "security_level": "official",
@@ -138,7 +138,7 @@ Error: must have required property 'deprecation_message'
 
 ## Consumer Validation
 
-The schema validates structure and patterns. Consuming applications (pulumicost-core)
+The schema validates structure and patterns. Consuming applications (finfocus-core)
 additionally validate:
 
 - Plugin name matches registry key
@@ -148,8 +148,8 @@ additionally validate:
 ## Version Compatibility
 
 - **schema_version**: Format version of the registry file
-- **min_spec_version**: Minimum PulumiCost spec version required by plugin
-- **max_spec_version**: Maximum PulumiCost spec version supported (optional)
+- **min_spec_version**: Minimum FinFocus spec version required by plugin
+- **max_spec_version**: Maximum FinFocus spec version supported (optional)
 
-When installing a plugin, pulumicost-core checks that the current spec version falls
+When installing a plugin, finfocus-core checks that the current spec version falls
 within the plugin's supported range.

--- a/specs/004-plugin-registry-schema/research.md
+++ b/specs/004-plugin-registry-schema/research.md
@@ -67,7 +67,7 @@ hyphens, underscores, and repo can also contain dots.
 
 **Examples**:
 
-- `rshade/pulumicost-plugin-kubecost` - Valid
+- `rshade/finfocus-plugin-kubecost` - Valid
 - `my-org/my.repo.name` - Valid
 - `invalid` - Invalid (no slash)
 

--- a/specs/004-plugin-registry-schema/spec.md
+++ b/specs/004-plugin-registry-schema/spec.md
@@ -11,7 +11,7 @@
 
 - Q: Should the schema enforce that the plugin `name` field matches its registry key?
   → A: Schema does NOT enforce match; documented as invalid for consumer validation
-  (pulumicost-core test file)
+  (finfocus-core test file)
 - Q: Should a deprecated plugin without a `deprecation_message` be allowed?
   → A: No, require `deprecation_message` when `deprecated: true` (no existing entries)
 - Q: Should schema validate that `max_spec_version` >= `min_spec_version`?
@@ -47,11 +47,11 @@ messages.
 
 ### User Story 2 - Discover Plugin Metadata (Priority: P1)
 
-A PulumiCost user runs `pulumicost plugin install kubecost` and the CLI fetches the registry
+A FinFocus user runs `finfocus plugin install kubecost` and the CLI fetches the registry
 index to locate the plugin's repository, supported providers, and minimum spec version.
 
 **Why this priority**: This represents the primary consumer use case that drives the need
-for a formal schema - the plugin installation system in pulumicost-core.
+for a formal schema - the plugin installation system in finfocus-core.
 
 **Independent Test**: Can be tested by verifying that the schema captures all metadata
 fields required by the plugin installation system to discover and install plugins.
@@ -124,7 +124,7 @@ and providers and verifying filtering operations work correctly.
 
 - **Name/key mismatch**: When a plugin `name` doesn't match its registry key, the schema
   does not enforce this constraint (JSON Schema limitation). Consuming applications
-  (e.g., pulumicost-core) MUST validate this match and reject mismatched entries.
+  (e.g., finfocus-core) MUST validate this match and reject mismatched entries.
 - **Deprecated without message**: Schema requires `deprecation_message` when `deprecated`
   is `true`; validation fails if message is missing.
 - **Version constraint violation**: When `max_spec_version` < `min_spec_version`, the
@@ -187,8 +187,8 @@ and providers and verifying filtering operations work correctly.
 
 ## Assumptions
 
-- The registry index is consumed by pulumicost-core's plugin installation system
-  (rshade/pulumicost-core#163)
+- The registry index is consumed by finfocus-core's plugin installation system
+  (rshade/finfocus-core#163)
 - Plugin names must be unique within the registry
 - The schema follows JSON Schema draft 2020-12 specification
 - Third-party registries will use this same schema for compatibility

--- a/specs/004-plugin-registry-schema/tasks.md
+++ b/specs/004-plugin-registry-schema/tasks.md
@@ -103,7 +103,7 @@ PluginMetadata, and PluginRequirements messages
 
 - [x] T010 [US2] Document proto alignment in schema field descriptions
 - [x] T011 [US2] Add examples array to schema fields that have specific formats
-  - repository: `"rshade/pulumicost-plugin-kubecost"`
+  - repository: `"rshade/finfocus-plugin-kubecost"`
   - schema_version: `"1.0.0"`
   - min_spec_version: `"0.1.0"`
 

--- a/specs/005-zerolog/contracts/pluginsdk-api.go.txt
+++ b/specs/005-zerolog/contracts/pluginsdk-api.go.txt
@@ -15,7 +15,7 @@ import (
 // Metadata keys for gRPC trace propagation
 const (
 	// TraceIDMetadataKey is the gRPC metadata header for trace ID propagation
-	TraceIDMetadataKey = "x-pulumicost-trace-id"
+	TraceIDMetadataKey = "x-finfocus-trace-id"
 )
 
 // Standard field names for structured logging consistency across plugins

--- a/specs/005-zerolog/data-model.md
+++ b/specs/005-zerolog/data-model.md
@@ -66,7 +66,7 @@ gRPC metadata keys for trace propagation.
 
 | Constant           | Value                   | Description               |
 | ------------------ | ----------------------- | ------------------------- |
-| TraceIDMetadataKey | "x-pulumicost-trace-id" | gRPC metadata header name |
+| TraceIDMetadataKey | "x-finfocus-trace-id" | gRPC metadata header name |
 
 ### 5. Context Keys
 
@@ -78,7 +78,7 @@ Internal context keys for value storage.
 
 | Key        | Value                 | Description              |
 | ---------- | --------------------- | ------------------------ |
-| traceIDKey | "pulumicost-trace-id" | Context key for trace ID |
+| traceIDKey | "finfocus-trace-id" | Context key for trace ID |
 
 ## State Transitions
 
@@ -121,7 +121,7 @@ Plugin main() → NewPluginLogger(name, version, level, writer)
 ### Request Handling
 
 ```text
-gRPC Request with x-pulumicost-trace-id header
+gRPC Request with x-finfocus-trace-id header
           ↓
 TracingUnaryServerInterceptor extracts trace_id
           ↓

--- a/specs/005-zerolog/plan.md
+++ b/specs/005-zerolog/plan.md
@@ -7,7 +7,7 @@
 
 Add standardized logging utilities to the Plugin SDK using zerolog v1.34.0+ to
 enable consistent structured logging and distributed tracing across all
-PulumiCost plugins. The SDK will provide logger construction, gRPC interceptors
+FinFocus plugins. The SDK will provide logger construction, gRPC interceptors
 for trace ID propagation, standard field name constants, and operation timing
 helpers.
 

--- a/specs/005-zerolog/quickstart.md
+++ b/specs/005-zerolog/quickstart.md
@@ -1,13 +1,13 @@
 # Quickstart: Zerolog SDK Logging Utilities
 
-**Feature**: 005-zerolog | **SDK Package**: `github.com/rshade/pulumicost-spec/sdk/go/pluginsdk`
+**Feature**: 005-zerolog | **SDK Package**: `github.com/rshade/finfocus-spec/sdk/go/pluginsdk`
 
 ## Installation
 
 Add the SDK to your plugin's dependencies:
 
 ```bash
-go get github.com/rshade/pulumicost-spec/sdk/go@latest
+go get github.com/rshade/finfocus-spec/sdk/go@latest
 ```
 
 ## Basic Usage
@@ -20,7 +20,7 @@ package main
 import (
     "os"
     "github.com/rs/zerolog"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 ```go
 import (
     "google.golang.org/grpc"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func main() {
@@ -109,8 +109,8 @@ import (
     "github.com/rs/zerolog"
     "google.golang.org/grpc"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    pb "github.com/rshade/pulumicost-spec/sdk/go/proto"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    pb "github.com/rshade/finfocus-spec/sdk/go/proto"
 )
 
 type awsPlugin struct {
@@ -212,7 +212,7 @@ For production deployments with file output:
 ```go
 // Open log file
 logFile, err := os.OpenFile(
-    "/var/log/pulumicost/aws-public.log",
+    "/var/log/finfocus/aws-public.log",
     os.O_APPEND|os.O_CREATE|os.O_WRONLY,
     0644,
 )

--- a/specs/005-zerolog/research.md
+++ b/specs/005-zerolog/research.md
@@ -37,7 +37,7 @@
 
 ```go
 type contextKey string
-const traceIDKey contextKey = "pulumicost-trace-id"
+const traceIDKey contextKey = "finfocus-trace-id"
 ```
 
 ### 3. gRPC Interceptor Pattern
@@ -49,7 +49,7 @@ const traceIDKey contextKey = "pulumicost-trace-id"
 - Standard gRPC pattern for cross-cutting concerns
 - Metadata extraction is well-documented
 - Supports both client and server-side propagation
-- Works with existing PulumiCost gRPC infrastructure
+- Works with existing FinFocus gRPC infrastructure
 
 **Pattern**:
 

--- a/specs/005-zerolog/spec.md
+++ b/specs/005-zerolog/spec.md
@@ -20,7 +20,7 @@
 ### User Story 1 - Plugin Developer Creates Standardized Logger (Priority: P1)
 
 A plugin developer wants to create a consistent, well-configured logger for their
-PulumiCost plugin that includes standard metadata fields and follows ecosystem
+FinFocus plugin that includes standard metadata fields and follows ecosystem
 conventions.
 
 **Why this priority**: This is the foundation - without a standard logger
@@ -46,7 +46,7 @@ name/version and verifying it outputs structured JSON with required base fields.
 
 ### User Story 2 - Core System Traces Requests Through Plugin Calls (Priority: P1)
 
-A system operator needs to trace a single request through the entire PulumiCost
+A system operator needs to trace a single request through the entire FinFocus
 system, including into plugin RPC calls, to debug issues or analyze performance.
 
 **Why this priority**: Distributed tracing is essential for debugging production
@@ -60,7 +60,7 @@ available in the handler context.
 **Acceptance Scenarios**:
 
 1. **Given** a gRPC server configured with TracingUnaryServerInterceptor, **When**
-   a client sends a request with `x-pulumicost-trace-id` metadata header, **Then**
+   a client sends a request with `x-finfocus-trace-id` metadata header, **Then**
    the handler can retrieve the trace_id from context using TraceIDFromContext
 2. **Given** a gRPC request arrives without trace_id metadata, **When** the
    interceptor processes it, **Then** TraceIDFromContext returns an empty string
@@ -96,7 +96,7 @@ calling the returned function, and verifying duration_ms appears in log output.
 ### User Story 4 - Plugin Developer Uses Standard Field Names (Priority: P2)
 
 A plugin developer needs to use consistent field names when logging so that log
-aggregation and analysis tools can easily parse logs from any PulumiCost plugin.
+aggregation and analysis tools can easily parse logs from any FinFocus plugin.
 
 **Why this priority**: Standardization enables ecosystem-wide log analysis but
 individual plugins can function without it.
@@ -109,7 +109,7 @@ statements and verifying the resulting JSON uses those exact field names.
 1. **Given** a developer imports the logging package, **When** they use
    FieldTraceID, FieldOperation, FieldResourceType constants, **Then** logs
    contain fields named exactly "trace_id", "operation", "resource_type"
-2. **Given** all PulumiCost plugins use the standard field constants, **When**
+2. **Given** all FinFocus plugins use the standard field constants, **When**
    logs are aggregated, **Then** they can be queried consistently across all
    plugins
 
@@ -140,7 +140,7 @@ statements and verifying the resulting JSON uses those exact field names.
 - **FR-002**: System MUST export TracingUnaryServerInterceptor function that
   returns a gRPC UnaryServerInterceptor
 - **FR-003**: Interceptor MUST extract trace_id from gRPC metadata key
-  "x-pulumicost-trace-id" and add it to request context
+  "x-finfocus-trace-id" and add it to request context
 - **FR-004**: System MUST provide TraceIDFromContext function that extracts
   trace_id string from context
 - **FR-005**: System MUST provide ContextWithTraceID function that adds trace_id

--- a/specs/006-estimate-cost/contracts/estimate_cost.proto
+++ b/specs/006-estimate-cost/contracts/estimate_cost.proto
@@ -1,15 +1,15 @@
 // EstimateCost RPC Contract Definition
 //
 // This file defines the protobuf contract for the EstimateCost RPC method
-// that will be added to the CostSource service in proto/pulumicost/v1/costsource.proto
+// that will be added to the CostSource service in proto/finfocus/v1/costsource.proto
 
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 import "google/protobuf/struct.proto";
 
-option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1";
+option go_package = "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1";
 
 // EstimateCostRequest represents a request to estimate the cost of a Pulumi
 // resource before deployment. This enables "what-if" cost analysis for

--- a/specs/006-estimate-cost/data-model.md
+++ b/specs/006-estimate-cost/data-model.md
@@ -85,7 +85,7 @@ EstimateCostResponse {
 
 ### EstimateCost
 
-**Service**: `pulumicost.v1.CostSource`
+**Service**: `finfocus.v1.CostSource`
 
 **Signature**:
 

--- a/specs/006-estimate-cost/performance-baseline.md
+++ b/specs/006-estimate-cost/performance-baseline.md
@@ -3,7 +3,7 @@
 **Purpose**: Document baseline performance metrics for EstimateCost RPC per SC-002
 **Created**: 2025-11-30
 **Task**: T043 - Performance Benchmarking
-**Issue**: [#86](https://github.com/rshade/pulumicost-spec/issues/86)
+**Issue**: [#86](https://github.com/rshade/finfocus-spec/issues/86)
 
 ## Executive Summary
 
@@ -205,6 +205,6 @@ go test -bench=BenchmarkEstimateCost -benchmem -memprofile=mem.prof ./sdk/go/tes
 
 ## Related Tasks
 
-- T043: Performance benchmarking (this document) - [#86](https://github.com/rshade/pulumicost-spec/issues/86)
-- T044: Concurrent benchmark verification - [#87](https://github.com/rshade/pulumicost-spec/issues/87)
-- T045: CI performance regression tests - [#88](https://github.com/rshade/pulumicost-spec/issues/88)
+- T043: Performance benchmarking (this document) - [#86](https://github.com/rshade/finfocus-spec/issues/86)
+- T044: Concurrent benchmark verification - [#87](https://github.com/rshade/finfocus-spec/issues/87)
+- T045: CI performance regression tests - [#88](https://github.com/rshade/finfocus-spec/issues/88)

--- a/specs/006-estimate-cost/plan.md
+++ b/specs/006-estimate-cost/plan.md
@@ -61,7 +61,7 @@ _GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 ### I. gRPC Proto Specification-First Development ✅ PASS
 
 - ✅ Proto definitions are source of truth: New EstimateCost RPC will be defined in
-  `proto/pulumicost/v1/costsource.proto`
+  `proto/finfocus/v1/costsource.proto`
 - ✅ SDK code generated from proto: Go SDK will be regenerated via buf after proto updates
 - ✅ Comprehensive validation: EstimateCostRequest and EstimateCostResponse will have full validation
 - ✅ Breaking changes detected: buf lint/breaking checks in CI
@@ -129,12 +129,12 @@ specs/[###-feature]/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 └── costsource.proto          # Add EstimateCost RPC and messages here
 
 sdk/go/
 ├── proto/                     # Generated code (regenerated via buf)
-│   └── pulumicost/v1/
+│   └── finfocus/v1/
 │       ├── costsource.pb.go
 │       └── costsource_grpc.pb.go
 ├── pricing/                   # Domain types and validation
@@ -218,7 +218,7 @@ N/A - All constitutional requirements passed. No violations to justify.
 **Implementation Order** (from tasks.md):
 
 1. Write conformance tests for EstimateCost (RED phase)
-2. Update proto/pulumicost/v1/costsource.proto
+2. Update proto/finfocus/v1/costsource.proto
 3. Run `make generate` to regenerate Go SDK
 4. Implement validation functions in sdk/go/pricing/
 5. Extend testing framework in sdk/go/testing/

--- a/specs/006-estimate-cost/quickstart.md
+++ b/specs/006-estimate-cost/quickstart.md
@@ -13,7 +13,7 @@ them. This allows you to:
 
 ## Prerequisites
 
-- A PulumiCost plugin that implements the EstimateCost RPC
+- A FinFocus plugin that implements the EstimateCost RPC
 - The resource type you want to estimate must be supported by the plugin
 - gRPC client library for your language (examples use Go)
 
@@ -25,7 +25,7 @@ First, verify the plugin supports your resource type using the existing `Support
 
 ```go
 import (
-    pb "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    pb "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
     "google.golang.org/grpc"
 )
 

--- a/specs/006-estimate-cost/research.md
+++ b/specs/006-estimate-cost/research.md
@@ -53,7 +53,7 @@ attributes` (field 2)
   GetProjectedCost responses"
 - Avoids introducing incompatible precision handling between different cost APIs
 
-**Action Required**: Examine proto/pulumicost/v1/costsource.proto to determine exact type used in
+**Action Required**: Examine proto/finfocus/v1/costsource.proto to determine exact type used in
 existing cost response messages
 
 ### 3. Resource Type Validation Strategy

--- a/specs/006-estimate-cost/spec.md
+++ b/specs/006-estimate-cost/spec.md
@@ -29,7 +29,7 @@
 
 ### User Story 1 - Basic Cost Estimation (Priority: P1)
 
-As a developer using PulumiCost, I want to get a cost estimate for a resource before
+As a developer using FinFocus, I want to get a cost estimate for a resource before
 deploying it, so that I can make informed decisions about resource configurations during
 development.
 

--- a/specs/006-estimate-cost/tasks.md
+++ b/specs/006-estimate-cost/tasks.md
@@ -21,7 +21,7 @@ are REQUIRED per the TDD approach.
 - [x] T001 Verify Go 1.24+ toolchain and Protocol Buffers v3 installation
 - [x] T002 Verify buf v1.32.1 is installed in bin/ (run `make generate` if needed)
 - [x] T003 [P] Verify zerolog v1.34.0+ dependency in go.mod
-- [x] T004 [P] Review existing proto/pulumicost/v1/costsource.proto to identify cost field type
+- [x] T004 [P] Review existing proto/finfocus/v1/costsource.proto to identify cost field type
       pattern (examine GetActualCost and GetProjectedCost response messages - likely double, string,
       or custom decimal type - document findings in comment for T013)
 
@@ -62,12 +62,12 @@ cost estimate is returned. Tests: TestEstimateCostBasicConformance must pass.
 
 ### Protocol Definition for User Story 1
 
-- [x] T012 [US1] Add EstimateCostRequest message to proto/pulumicost/v1/costsource.proto
+- [x] T012 [US1] Add EstimateCostRequest message to proto/finfocus/v1/costsource.proto
       (fields: resource_type string=1, attributes google.protobuf.Struct=2)
-- [x] T013 [US1] Add EstimateCostResponse message to proto/pulumicost/v1/costsource.proto
+- [x] T013 [US1] Add EstimateCostResponse message to proto/finfocus/v1/costsource.proto
       (fields: currency string=1, cost_monthly [USE TYPE FROM T004 - double/string/custom decimal]=2)
 - [x] T014 [US1] Add EstimateCost RPC method to CostSource service in
-      proto/pulumicost/v1/costsource.proto (method signature with inline documentation)
+      proto/finfocus/v1/costsource.proto (method signature with inline documentation)
 - [x] T015 [US1] Add comprehensive proto comments for EstimateCost RPC, request, and response
       messages per Constitution Principle V
 - [x] T016 [US1] Run `make generate` to regenerate Go SDK from proto definitions in sdk/go/proto/
@@ -155,13 +155,13 @@ error responses. Tests: TestEstimateCostAdvancedConformance must pass.
 
 - [x] T040 [P] [US3] Add structured logging example in sdk/go/testing/integration_test.go
       (demonstrate zerolog integration per NFR-001) -
-      [Issue #83](https://github.com/rshade/pulumicost-spec/issues/83)
+      [Issue #83](https://github.com/rshade/finfocus-spec/issues/83)
 - [x] T041 [P] [US3] Add metrics tracking example in sdk/go/testing/integration_test.go
       (demonstrate latency/success rate tracking per NFR-002) -
-      [Issue #84](https://github.com/rshade/pulumicost-spec/issues/84)
+      [Issue #84](https://github.com/rshade/finfocus-spec/issues/84)
 - [x] T042 [P] [US3] Add tracing support example in sdk/go/testing/integration_test.go
       (demonstrate correlation ID handling per NFR-003) -
-      [Issue #85](https://github.com/rshade/pulumicost-spec/issues/85)
+      [Issue #85](https://github.com/rshade/finfocus-spec/issues/85)
 
 **Checkpoint**: Error handling complete - all error scenarios return appropriate gRPC status codes and messages
 
@@ -173,14 +173,14 @@ error responses. Tests: TestEstimateCostAdvancedConformance must pass.
 
 - [x] T043 [P] Run benchmarks with `go test -bench=BenchmarkEstimateCost -benchmem ./sdk/go/testing/`
       and verify <500ms response time (SC-002) - PASS: ~95µs average (4,400x under target)
-      [Issue #86](https://github.com/rshade/pulumicost-spec/issues/86)
+      [Issue #86](https://github.com/rshade/finfocus-spec/issues/86)
       See [performance-baseline.md](./performance-baseline.md) for full analysis
 - [x] T044 [P] Run concurrent benchmark with 50+ requests per Advanced conformance and verify
       <500ms under load - PASS: 50+ concurrent requests, max ~8ms per request, all <500ms verified
-      [Issue #87](https://github.com/rshade/pulumicost-spec/issues/87)
+      [Issue #87](https://github.com/rshade/finfocus-spec/issues/87)
       See [performance-baseline.md](./performance-baseline.md#concurrent-benchmark-results-t044) for details
 - [x] T045 Add performance regression tests to CI in .github/workflows/ (benchmark comparison between commits)
-      [Issue #88](https://github.com/rshade/pulumicost-spec/issues/88)
+      [Issue #88](https://github.com/rshade/finfocus-spec/issues/88)
 
 ---
 
@@ -197,7 +197,7 @@ error responses. Tests: TestEstimateCostAdvancedConformance must pass.
 - [x] T052 Run `make validate` to verify complete validation pipeline (tests + linting + npm validations)
 - [x] T053 Verify buf breaking check passes in CI (non-breaking change per Constitution Principle IV)
 - [x] T054 Update data-model.md line 56 to replace "[decimal type TBD]" with actual type determined in T004
-      [Issue #89](https://github.com/rshade/pulumicost-spec/issues/89)
+      [Issue #89](https://github.com/rshade/finfocus-spec/issues/89)
 
 ---
 

--- a/specs/007-zerolog-logging-example/research.md
+++ b/specs/007-zerolog-logging-example/research.md
@@ -6,7 +6,7 @@
 ## Overview
 
 This research consolidates findings for implementing a structured logging example demonstrating
-zerolog integration for the EstimateCost RPC in the PulumiCost SDK testing package.
+zerolog integration for the EstimateCost RPC in the FinFocus SDK testing package.
 
 ## Dependencies Analysis
 
@@ -43,7 +43,7 @@ zerolog integration for the EstimateCost RPC in the PulumiCost SDK testing packa
 
 ### 006-estimate-cost EstimateCost RPC
 
-**Status**: Implemented in proto/pulumicost/v1/costsource.proto (lines 29-42, 440-484)
+**Status**: Implemented in proto/finfocus/v1/costsource.proto (lines 29-42, 440-484)
 
 **Key Types**:
 

--- a/specs/007-zerolog-logging-example/spec.md
+++ b/specs/007-zerolog-logging-example/spec.md
@@ -10,7 +10,7 @@
 ### User Story 1 - Plugin Developer Learns Logging Patterns (Priority: P1)
 
 A plugin developer wants to understand how to properly integrate zerolog structured
-logging with PulumiCost plugin operations, specifically for the EstimateCost RPC.
+logging with FinFocus plugin operations, specifically for the EstimateCost RPC.
 
 **Why this priority**: Documentation through working examples is the most effective way
 to ensure consistent logging practices across the plugin ecosystem. This example serves

--- a/specs/008-trace-id-validation/data-model.md
+++ b/specs/008-trace-id-validation/data-model.md
@@ -63,7 +63,7 @@ Go context carrying the validated trace ID through the request handler.
 
 ```go
 type contextKey string
-const traceIDKey contextKey = "pulumicost-trace-id"
+const traceIDKey contextKey = "finfocus-trace-id"
 ```
 
 ### gRPC Metadata
@@ -72,7 +72,7 @@ Incoming request metadata containing trace ID header.
 
 | Attribute | Type     | Description                                                |
 | --------- | -------- | ---------------------------------------------------------- |
-| key       | string   | `"x-pulumicost-trace-id"` (constant: `TraceIDMetadataKey`) |
+| key       | string   | `"x-finfocus-trace-id"` (constant: `TraceIDMetadataKey`) |
 | values    | []string | Header values (first value used if multiple)               |
 
 ## Data Flow
@@ -83,7 +83,7 @@ Client Request
      ▼
 ┌────────────────────────────────────────┐
 │         gRPC Metadata Headers          │
-│  x-pulumicost-trace-id: <trace_id>     │
+│  x-finfocus-trace-id: <trace_id>     │
 └────────────────┬───────────────────────┘
                  │
                  ▼
@@ -176,6 +176,6 @@ func ValidateTraceID(traceID string) error
 
 | Constant             | Value                     | Package   | Description              |
 | -------------------- | ------------------------- | --------- | ------------------------ |
-| `TraceIDMetadataKey` | `"x-pulumicost-trace-id"` | pluginsdk | gRPC metadata header key |
+| `TraceIDMetadataKey` | `"x-finfocus-trace-id"` | pluginsdk | gRPC metadata header key |
 | `FieldTraceID`       | `"trace_id"`              | pluginsdk | Logging field name       |
-| `traceIDKey`         | `"pulumicost-trace-id"`   | pluginsdk | Context key (private)    |
+| `traceIDKey`         | `"finfocus-trace-id"`   | pluginsdk | Context key (private)    |

--- a/specs/008-trace-id-validation/quickstart.md
+++ b/specs/008-trace-id-validation/quickstart.md
@@ -38,7 +38,7 @@ If you're already using `TracingUnaryServerInterceptor()`, validation is
 automatically enabled when you upgrade the SDK:
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+import "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 
 // Your existing code continues to work unchanged
 server := grpc.NewServer(
@@ -67,7 +67,7 @@ func (s *myPlugin) GetActualCost(ctx context.Context, req *pb.GetActualCostReque
 If you need to generate a trace ID on the client side:
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+import "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 
 // Generate a valid trace ID
 traceID := pluginsdk.GenerateTraceID()
@@ -109,7 +109,7 @@ Without validation, attackers could inject malicious trace IDs:
 
 ```text
 # Malicious input
-x-pulumicost-trace-id: fake\nERROR: System compromised\ntrace_id=
+x-finfocus-trace-id: fake\nERROR: System compromised\ntrace_id=
 
 # Would appear in logs as:
 INFO trace_id=fake
@@ -121,7 +121,7 @@ With validation, the malicious input is replaced:
 
 ```text
 # Same malicious input
-x-pulumicost-trace-id: fake\nERROR: System compromised\ntrace_id=
+x-finfocus-trace-id: fake\nERROR: System compromised\ntrace_id=
 
 # Now appears in logs as:
 INFO trace_id=a1b2c3d4e5f6789012345678abcdef01 processing request

--- a/specs/008-trace-id-validation/spec.md
+++ b/specs/008-trace-id-validation/spec.md
@@ -9,7 +9,7 @@
 
 ### User Story 1 - Secure Trace ID Processing (Priority: P1)
 
-As a plugin developer using the PulumiCost SDK, I want the tracing interceptor to
+As a plugin developer using the FinFocus SDK, I want the tracing interceptor to
 validate incoming trace_id values so that malicious or malformed trace IDs cannot
 cause log injection attacks or corrupt my log aggregation systems.
 

--- a/specs/009-focus-1-2-integration/contracts/enums.proto
+++ b/specs/009-focus-1-2-integration/contracts/enums.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
-option go_package = "github.com/pulumi/pulumicost-spec/sdk/go/pulumicost/v1;pulumicostv1";
+option go_package = "github.com/pulumi/finfocus-spec/sdk/go/finfocus/v1;finfocusv1";
 
 // FocusServiceCategory represents the standard service classifications
 // defined in FinOps FOCUS 1.2.

--- a/specs/009-focus-1-2-integration/contracts/focus.proto
+++ b/specs/009-focus-1-2-integration/contracts/focus.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 import "google/protobuf/timestamp.proto";
-import "pulumicost/v1/enums.proto";
+import "finfocus/v1/enums.proto";
 
-option go_package = "github.com/pulumi/pulumicost-spec/sdk/go/pulumicost/v1;pulumicostv1";
+option go_package = "github.com/pulumi/finfocus-spec/sdk/go/finfocus/v1;finfocusv1";
 
 // FocusCostRecord represents a single cost line item normalized to the
 // FinOps FOCUS 1.2 specification.

--- a/specs/009-focus-1-2-integration/data-model.md
+++ b/specs/009-focus-1-2-integration/data-model.md
@@ -1,6 +1,6 @@
 # Data Model: FinOps FOCUS 1.2 Integration
 
-## Enums (`proto/pulumicost/v1/enums.proto`)
+## Enums (`proto/finfocus/v1/enums.proto`)
 
 ### FocusServiceCategory
 
@@ -40,7 +40,7 @@
 | `PRICING_CATEGORY_DYNAMIC`     | 3     | Spot / Preemptible      |
 | `PRICING_CATEGORY_OTHER`       | 4     | Fallback                |
 
-## Messages (`proto/pulumicost/v1/focus.proto`)
+## Messages (`proto/finfocus/v1/focus.proto`)
 
 ### FocusCostRecord
 

--- a/specs/009-focus-1-2-integration/plan.md
+++ b/specs/009-focus-1-2-integration/plan.md
@@ -7,7 +7,7 @@
 
 ## Technical Context
 
-This feature upgrades the `pulumicost-spec` to align with FinOps FOCUS 1.2 by introducing
+This feature upgrades the `finfocus-spec` to align with FinOps FOCUS 1.2 by introducing
 a new `FocusCostRecord` Protobuf message, standardizing categorization via strict Enums
 (Vocabulary), and implementing a "Backpack & Builder" pattern in the Go SDK.
 
@@ -52,7 +52,7 @@ a new `FocusCostRecord` Protobuf message, standardizing categorization via stric
    - Action: Define Enum values in `enums.proto`.
    - Output: `specs/009-focus-1-2-integration/data-model.md`
 3. **Define Contracts**:
-   - Action: Draft `proto/pulumicost/v1/focus.proto` and `proto/pulumicost/v1/enums.proto`.
+   - Action: Draft `proto/finfocus/v1/focus.proto` and `proto/finfocus/v1/enums.proto`.
    - Output: `specs/009-focus-1-2-integration/contracts/focus.proto`
 
 ## Phase 1: Specification & SDK Core
@@ -60,8 +60,8 @@ a new `FocusCostRecord` Protobuf message, standardizing categorization via stric
 **Goal**: Implement the Protobuf spec and base SDK Builder.
 
 1. **Protobuf Implementation**:
-   - Create `proto/pulumicost/v1/enums.proto` (Vocabularies).
-   - Create `proto/pulumicost/v1/focus.proto` (`FocusCostRecord` message).
+   - Create `proto/finfocus/v1/enums.proto` (Vocabularies).
+   - Create `proto/finfocus/v1/focus.proto` (`FocusCostRecord` message).
    - Run `buf generate` to create Go code.
 2. **SDK Builder Implementation**:
    - Create `sdk/go/pluginsdk/focus_builder.go`.

--- a/specs/009-focus-1-2-integration/quickstart.md
+++ b/specs/009-focus-1-2-integration/quickstart.md
@@ -14,8 +14,8 @@ import (
  "fmt"
  "time"
 
- pb "github.com/pulumi/pulumicost-spec/sdk/go/pulumicost/v1"
- "github.com/pulumi/pulumicost-spec/sdk/go/pluginsdk"
+ pb "github.com/pulumi/finfocus-spec/sdk/go/finfocus/v1"
+ "github.com/pulumi/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func main() {

--- a/specs/009-focus-1-2-integration/spec.md
+++ b/specs/009-focus-1-2-integration/spec.md
@@ -5,10 +5,10 @@
 **Status**: Draft
 **Input**: User description:
 
-> The `pulumicost-spec` currently serves as a high-level query API for cloud costs.
+> The `finfocus-spec` currently serves as a high-level query API for cloud costs.
 > To achieve the project's vision of becoming the universal, open-source standard
 > for cloud cost observability, it must align with the industry-standard FinOps
-> FOCUS 1.2 Specification. Adopting FOCUS 1.2 will transform `pulumicost` from
+> FOCUS 1.2 Specification. Adopting FOCUS 1.2 will transform `finfocus` from
 > a simple cost summarizer into a forensic-grade cost analysis tool. To ensure
 > this is sustainable and upgradeable (e.g., to FOCUS 1.3), we will employ a
 > "Backpack & Builder" strategy to insulate plugin developers from schema complexity.

--- a/specs/009-focus-1-2-integration/tasks.md
+++ b/specs/009-focus-1-2-integration/tasks.md
@@ -7,10 +7,10 @@
 
 **Goal**: Initialize new Protobuf contracts and prepare the project for FOCUS 1.2 integration.
 
-- [x] T001 Create `proto/pulumicost/v1/enums.proto` with Focus Service, Charge, and Pricing enums `specs/009-focus-1-2-integration/contracts/enums.proto`
-- [x] T002 Create `proto/pulumicost/v1/focus.proto` with `FocusCostRecord` message definition `specs/009-focus-1-2-integration/contracts/focus.proto`
-- [x] T003 Update `proto/pulumicost/v1/costsource.proto` to import `enums.proto`
-      and `focus.proto` `proto/pulumicost/v1/costsource.proto`
+- [x] T001 Create `proto/finfocus/v1/enums.proto` with Focus Service, Charge, and Pricing enums `specs/009-focus-1-2-integration/contracts/enums.proto`
+- [x] T002 Create `proto/finfocus/v1/focus.proto` with `FocusCostRecord` message definition `specs/009-focus-1-2-integration/contracts/focus.proto`
+- [x] T003 Update `proto/finfocus/v1/costsource.proto` to import `enums.proto`
+      and `focus.proto` `proto/finfocus/v1/costsource.proto`
 - [x] T004 Run `buf generate` to generate Go SDK code for new protos `Makefile`
 
 ## Phase 2: Foundational

--- a/specs/010-focus-column-audit/contracts/focus_proto_additions.proto
+++ b/specs/010-focus-column-audit/contracts/focus_proto_additions.proto
@@ -1,10 +1,10 @@
 // FOCUS 1.2 Column Audit - Proto Field Additions
 // This file documents the proto field additions required for full FOCUS 1.2 compliance.
-// These definitions should be merged into proto/pulumicost/v1/focus.proto and enums.proto.
+// These definitions should be merged into proto/finfocus/v1/focus.proto and enums.proto.
 
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 // =============================================================================
 // NEW ENUM TYPES (add to enums.proto)

--- a/specs/010-focus-column-audit/data-model.md
+++ b/specs/010-focus-column-audit/data-model.md
@@ -12,7 +12,7 @@ columns and adds 2 new enum types to achieve full FOCUS 1.2 compliance.
 
 ### Current State (38 fields)
 
-The existing `FocusCostRecord` message in `proto/pulumicost/v1/focus.proto` contains
+The existing `FocusCostRecord` message in `proto/finfocus/v1/focus.proto` contains
 38 fields covering 13 of 14 mandatory columns and 24 of 42 conditional columns.
 
 ### Target State (57 fields)

--- a/specs/010-focus-column-audit/plan.md
+++ b/specs/010-focus-column-audit/plan.md
@@ -89,13 +89,13 @@ specs/010-focus-column-audit/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 ├── focus.proto          # Add 19 missing FOCUS columns
 └── enums.proto          # Add new enum types (CommitmentDiscountStatus, etc.)
 
 sdk/go/
 ├── proto/               # Generated protobuf code (via buf generate)
-│   └── pulumicost/v1/
+│   └── finfocus/v1/
 │       ├── focus.pb.go
 │       └── enums.pb.go
 └── pluginsdk/

--- a/specs/010-focus-column-audit/quickstart.md
+++ b/specs/010-focus-column-audit/quickstart.md
@@ -12,7 +12,7 @@ this feature. After implementation, the `FocusCostRecord` message and
 ## Prerequisites
 
 - Go 1.24+
-- pulumicost-spec SDK v0.5.0+ (after this feature is merged)
+- finfocus-spec SDK v0.5.0+ (after this feature is merged)
 
 ## Basic Usage
 
@@ -24,8 +24,8 @@ package main
 import (
     "time"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func main() {

--- a/specs/010-focus-column-audit/spec.md
+++ b/specs/010-focus-column-audit/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `010-focus-column-audit`
 **Created**: 2025-11-28
 **Status**: Draft
-**Input**: User description: "Pulumicost Spec - FinOps FOCUS 1.2 Column Audit"
+**Input**: User description: "FinFocus Spec - FinOps FOCUS 1.2 Column Audit"
 
 ## Clarifications
 
@@ -23,7 +23,7 @@ A plugin developer wants to ensure their FOCUS 1.2 implementation covers all man
 columns defined by the FinOps Foundation, so they can certify their plugin's compliance.
 
 **Why this priority**: Without complete column coverage, plugins cannot claim FOCUS 1.2
-compliance, which is a core value proposition of PulumiCost.
+compliance, which is a core value proposition of FinFocus.
 
 **Independent Test**: Can be verified by comparing the proto definition against the official
 FOCUS 1.2 specification and running an automated audit script.

--- a/specs/010-focus-column-audit/tasks.md
+++ b/specs/010-focus-column-audit/tasks.md
@@ -22,8 +22,8 @@
 
 ## Path Conventions
 
-- **Proto definitions**: `proto/pulumicost/v1/`
-- **Generated code**: `sdk/go/proto/pulumicost/v1/`
+- **Proto definitions**: `proto/finfocus/v1/`
+- **Generated code**: `sdk/go/proto/finfocus/v1/`
 - **SDK code**: `sdk/go/pluginsdk/`
 - **Documentation**: `docs/`, `sdk/go/pluginsdk/README.md`
 - **Examples**: `examples/plugins/`
@@ -49,35 +49,35 @@
 
 ### New Enum Types
 
-- [x] T004 [P] Add `FocusCommitmentDiscountStatus` enum to `proto/pulumicost/v1/enums.proto`
-- [x] T005 [P] Add `FocusCapacityReservationStatus` enum to `proto/pulumicost/v1/enums.proto`
+- [x] T004 [P] Add `FocusCommitmentDiscountStatus` enum to `proto/finfocus/v1/enums.proto`
+- [x] T005 [P] Add `FocusCapacityReservationStatus` enum to `proto/finfocus/v1/enums.proto`
 
 ### Proto Field Additions (19 fields)
 
-- [x] T006 [P] Add `contracted_cost` (field 41) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T007 [P] Add `billing_account_type` (field 42) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T008 [P] Add `sub_account_type` (field 43) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T009 [P] Add `capacity_reservation_id` (field 44) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T010 [P] Add `capacity_reservation_status` (field 45) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T011 [P] Add `commitment_discount_quantity` (field 46) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T012 [P] Add `commitment_discount_status` (field 47) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T013 [P] Add `commitment_discount_type` (field 48) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T014 [P] Add `commitment_discount_unit` (field 49) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T015 [P] Add `contracted_unit_price` (field 50) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T016 [P] Add `pricing_currency` (field 51) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T017 [P] Add `pricing_currency_contracted_unit_price` (field 52) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T018 [P] Add `pricing_currency_effective_cost` (field 53) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T019 [P] Add `pricing_currency_list_unit_price` (field 54) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T020 [P] Add `publisher` (field 55) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T021 [P] Add `service_subcategory` (field 56) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T022 [P] Add `sku_meter` (field 57) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
-- [x] T023 [P] Add `sku_price_details` (field 58) to FocusCostRecord in `proto/pulumicost/v1/focus.proto`
+- [x] T006 [P] Add `contracted_cost` (field 41) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T007 [P] Add `billing_account_type` (field 42) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T008 [P] Add `sub_account_type` (field 43) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T009 [P] Add `capacity_reservation_id` (field 44) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T010 [P] Add `capacity_reservation_status` (field 45) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T011 [P] Add `commitment_discount_quantity` (field 46) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T012 [P] Add `commitment_discount_status` (field 47) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T013 [P] Add `commitment_discount_type` (field 48) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T014 [P] Add `commitment_discount_unit` (field 49) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T015 [P] Add `contracted_unit_price` (field 50) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T016 [P] Add `pricing_currency` (field 51) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T017 [P] Add `pricing_currency_contracted_unit_price` (field 52) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T018 [P] Add `pricing_currency_effective_cost` (field 53) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T019 [P] Add `pricing_currency_list_unit_price` (field 54) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T020 [P] Add `publisher` (field 55) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T021 [P] Add `service_subcategory` (field 56) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T022 [P] Add `sku_meter` (field 57) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
+- [x] T023 [P] Add `sku_price_details` (field 58) to FocusCostRecord in `proto/finfocus/v1/focus.proto`
 
 ### Proto Validation and Generation
 
-- [x] T024 Run `buf lint` to validate proto syntax in `proto/pulumicost/v1/`
+- [x] T024 Run `buf lint` to validate proto syntax in `proto/finfocus/v1/`
 - [x] T025 Run `buf breaking` to confirm backward compatibility
-- [x] T026 Run `make generate` to regenerate Go code in `sdk/go/proto/pulumicost/v1/`
+- [x] T026 Run `make generate` to regenerate Go code in `sdk/go/proto/finfocus/v1/`
 - [x] T027 Run `go build ./...` to verify generated code compiles
 
 **Checkpoint**: Proto definitions complete - SDK implementation can now begin
@@ -98,8 +98,8 @@
 ### Implementation for User Story 1
 
 - [x] T030 [US1] Create audit script `scripts/audit_focus_columns.go` to verify column coverage
-- [x] T031 [US1] Add FOCUS section reference comments to all 19 new fields in `proto/pulumicost/v1/focus.proto`
-- [x] T032 [US1] Add FOCUS section reference comments to new enums in `proto/pulumicost/v1/enums.proto`
+- [x] T031 [US1] Add FOCUS section reference comments to all 19 new fields in `proto/finfocus/v1/focus.proto`
+- [x] T032 [US1] Add FOCUS section reference comments to new enums in `proto/finfocus/v1/enums.proto`
 - [x] T033 [US1] Run audit script and verify 57/57 columns pass
 
 **Checkpoint**: All 57 FOCUS 1.2 columns verified in proto with correct types

--- a/specs/010-plugin-conformance-suite/plan.md
+++ b/specs/010-plugin-conformance-suite/plan.md
@@ -7,7 +7,7 @@
 
 Formalize and extend the existing `sdk/go/testing/` framework into a documented Plugin Conformance
 Test Suite. The suite will be a Go library that plugin authors import to validate their
-implementations against the pulumicost-spec at three conformance levels (Basic, Standard, Advanced)
+implementations against the finfocus-spec at three conformance levels (Basic, Standard, Advanced)
 with structured JSON output for CI/CD integration.
 
 ## Technical Context

--- a/specs/010-plugin-conformance-suite/quickstart.md
+++ b/specs/010-plugin-conformance-suite/quickstart.md
@@ -5,7 +5,7 @@
 ## Overview
 
 The Plugin Conformance Test Suite validates that your CostSource plugin implementation meets the
-pulumicost-spec requirements. Run these tests to ensure your plugin is ready for production
+finfocus-spec requirements. Run these tests to ensure your plugin is ready for production
 deployment.
 
 ## Installation
@@ -13,7 +13,7 @@ deployment.
 Add the testing package to your plugin's test dependencies:
 
 ```bash
-go get github.com/rshade/pulumicost-spec/sdk/go/testing
+go get github.com/rshade/finfocus-spec/sdk/go/testing
 ```
 
 ## Basic Usage (< 10 lines)
@@ -24,7 +24,7 @@ package myplugin_test
 import (
     "testing"
 
-    plugintesting "github.com/rshade/pulumicost-spec/sdk/go/testing"
+    plugintesting "github.com/rshade/finfocus-spec/sdk/go/testing"
     "github.com/yourorg/myplugin"
 )
 

--- a/specs/010-plugin-conformance-suite/spec.md
+++ b/specs/010-plugin-conformance-suite/spec.md
@@ -11,7 +11,7 @@
 
 As a plugin developer, I want to run automated tests that verify my plugin's `GetPricingSpec`
 response is valid, schema-compliant, and uses correct enums and data formats, so that I can be
-confident my plugin integrates correctly with the PulumiCost ecosystem.
+confident my plugin integrates correctly with the FinFocus ecosystem.
 
 **Why this priority**: Specification compliance is the foundation of plugin interoperability.
 Without valid responses, plugins cannot integrate with the core system at all. This is the most

--- a/specs/011-pluginsdk-conformance/contracts/README.md
+++ b/specs/011-pluginsdk-conformance/contracts/README.md
@@ -19,7 +19,7 @@ Go SDK utilities that wrap existing functionality.
 
 The adapter functions delegate to existing contracts:
 
-- **Proto Contract**: `proto/pulumicost/v1/costsource.proto` (unchanged)
+- **Proto Contract**: `proto/finfocus/v1/costsource.proto` (unchanged)
 - **Testing Contract**: `sdk/go/testing/conformance.go` function signatures (consumed)
 
 ## Go API Contract (Documentation)

--- a/specs/011-pluginsdk-conformance/quickstart.md
+++ b/specs/011-pluginsdk-conformance/quickstart.md
@@ -6,13 +6,13 @@
 ## Overview
 
 This guide shows how to use the conformance testing adapter functions to validate your
-`pluginsdk.Plugin` implementation against the PulumiCost specification.
+`pluginsdk.Plugin` implementation against the FinFocus specification.
 
 ## Prerequisites
 
 - Go 1.20 or later
 - A plugin implementing `pluginsdk.Plugin` interface
-- Import: `github.com/rshade/pulumicost-spec/sdk/go/pluginsdk`
+- Import: `github.com/rshade/finfocus-spec/sdk/go/pluginsdk`
 
 ## Basic Usage
 
@@ -26,7 +26,7 @@ package myplugin_test
 import (
     "testing"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func TestPluginBasicConformance(t *testing.T) {
@@ -96,7 +96,7 @@ package myplugin_test
 import (
     "testing"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 // TestConformance runs the full conformance suite
@@ -184,7 +184,7 @@ If you were previously using `sdk/go/testing` directly:
 **Before** (manual conversion):
 
 ```go
-import plugintesting "github.com/rshade/pulumicost-spec/sdk/go/testing"
+import plugintesting "github.com/rshade/finfocus-spec/sdk/go/testing"
 
 plugin := NewMyPlugin()
 server := pluginsdk.NewServer(plugin)  // Manual conversion
@@ -194,7 +194,7 @@ result, err := plugintesting.RunStandardConformance(server)
 **After** (using adapters):
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+import "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 
 plugin := NewMyPlugin()
 result, err := pluginsdk.RunStandardConformance(plugin)  // Direct!

--- a/specs/011-pluginsdk-conformance/spec.md
+++ b/specs/011-pluginsdk-conformance/spec.md
@@ -11,7 +11,7 @@
 
 As a plugin developer using the `pluginsdk.Plugin` interface, I want to run basic conformance tests
 against my plugin implementation with a single function call, so that I can validate my plugin meets
-minimum PulumiCost specification requirements without manually converting to the raw gRPC interface.
+minimum FinFocus specification requirements without manually converting to the raw gRPC interface.
 
 **Why this priority**: This is the core value proposition. Plugin developers using the high-level
 `Plugin` interface should not need to understand the underlying gRPC conversion to run conformance

--- a/specs/012-iso4217-currency/quickstart.md
+++ b/specs/012-iso4217-currency/quickstart.md
@@ -1,11 +1,11 @@
 # Quickstart: ISO 4217 Currency Package
 
-**Package**: `github.com/rshade/pulumicost-spec/sdk/go/currency`
+**Package**: `github.com/rshade/finfocus-spec/sdk/go/currency`
 
 ## Installation
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/currency"
+import "github.com/rshade/finfocus-spec/sdk/go/currency"
 ```
 
 ## Basic Usage
@@ -17,7 +17,7 @@ package main
 
 import (
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/currency"
+    "github.com/rshade/finfocus-spec/sdk/go/currency"
 )
 
 func main() {
@@ -45,7 +45,7 @@ package main
 
 import (
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/currency"
+    "github.com/rshade/finfocus-spec/sdk/go/currency"
 )
 
 func main() {
@@ -77,7 +77,7 @@ package main
 
 import (
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/currency"
+    "github.com/rshade/finfocus-spec/sdk/go/currency"
 )
 
 func main() {
@@ -103,7 +103,7 @@ package pluginsdk
 
 import (
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/currency"
+    "github.com/rshade/finfocus-spec/sdk/go/currency"
 )
 
 // validateCurrency checks if a currency code is a valid ISO 4217 code.
@@ -125,7 +125,7 @@ package main
 
 import (
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/currency"
+    "github.com/rshade/finfocus-spec/sdk/go/currency"
 )
 
 func formatAmount(amount float64, currencyCode string) string {
@@ -153,7 +153,7 @@ package main
 import (
     "errors"
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/currency"
+    "github.com/rshade/finfocus-spec/sdk/go/currency"
 )
 
 func main() {

--- a/specs/012-iso4217-currency/spec.md
+++ b/specs/012-iso4217-currency/spec.md
@@ -79,7 +79,7 @@ all expected ISO 4217 currencies (180+ codes).
 
 ### User Story 4 - Migrate Existing Validation (Priority: P4)
 
-As a maintainer of the PulumiCost SDK, I need the existing `focus_conformance.go` to use the new
+As a maintainer of the FinFocus SDK, I need the existing `focus_conformance.go` to use the new
 currency package so that validation logic is centralized and maintainable.
 
 **Why this priority**: This is a refactoring task that depends on the new package being complete.

--- a/specs/013-plugin-metrics/contracts/metrics.go.design
+++ b/specs/013-plugin-metrics/contracts/metrics.go.design
@@ -20,8 +20,8 @@ import (
 // Prometheus metrics for each unary RPC call.
 //
 // The interceptor records:
-//   - pulumicost_plugin_requests_total: Counter with labels grpc_method, grpc_code, plugin_name
-//   - pulumicost_plugin_request_duration_seconds: Histogram with labels grpc_method, plugin_name
+//   - finfocus_plugin_requests_total: Counter with labels grpc_method, grpc_code, plugin_name
+//   - finfocus_plugin_request_duration_seconds: Histogram with labels grpc_method, plugin_name
 //
 // Parameters:
 //   - pluginName: Identifier for the plugin, used as the plugin_name label value
@@ -124,7 +124,7 @@ func StartMetricsServer(config MetricsServerConfig) (*http.Server, error)
 
 const (
 	// MetricNamespace is the Prometheus namespace for all plugin metrics.
-	MetricNamespace = "pulumicost"
+	MetricNamespace = "finfocus"
 
 	// MetricSubsystem is the Prometheus subsystem for plugin metrics.
 	MetricSubsystem = "plugin"

--- a/specs/013-plugin-metrics/data-model.md
+++ b/specs/013-plugin-metrics/data-model.md
@@ -14,7 +14,7 @@ consists of metric types, their labels, and configuration structures.
 
 Tracks total gRPC requests received by the plugin.
 
-**Metric Name**: `pulumicost_plugin_requests_total`
+**Metric Name**: `finfocus_plugin_requests_total`
 
 **Fields/Labels**:
 
@@ -40,7 +40,7 @@ Tracks total gRPC requests received by the plugin.
 
 Tracks request latency distribution.
 
-**Metric Name**: `pulumicost_plugin_request_duration_seconds`
+**Metric Name**: `finfocus_plugin_request_duration_seconds`
 
 **Fields/Labels**:
 

--- a/specs/013-plugin-metrics/quickstart.md
+++ b/specs/013-plugin-metrics/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart: Plugin Metrics
 
-This guide shows how to add Prometheus metrics to your PulumiCost plugin in under 5 minutes.
+This guide shows how to add Prometheus metrics to your FinFocus plugin in under 5 minutes.
 
 ## Basic Usage (Recommended)
 
@@ -10,7 +10,7 @@ Add the metrics interceptor to your plugin's server configuration:
 package main
 
 import (
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
     "google.golang.org/grpc"
 )
 
@@ -72,22 +72,22 @@ After enabling, you'll see these metrics at `/metrics`:
 ### Request Counter
 
 ```text
-# HELP pulumicost_plugin_requests_total Total gRPC requests
-# TYPE pulumicost_plugin_requests_total counter
-pulumicost_plugin_requests_total{grpc_method="GetProjectedCost",grpc_code="OK",plugin_name="my-plugin"} 42
-pulumicost_plugin_requests_total{grpc_method="GetProjectedCost",grpc_code="Internal",plugin_name="my-plugin"} 3
+# HELP finfocus_plugin_requests_total Total gRPC requests
+# TYPE finfocus_plugin_requests_total counter
+finfocus_plugin_requests_total{grpc_method="GetProjectedCost",grpc_code="OK",plugin_name="my-plugin"} 42
+finfocus_plugin_requests_total{grpc_method="GetProjectedCost",grpc_code="Internal",plugin_name="my-plugin"} 3
 ```
 
 ### Request Duration
 
 ```text
-# HELP pulumicost_plugin_request_duration_seconds Request duration histogram
-# TYPE pulumicost_plugin_request_duration_seconds histogram
-pulumicost_plugin_request_duration_seconds_bucket{grpc_method="GetProjectedCost",plugin_name="my-plugin",le="0.005"} 10
-pulumicost_plugin_request_duration_seconds_bucket{grpc_method="GetProjectedCost",plugin_name="my-plugin",le="0.01"} 25
+# HELP finfocus_plugin_request_duration_seconds Request duration histogram
+# TYPE finfocus_plugin_request_duration_seconds histogram
+finfocus_plugin_request_duration_seconds_bucket{grpc_method="GetProjectedCost",plugin_name="my-plugin",le="0.005"} 10
+finfocus_plugin_request_duration_seconds_bucket{grpc_method="GetProjectedCost",plugin_name="my-plugin",le="0.01"} 25
 ...
-pulumicost_plugin_request_duration_seconds_sum{grpc_method="GetProjectedCost",plugin_name="my-plugin"} 1.234
-pulumicost_plugin_request_duration_seconds_count{grpc_method="GetProjectedCost",plugin_name="my-plugin"} 45
+finfocus_plugin_request_duration_seconds_sum{grpc_method="GetProjectedCost",plugin_name="my-plugin"} 1.234
+finfocus_plugin_request_duration_seconds_count{grpc_method="GetProjectedCost",plugin_name="my-plugin"} 45
 ```
 
 ## Prometheus Configuration
@@ -96,7 +96,7 @@ Add to your `prometheus.yml`:
 
 ```yaml
 scrape_configs:
-  - job_name: 'pulumicost-plugins'
+  - job_name: 'finfocus-plugins'
     static_configs:
       - targets: ['localhost:9090']
 ```
@@ -106,20 +106,20 @@ scrape_configs:
 ### Request Rate by Method
 
 ```promql
-sum(rate(pulumicost_plugin_requests_total[5m])) by (grpc_method)
+sum(rate(finfocus_plugin_requests_total[5m])) by (grpc_method)
 ```
 
 ### Error Rate
 
 ```promql
-sum(rate(pulumicost_plugin_requests_total{grpc_code!="OK"}[5m]))
-/ sum(rate(pulumicost_plugin_requests_total[5m]))
+sum(rate(finfocus_plugin_requests_total{grpc_code!="OK"}[5m]))
+/ sum(rate(finfocus_plugin_requests_total[5m]))
 ```
 
 ### P99 Latency
 
 ```promql
-histogram_quantile(0.99, sum(rate(pulumicost_plugin_request_duration_seconds_bucket[5m])) by (le, grpc_method))
+histogram_quantile(0.99, sum(rate(finfocus_plugin_request_duration_seconds_bucket[5m])) by (le, grpc_method))
 ```
 
 ## Complete Example
@@ -134,7 +134,7 @@ import (
     "os/signal"
     "syscall"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
     "google.golang.org/grpc"
 )
 

--- a/specs/013-plugin-metrics/research.md
+++ b/specs/013-plugin-metrics/research.md
@@ -26,7 +26,7 @@
 ```go
 reg := prometheus.NewRegistry()
 counter := prometheus.NewCounterVec(prometheus.CounterOpts{
-    Name: "pulumicost_plugin_requests_total",
+    Name: "finfocus_plugin_requests_total",
     Help: "Total gRPC requests",
 }, []string{"grpc_method", "grpc_code", "plugin_name"})
 reg.MustRegister(counter)
@@ -45,7 +45,7 @@ reg.MustRegister(counter)
 - Well-established patterns from [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus)
 - Standard labels: `grpc_method`, `grpc_code` are industry conventions
 - Interceptor pattern integrates cleanly with existing `TracingUnaryServerInterceptor`
-- Unary interceptor sufficient (PulumiCost uses unary RPCs only)
+- Unary interceptor sufficient (FinFocus uses unary RPCs only)
 
 **Alternatives Considered**:
 
@@ -101,7 +101,7 @@ func MetricsUnaryServerInterceptor(pluginName string) grpc.UnaryServerIntercepto
 var defaultBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0}
 
 requestDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-    Name:    "pulumicost_plugin_request_duration_seconds",
+    Name:    "finfocus_plugin_request_duration_seconds",
     Help:    "Request duration histogram",
     Buckets: defaultBuckets,
 }, []string{"grpc_method", "plugin_name"})

--- a/specs/013-plugin-metrics/spec.md
+++ b/specs/013-plugin-metrics/spec.md
@@ -97,7 +97,7 @@ histogram shows distinct latency data per method label.
   (TracingUnaryServerInterceptor and custom interceptors).
 - **FR-006**: System MUST record metrics for all outcomes including successful responses, errors,
   and panics.
-- **FR-007**: System MUST use consistent metric naming with the `pulumicost_plugin_` prefix for all
+- **FR-007**: System MUST use consistent metric naming with the `finfocus_plugin_` prefix for all
   metrics.
 - **FR-008**: System MUST record accurate latency measurements from request start to response
   completion.

--- a/specs/014-recommendations-rpc/contracts/recommendations.proto
+++ b/specs/014-recommendations-rpc/contracts/recommendations.proto
@@ -4,7 +4,7 @@
 
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 import "google/protobuf/timestamp.proto";
 

--- a/specs/014-recommendations-rpc/plan.md
+++ b/specs/014-recommendations-rpc/plan.md
@@ -59,7 +59,7 @@ specs/013-recommendations-rpc/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 └── costsource.proto     # Add GetRecommendations RPC + all recommendation messages
                          # (single-file approach per research.md decision)
 

--- a/specs/014-recommendations-rpc/quickstart.md
+++ b/specs/014-recommendations-rpc/quickstart.md
@@ -4,15 +4,15 @@
 
 ## Overview
 
-This guide shows how to implement the `GetRecommendations` RPC in a PulumiCost plugin.
+This guide shows how to implement the `GetRecommendations` RPC in a FinFocus plugin.
 The implementation is optional - plugins that don't support recommendations simply don't
 implement the `RecommendationsProvider` interface.
 
 ## Prerequisites
 
 - Go 1.25.4+
-- Existing PulumiCost plugin implementation
-- `pulumicost-spec` SDK imported
+- Existing FinFocus plugin implementation
+- `finfocus-spec` SDK imported
 
 ## Step 1: Implement the RecommendationsProvider Interface
 
@@ -22,10 +22,10 @@ package myplugin
 import (
     "context"
 
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
-// MyPlugin implements the PulumiCost Plugin interface
+// MyPlugin implements the FinFocus Plugin interface
 type MyPlugin struct {
     // ... existing fields ...
 }
@@ -196,8 +196,8 @@ config := pluginsdk.ServeConfig{
 
 The interceptor automatically records:
 
-- `pulumicost_plugin_requests_total{grpc_method="...",grpc_code="...",plugin_name="..."}`
-- `pulumicost_plugin_request_duration_seconds{grpc_method="...",plugin_name="..."}`
+- `finfocus_plugin_requests_total{grpc_method="...",grpc_code="...",plugin_name="..."}`
+- `finfocus_plugin_request_duration_seconds{grpc_method="...",plugin_name="..."}`
 
 ## Step 5: Test with Conformance Suite
 

--- a/specs/014-recommendations-rpc/research.md
+++ b/specs/014-recommendations-rpc/research.md
@@ -81,14 +81,14 @@ type RecommendationsProvider interface {
 
 - Existing `MetricsUnaryServerInterceptor` automatically captures request count and duration
 - Add recommendation-specific counter for items returned per response
-- Follow existing metric naming: `pulumicost_plugin_*`
+- Follow existing metric naming: `finfocus_plugin_*`
 
 **New Metrics**:
 
 ```go
 // In addition to automatic request_total and request_duration:
-pulumicost_plugin_recommendations_returned_total  // Counter: total recommendations
-pulumicost_plugin_recommendations_per_response    // Histogram: recommendations per call
+finfocus_plugin_recommendations_returned_total  // Counter: total recommendations
+finfocus_plugin_recommendations_per_response    // Histogram: recommendations per call
 ```
 
 **Alternatives Considered**:

--- a/specs/014-recommendations-rpc/spec.md
+++ b/specs/014-recommendations-rpc/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `013-recommendations-rpc`
 **Created**: 2025-12-04
 **Status**: Draft
-**GitHub Issue**: [#122](https://github.com/rshade/pulumicost-spec/issues/122)
+**GitHub Issue**: [#122](https://github.com/rshade/finfocus-spec/issues/122)
 **Input**: Add GetRecommendations RPC to CostSourceService for FinOps recommendations
 
 ## Overview
@@ -26,7 +26,7 @@ actionable optimization opportunities to users.
 
 ### User Story 1 - Retrieve All Recommendations (Priority: P1)
 
-As a DevOps engineer using PulumiCost, I want to retrieve all cost optimization recommendations
+As a DevOps engineer using FinFocus, I want to retrieve all cost optimization recommendations
 from my connected cost sources so that I can identify opportunities to reduce cloud spending.
 
 **Why this priority**: This is the core functionality - without the ability to retrieve
@@ -253,7 +253,7 @@ correctly for each recommendation type.
 
 ## Out of Scope
 
-- CLI output formatting (follow-up in pulumicost-core)
+- CLI output formatting (follow-up in finfocus-core)
 - Aggregation logic for combining recommendations from multiple plugins
 - Caching of recommendations
 - State management for tracking applied/dismissed recommendations

--- a/specs/014-recommendations-rpc/tasks.md
+++ b/specs/014-recommendations-rpc/tasks.md
@@ -18,7 +18,7 @@ testing of each story.
 
 Based on plan.md project structure:
 
-- **Proto**: `proto/pulumicost/v1/costsource.proto`
+- **Proto**: `proto/finfocus/v1/costsource.proto`
 - **SDK**: `sdk/go/proto/`, `sdk/go/pluginsdk/`, `sdk/go/testing/`
 - **Examples**: `examples/recommendations/`
 
@@ -42,63 +42,63 @@ Based on plan.md project structure:
 
 ### Proto Definitions
 
-- [ ] T010 Add RecommendationCategory enum to proto/pulumicost/v1/costsource.proto (values:
+- [ ] T010 Add RecommendationCategory enum to proto/finfocus/v1/costsource.proto (values:
       UNSPECIFIED, COST, PERFORMANCE, SECURITY, RELIABILITY)
-- [ ] T011 [P] Add RecommendationActionType enum to proto/pulumicost/v1/costsource.proto
+- [ ] T011 [P] Add RecommendationActionType enum to proto/finfocus/v1/costsource.proto
       (values: UNSPECIFIED, RIGHTSIZE, TERMINATE, PURCHASE_COMMITMENT, ADJUST_REQUESTS, MODIFY,
       DELETE_UNUSED)
-- [ ] T012 [P] Add RecommendationPriority enum to proto/pulumicost/v1/costsource.proto
+- [ ] T012 [P] Add RecommendationPriority enum to proto/finfocus/v1/costsource.proto
       (values: UNSPECIFIED, LOW, MEDIUM, HIGH, CRITICAL)
-- [ ] T013 Add ResourceUtilization message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T013 Add ResourceUtilization message to proto/finfocus/v1/costsource.proto (fields:
       cpu_percent, memory_percent, storage_percent, network_in_mbps, network_out_mbps,
       custom_metrics)
-- [ ] T014 [P] Add ResourceRecommendationInfo message to proto/pulumicost/v1/costsource.proto
+- [ ] T014 [P] Add ResourceRecommendationInfo message to proto/finfocus/v1/costsource.proto
       (fields: id, name, provider, resource_type, region, sku, tags, utilization)
-- [ ] T015 Add RecommendationImpact message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T015 Add RecommendationImpact message to proto/finfocus/v1/costsource.proto (fields:
       estimated_savings, currency, projection_period, current_cost, projected_cost,
       savings_percentage, implementation_cost, migration_effort_hours)
-- [ ] T016 Add RecommendationSummary message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T016 Add RecommendationSummary message to proto/finfocus/v1/costsource.proto (fields:
       total_recommendations, total_estimated_savings, currency, projection_period,
       count_by_category, savings_by_category, count_by_action_type, savings_by_action_type)
 
 ### Action Detail Messages
 
-- [ ] T017 Add RightsizeAction message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T017 Add RightsizeAction message to proto/finfocus/v1/costsource.proto (fields:
       current_sku, recommended_sku, current_instance_type, recommended_instance_type,
       projected_utilization)
-- [ ] T018 [P] Add TerminateAction message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T018 [P] Add TerminateAction message to proto/finfocus/v1/costsource.proto (fields:
       termination_reason, idle_days)
-- [ ] T019 [P] Add CommitmentAction message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T019 [P] Add CommitmentAction message to proto/finfocus/v1/costsource.proto (fields:
       commitment_type, term, payment_option, recommended_quantity, scope)
-- [ ] T020 [P] Add KubernetesResources message to proto/pulumicost/v1/costsource.proto
+- [ ] T020 [P] Add KubernetesResources message to proto/finfocus/v1/costsource.proto
       (fields: cpu, memory)
-- [ ] T021 Add KubernetesAction message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T021 Add KubernetesAction message to proto/finfocus/v1/costsource.proto (fields:
       cluster_id, namespace, controller_kind, controller_name, container_name, current_requests,
       recommended_requests, current_limits, recommended_limits, algorithm) - depends on T020
-- [ ] T022 [P] Add ModifyAction message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T022 [P] Add ModifyAction message to proto/finfocus/v1/costsource.proto (fields:
       modification_type, current_config, recommended_config)
 
 ### Core Recommendation Message
 
 - [ ] T023 Add Recommendation message with oneof action_detail to
-      proto/pulumicost/v1/costsource.proto (all fields from data-model.md including oneof for
+      proto/finfocus/v1/costsource.proto (all fields from data-model.md including oneof for
       rightsize, terminate, commitment, kubernetes, modify) - depends on T010-T022
 
 ### Request/Response Messages
 
-- [ ] T024 Add RecommendationFilter message to proto/pulumicost/v1/costsource.proto (fields:
+- [ ] T024 Add RecommendationFilter message to proto/finfocus/v1/costsource.proto (fields:
       provider, region, resource_type, category, action_type)
-- [ ] T025 Add GetRecommendationsRequest message to proto/pulumicost/v1/costsource.proto
+- [ ] T025 Add GetRecommendationsRequest message to proto/finfocus/v1/costsource.proto
       (fields: filter, projection_period, page_size, page_token) - depends on T024
-- [ ] T026 Add GetRecommendationsResponse message to proto/pulumicost/v1/costsource.proto
+- [ ] T026 Add GetRecommendationsResponse message to proto/finfocus/v1/costsource.proto
       (fields: recommendations, summary, next_page_token) - depends on T023, T016
 
 ### Service Method
 
 - [ ] T027 Add GetRecommendations RPC method to CostSourceService in
-      proto/pulumicost/v1/costsource.proto - depends on T025, T026
+      proto/finfocus/v1/costsource.proto - depends on T025, T026
 - [ ] T028 Add capabilities field (map<string, bool>) to SupportsResponse message in
-      proto/pulumicost/v1/costsource.proto
+      proto/finfocus/v1/costsource.proto
 
 ### Code Generation
 
@@ -306,8 +306,8 @@ recommendation type
 ### Prometheus Metrics
 
 - [ ] T092 Add recommendations-specific metrics in sdk/go/pluginsdk/metrics.go
-      (pulumicost_plugin_recommendations_returned_total counter,
-      pulumicost_plugin_recommendations_per_response histogram)
+      (finfocus_plugin_recommendations_returned_total counter,
+      finfocus_plugin_recommendations_per_response histogram)
 - [ ] T093 Add GetRecommendations metrics recording in MetricsUnaryServerInterceptor
 
 ### Tracing

--- a/specs/015-fallback-hint/contracts/costsource.proto
+++ b/specs/015-fallback-hint/contracts/costsource.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
-option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto;pbc";
+option go_package = "github.com/rshade/finfocus-spec/sdk/go/proto;pbc";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/struct.proto";
-import "pulumicost/v1/focus.proto";
+import "finfocus/v1/focus.proto";
 
 // CostSourceService provides gRPC interface for cost source plugins to implement.
 // This service defines the contract for retrieving actual costs, projected costs,

--- a/specs/015-fallback-hint/plan.md
+++ b/specs/015-fallback-hint/plan.md
@@ -58,7 +58,7 @@ specs/001-fallback-hint/
 
 ```text
 proto/
-└── pulumicost/
+└── finfocus/
     └── v1/
         └── costsource.proto  # Primary modification target
 

--- a/specs/015-fallback-hint/quickstart.md
+++ b/specs/015-fallback-hint/quickstart.md
@@ -10,10 +10,10 @@ for a specific resource.
 
 ### 1. Regenerate SDK
 
-Ensure your plugin is using the latest `pulumicost` SDK (v1.x.x).
+Ensure your plugin is using the latest `finfocus` SDK (v1.x.x).
 
 ```bash
-go get github.com/rshade/pulumicost-spec/sdk/go@latest
+go get github.com/rshade/finfocus-spec/sdk/go@latest
 ```
 
 ### 2. Using Functional Options

--- a/specs/015-fallback-hint/tasks.md
+++ b/specs/015-fallback-hint/tasks.md
@@ -15,7 +15,7 @@
 
 ## Path Conventions
 
-- **Proto definition**: `proto/pulumicost/v1/costsource.proto`
+- **Proto definition**: `proto/finfocus/v1/costsource.proto`
 - **SDK helpers**: `sdk/go/pluginsdk/`
 - **Generated code**: `sdk/go/proto/` (regenerated, do not edit manually)
 - **Spec contracts**: `specs/001-fallback-hint/contracts/costsource.proto`
@@ -38,9 +38,9 @@
 
 **⚠️ CRITICAL**: No SDK or user story work can begin until proto changes are complete and regenerated
 
-- [x] T003 Add FallbackHint enum to proto/pulumicost/v1/costsource.proto with four values
+- [x] T003 Add FallbackHint enum to proto/finfocus/v1/costsource.proto with four values
 - [x] T004 Add fallback_hint field to GetActualCostResponse message in
-      proto/pulumicost/v1/costsource.proto
+      proto/finfocus/v1/costsource.proto
 - [x] T005 Run `make generate` to regenerate Go bindings in sdk/go/proto/
 - [x] T006 Run `buf lint` to validate proto changes
 - [x] T007 Verify generated code compiles with `go build ./...`

--- a/specs/016-pluginsdk-env/checklists/requirements.md
+++ b/specs/016-pluginsdk-env/checklists/requirements.md
@@ -32,9 +32,9 @@
 
 ## Cross-Repository Analysis
 
-- [x] Reviewed pulumicost-core environment variable usage
-- [x] Reviewed pulumicost-plugin-aws-public environment variable usage
-- [x] Reviewed pulumicost-plugin-aws-ce environment variable usage
+- [x] Reviewed finfocus-core environment variable usage
+- [x] Reviewed finfocus-plugin-aws-public environment variable usage
+- [x] Reviewed finfocus-plugin-aws-ce environment variable usage
 - [x] Documented variables used consistently across repos
 - [x] Documented variables requiring migration
 - [x] Documented core-only variables excluded from plugin SDK

--- a/specs/016-pluginsdk-env/plan.md
+++ b/specs/016-pluginsdk-env/plan.md
@@ -26,7 +26,7 @@ that implement canonical-first, fallback-second reading pattern using Go stdlib 
 **Project Type**: Single Go module (SDK library)
 **Performance Goals**: N/A (simple env var reads, ~nanosecond operations)
 **Constraints**: Must maintain 100% backward compatibility with `LOG_LEVEL` (no PORT fallback)
-**Scale/Scope**: Used by all PulumiCost plugins (3+ repos currently)
+**Scale/Scope**: Used by all FinFocus plugins (3+ repos currently)
 
 ## Constitution Check
 

--- a/specs/016-pluginsdk-env/quickstart.md
+++ b/specs/016-pluginsdk-env/quickstart.md
@@ -5,7 +5,7 @@
 ## Overview
 
 This feature adds centralized environment variable handling to the `pluginsdk` package,
-providing a standardized way for PulumiCost plugins to read configuration from the
+providing a standardized way for FinFocus plugins to read configuration from the
 environment.
 
 ## Installation
@@ -14,7 +14,7 @@ The environment handling is part of the existing `pluginsdk` package. No additio
 installation required:
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+import "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 ```
 
 ## Basic Usage
@@ -26,7 +26,7 @@ package main
 
 import (
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func main() {

--- a/specs/016-pluginsdk-env/research.md
+++ b/specs/016-pluginsdk-env/research.md
@@ -66,7 +66,7 @@ as PORT. Supporting fallback enables gradual migration of existing plugins.
 
 **Decision**: Use strict `"true"`/`"false"` string matching with warning logging
 
-**Rationale**: Follows existing pattern in `pulumicost-plugin-aws-public/internal/plugin
+**Rationale**: Follows existing pattern in `finfocus-plugin-aws-public/internal/plugin
 /testmode.go`. Strict matching prevents accidental test mode activation from typos like
 `"yes"` or `"1"`.
 
@@ -128,7 +128,7 @@ func resolvePort(requested int) (int, error) {
 - Logs to stderr on parse error
 - Will be modified to use `GetPort()` which adds canonical variable
 
-### Existing Test Mode Pattern (`pulumicost-plugin-aws-public`)
+### Existing Test Mode Pattern (`finfocus-plugin-aws-public`)
 
 ```go
 const testModeEnvVar = "PULUMICOST_TEST_MODE"
@@ -147,7 +147,7 @@ func ValidateTestModeEnv() {
 
 **Analysis**: This pattern will be adopted in the SDK with minor modifications.
 
-### Logging Pattern (`pulumicost-core`)
+### Logging Pattern (`finfocus-core`)
 
 Uses `zerolog` for structured logging. The SDK already imports zerolog (see `sdk.go:12`).
 
@@ -155,7 +155,7 @@ Uses `zerolog` for structured logging. The SDK already imports zerolog (see `sdk
 
 ### Environment Variable Constants
 
-All constants follow the `PULUMICOST_` prefix convention established by pulumicost-core:
+All constants follow the `PULUMICOST_` prefix convention established by finfocus-core:
 
 | Constant | Value | Type |
 |----------|-------|------|

--- a/specs/016-pluginsdk-env/spec.md
+++ b/specs/016-pluginsdk-env/spec.md
@@ -16,13 +16,13 @@
 
 ### User Story 1 - Plugin Developer Uses Standard Port Configuration (Priority: P1)
 
-A plugin developer building a new PulumiCost plugin needs their plugin to automatically bind to
+A plugin developer building a new FinFocus plugin needs their plugin to automatically bind to
 the correct gRPC port. They set `PULUMICOST_PLUGIN_PORT=8080` in their environment and their
 plugin correctly binds to port 8080 without any code changes.
 
 **Why this priority**: This is the core problem that caused E2E testing failures. Plugin port
 configuration must work consistently across all plugins to enable reliable plugin orchestration
-by pulumicost-core.
+by finfocus-core.
 
 **Independent Test**: Can be fully tested by setting `PULUMICOST_PLUGIN_PORT=8080`, starting a
 plugin, and verifying it binds to port 8080. Delivers immediate value by fixing the port
@@ -156,7 +156,7 @@ calling `pluginsdk.GetLogLevel()`, and verifying it returns "debug".
 
 #### Port Configuration
 
-- **FR-001**: Plugin SDK MUST provide exported constants for all standard PulumiCost
+- **FR-001**: Plugin SDK MUST provide exported constants for all standard FinFocus
   environment variable names
 - **FR-002**: Plugin SDK MUST provide a `GetPort()` function that reads
   `PULUMICOST_PLUGIN_PORT` only (no fallback to PORT)
@@ -214,7 +214,7 @@ calling `pluginsdk.GetLogLevel()`, and verifying it returns "debug".
   `PULUMICOST_PLUGIN_PORT` on first attempt
 - **SC-002**: Plugin developers can configure all standard environment variables by
   referencing a single source of truth in `pluginsdk/env.go`
-- **SC-003**: E2E tests between pulumicost-core and plugins pass when core sets
+- **SC-003**: E2E tests between finfocus-core and plugins pass when core sets
   `PULUMICOST_PLUGIN_PORT` (fixing the original issue)
 - **SC-004**: Documentation clearly shows plugin developers how to use environment
   configuration functions
@@ -229,12 +229,12 @@ calling `pluginsdk.GetLogLevel()`, and verifying it returns "debug".
 - Port validation beyond positive integer check is delegated to the network layer
 - Log level and format values are passed through as strings; semantic validation is the
   plugin's responsibility
-- Test mode validation (strict "true"/"false") follows the pattern in pulumicost-plugin-
+- Test mode validation (strict "true"/"false") follows the pattern in finfocus-plugin-
   aws-public
 
 ## Cross-Repository Consistency Notes
 
-Based on analysis of pulumicost-core, pulumicost-plugin-aws-public, and pulumicost-plugin-
+Based on analysis of finfocus-core, finfocus-plugin-aws-public, and finfocus-plugin-
 aws-ce:
 
 ### Variables Used Consistently
@@ -246,13 +246,13 @@ aws-ce:
 
 ### Variables Requiring Migration
 
-- `LOG_LEVEL` in pulumicost-plugin-aws-public should migrate to `PULUMICOST_LOG_LEVEL`
+- `LOG_LEVEL` in finfocus-plugin-aws-public should migrate to `PULUMICOST_LOG_LEVEL`
   (fallback supported for backward compatibility)
 - `PORT` usage must be replaced with `PULUMICOST_PLUGIN_PORT` (no fallback - breaking change)
 
 ### Core-Only Variables (Not in Plugin SDK)
 
-The following are used by pulumicost-core only and should NOT be in the plugin SDK:
+The following are used by finfocus-core only and should NOT be in the plugin SDK:
 
 - `PULUMICOST_OUTPUT_FORMAT` - CLI output formatting
 - `PULUMICOST_OUTPUT_PRECISION` - Decimal precision for CLI output

--- a/specs/017-pluginsdk-serve-docs/quickstart.md
+++ b/specs/017-pluginsdk-serve-docs/quickstart.md
@@ -4,7 +4,7 @@
 **Date**: 2025-12-08
 
 This quickstart provides copy-paste-ready examples for using `pluginsdk.Serve()` to start a
-PulumiCost plugin gRPC server.
+FinFocus plugin gRPC server.
 
 ## Minimal Plugin Example
 
@@ -21,8 +21,8 @@ import (
     "os/signal"
     "syscall"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 // MyPlugin implements the pluginsdk.Plugin interface.
@@ -168,7 +168,7 @@ func main() {
 ## Why PORT is Not Supported
 
 The generic `PORT` environment variable is intentionally not supported to prevent multi-plugin
-port conflicts. When pulumicost-core spawns multiple plugins (e.g., aws-public + aws-ce), each
+port conflicts. When finfocus-core spawns multiple plugins (e.g., aws-public + aws-ce), each
 needs a unique port. Using `--port` flag allows the core to allocate distinct ports for each
 plugin subprocess.
 

--- a/specs/017-pluginsdk-serve-docs/research.md
+++ b/specs/017-pluginsdk-serve-docs/research.md
@@ -43,7 +43,7 @@ The port is resolved via `resolvePort()` function with this priority:
 3. **Ephemeral (0)** - OS assigns available port
 
 **Decision**: PORT environment variable is NOT supported to avoid multi-plugin conflicts.
-**Rationale**: When pulumicost-core spawns multiple plugins (e.g., aws-public + aws-ce), each needs
+**Rationale**: When finfocus-core spawns multiple plugins (e.g., aws-public + aws-ce), each needs
 a unique port. Using --port flag allows the core to allocate distinct ports.
 **Source**: `sdk/go/pluginsdk/sdk.go:322-336`
 
@@ -200,7 +200,7 @@ Returns the underlying gRPC error if server fails for reasons other than context
 
 **Alternative**: Support generic PORT environment variable as fallback
 **Rejected Because**: Multi-plugin orchestration requires unique ports per plugin. Generic PORT
-would cause conflicts when pulumicost-core spawns multiple plugins.
+would cause conflicts when finfocus-core spawns multiple plugins.
 
 ### External Binding (Rejected)
 

--- a/specs/017-pluginsdk-serve-docs/spec.md
+++ b/specs/017-pluginsdk-serve-docs/spec.md
@@ -10,7 +10,7 @@ detailing its startup behavior, environment variable usage, and expected flags."
 
 ### User Story 1 - Plugin Developer Learns Serve() Usage (Priority: P1)
 
-A plugin developer building a new PulumiCost plugin needs to understand how to configure and start
+A plugin developer building a new FinFocus plugin needs to understand how to configure and start
 the gRPC server using `pluginsdk.Serve()`. They need clear documentation explaining the function
 signature, configuration options, and expected behavior.
 
@@ -22,7 +22,7 @@ implementing a minimal plugin that starts and accepts gRPC connections.
 
 **Acceptance Scenarios**:
 
-1. **Given** a developer new to PulumiCost, **When** they read the Serve() documentation,
+1. **Given** a developer new to FinFocus, **When** they read the Serve() documentation,
    **Then** they can write a minimal main() function that starts a plugin server without errors.
 2. **Given** a developer reading the documentation, **When** they look for configuration options,
    **Then** they find a complete list of ServeConfig fields with descriptions.
@@ -75,7 +75,7 @@ matches documented behavior.
 
 ### User Story 4 - DevOps Engineer Deploys Multiple Plugins (Priority: P2)
 
-A DevOps engineer deploying pulumicost-core needs to understand how to orchestrate multiple plugins
+A DevOps engineer deploying finfocus-core needs to understand how to orchestrate multiple plugins
 (e.g., aws-public + aws-ce) with unique ports. They need documentation explaining why
 PORT fallback is not supported.
 

--- a/specs/018-log-file/quickstart.md
+++ b/specs/018-log-file/quickstart.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The PulumiCost SDK supports redirecting plugin logs to a file via the `PULUMICOST_LOG_FILE`
+The FinFocus SDK supports redirecting plugin logs to a file via the `PULUMICOST_LOG_FILE`
 environment variable. This enables the Core CLI to orchestrate plugins without log output
 polluting the user-facing interface.
 
@@ -36,15 +36,15 @@ Set the environment variable before spawning plugins:
 
 ```bash
 # Direct all plugin logs to a single file
-export PULUMICOST_LOG_FILE=/var/log/pulumicost/plugins.log
+export PULUMICOST_LOG_FILE=/var/log/finfocus/plugins.log
 ./my-plugin
 ```
 
 Or set per-plugin for separate log files:
 
 ```bash
-PULUMICOST_LOG_FILE=/var/log/pulumicost/aws.log ./aws-plugin &
-PULUMICOST_LOG_FILE=/var/log/pulumicost/azure.log ./azure-plugin &
+PULUMICOST_LOG_FILE=/var/log/finfocus/aws.log ./aws-plugin &
+PULUMICOST_LOG_FILE=/var/log/finfocus/azure.log ./azure-plugin &
 ```
 
 ## Custom Logger Configuration
@@ -54,7 +54,7 @@ If you create a custom logger, use `NewLogWriter()` to respect the environment v
 ```go
 import (
     "github.com/rs/zerolog"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func main() {

--- a/specs/019-get-budgets-rpc/plan.md
+++ b/specs/019-get-budgets-rpc/plan.md
@@ -93,17 +93,17 @@ specs/001-get-budgets-rpc/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 ├── budget.proto         # NEW: Budget message definitions
 └── costsource.proto     # UPDATED: Add GetBudgets RPC
 
 sdk/go/
 ├── proto/               # GENERATED: gRPC service and message types
-│   ├── pulumicost/
+│   ├── finfocus/
 │   │   └── v1/
 │   │       ├── budget.pb.go
 │   │       └── costsource.pb.go
-│   └── pulumicost/
+│   └── finfocus/
 │       └── v1/
 │           ├── budget_grpc.pb.go
 │           └── costsource_grpc.pb.go

--- a/specs/019-get-budgets-rpc/quickstart.md
+++ b/specs/019-get-budgets-rpc/quickstart.md
@@ -6,7 +6,7 @@
 ## Overview
 
 This guide provides a quick start for implementing the GetBudgets RPC in plugins and integrating
-budget functionality into pulumicost-core.
+budget functionality into finfocus-core.
 
 ## For Plugin Developers
 
@@ -50,7 +50,7 @@ budget := &pbc.Budget{
 
 ### 1. Update Proto Definitions
 
-Add budget messages to `proto/pulumicost/v1/budget.proto`:
+Add budget messages to `proto/finfocus/v1/budget.proto`:
 
 ```protobuf
 message Budget {
@@ -61,7 +61,7 @@ message Budget {
 }
 ```
 
-Add RPC to `proto/pulumicost/v1/costsource.proto`:
+Add RPC to `proto/finfocus/v1/costsource.proto`:
 
 ```protobuf
 service CostSource {

--- a/specs/019-get-budgets-rpc/spec.md
+++ b/specs/019-get-budgets-rpc/spec.md
@@ -12,7 +12,7 @@ Billing Budgets, Azure Cost Management, Kubecost)."
 ### User Story 1 - Unified Budget Visibility Across Providers (Priority: P1)
 
 As a FinOps engineer managing cloud costs across multiple providers, I want to see all my
-budgets (AWS, GCP, Azure, Kubecost) in a single pulumicost output so that I have a unified
+budgets (AWS, GCP, Azure, Kubecost) in a single finfocus output so that I have a unified
 view of my spending limits and can make informed decisions about resource allocation.
 
 **Why this priority**: This is the core value proposition - consolidating budget information
@@ -24,7 +24,7 @@ immediate value for budget monitoring.
 
 **Acceptance Scenarios**:
 
-1. **Given** AWS and GCP plugins are configured with budget data, **When** I run pulumicost
+1. **Given** AWS and GCP plugins are configured with budget data, **When** I run finfocus
    commands, **Then** I see budgets from both providers in the output
 2. **Given** a budget exceeds its threshold in AWS, **When** I view budget status, **Then**
    the exceeded budget is clearly marked and highlighted
@@ -36,14 +36,14 @@ immediate value for budget monitoring.
 ### User Story 2 - Kubernetes Budget Tracking (Priority: P2)
 
 As a Kubernetes operator responsible for cost governance, I want Kubecost budgets to be
-exposed through pulumicost so that I can track namespace spending limits alongside
+exposed through finfocus so that I can track namespace spending limits alongside
 infrastructure costs.
 
 **Why this priority**: Enables comprehensive cost visibility including container orchestration
 budgets, which is critical for organizations running Kubernetes workloads.
 
 **Independent Test**: Can be fully tested by configuring Kubecost plugin and verifying
-namespace budget information appears in pulumicost output, providing standalone value for
+namespace budget information appears in finfocus output, providing standalone value for
 Kubernetes cost management.
 
 **Acceptance Scenarios**:
@@ -146,6 +146,6 @@ and displaying summary statistics, offering standalone value for high-level budg
 - **SC-003**: System successfully retrieves budget data from at least 95% of configured plugins
 - **SC-004**: Users report 80% satisfaction with budget visibility and unified display
 - **SC-005**: Budget threshold alerts trigger within 1 minute of threshold being crossed
-  (alerts handled by pulumicost-core consuming applications)
+  (alerts handled by finfocus-core consuming applications)
 - **SC-006**: Multi-cloud users can assess overall budget health in under 30 seconds
 - **SC-007**: System supports 100-1000 budgets per user/department with acceptable performance

--- a/specs/019-get-budgets-rpc/tasks.md
+++ b/specs/019-get-budgets-rpc/tasks.md
@@ -15,7 +15,7 @@
 
 ## Path Conventions
 
-- **Proto definitions**: `proto/pulumicost/v1/`
+- **Proto definitions**: `proto/finfocus/v1/`
 - **Generated SDK**: `sdk/go/proto/`
 - **Plugin SDK**: `sdk/go/pluginsdk/`
 - **Testing**: `sdk/go/testing/`
@@ -26,8 +26,8 @@
 
 **Purpose**: Proto definitions and basic project structure for budget functionality
 
-- [x] T001 Create budget.proto with core message definitions in proto/pulumicost/v1/budget.proto
-- [x] T002 Add GetBudgets RPC to CostSource service in proto/pulumicost/v1/costsource.proto
+- [x] T001 Create budget.proto with core message definitions in proto/finfocus/v1/budget.proto
+- [x] T002 Add GetBudgets RPC to CostSource service in proto/finfocus/v1/costsource.proto
 - [x] T003 [P] Validate proto syntax with buf lint
 - [x] T004 [P] Create budget_spec.schema.json for JSON validation in schemas/budget_spec.schema.json
 
@@ -68,15 +68,15 @@ output with correct provider attribution
 ### Implementation for User Story 1
 
 - [ ] T013 [US1] Implement AWS budget mapping in aws-cost-plugin repository
-  - Issue: [rshade/pulumicost-plugin-aws-ce#4](https://github.com/rshade/pulumicost-plugin-aws-ce/issues/4)
+  - Issue: [rshade/finfocus-plugin-aws-ce#4](https://github.com/rshade/finfocus-plugin-aws-ce/issues/4)
 - [ ] T014 [US1] Implement GCP budget mapping in gcp-cost-plugin repository
 - [ ] T015 [US1] Implement Azure budget mapping in azure-cost-plugin repository
 - [ ] T016 [US1] Add provider filtering support in GetBudgets RPC
-  - Issue: [rshade/pulumicost-core#263](https://github.com/rshade/pulumicost-core/issues/263)
+  - Issue: [rshade/finfocus-core#263](https://github.com/rshade/finfocus-core/issues/263)
 - [ ] T017 [US1] Add currency handling for multi-provider budgets
-  - Issue: [rshade/pulumicost-core#263](https://github.com/rshade/pulumicost-core/issues/263)
+  - Issue: [rshade/finfocus-core#263](https://github.com/rshade/finfocus-core/issues/263)
 - [ ] T018 [US1] Update budget summary calculation for cross-provider aggregation
-  - Issue: [rshade/pulumicost-core#263](https://github.com/rshade/pulumicost-core/issues/263)
+  - Issue: [rshade/finfocus-core#263](https://github.com/rshade/finfocus-core/issues/263)
 
 **Checkpoint**: At this point, User Story 1 should be fully functional and testable independently
 
@@ -91,22 +91,22 @@ output with correct provider attribution
 ### Tests for User Story 2 ⚠️
 
 - [ ] T019 [P] [US2] Kubecost budget mapping validation test
-  - Issue: [rshade/pulumicost-core#264](https://github.com/rshade/pulumicost-core/issues/264)
+  - Issue: [rshade/finfocus-core#264](https://github.com/rshade/finfocus-core/issues/264)
 - [ ] T020 [P] [US2] Namespace-level budget filtering test
-  - Issue: [rshade/pulumicost-core#264](https://github.com/rshade/pulumicost-core/issues/264)
+  - Issue: [rshade/finfocus-core#264](https://github.com/rshade/finfocus-core/issues/264)
 
 ### Implementation for User Story 2
 
 - [ ] T021 [US2] Implement Kubecost budget mapping in kubecost-cost-plugin repository
-  - Issue: [rshade/pulumicost-plugin-kubecost#38](https://github.com/rshade/pulumicost-plugin-kubecost/issues/38)
+  - Issue: [rshade/finfocus-plugin-kubecost#38](https://github.com/rshade/finfocus-plugin-kubecost/issues/38)
 - [ ] T022 [US2] Add namespace filtering support to BudgetFilter
-  - Issue: [rshade/pulumicost-core#266](https://github.com/rshade/pulumicost-core/issues/266)
+  - Issue: [rshade/finfocus-core#266](https://github.com/rshade/finfocus-core/issues/266)
 - [ ] T023 [US2] Implement namespace-specific budget status tracking
-  - Issue: [rshade/pulumicost-core#266](https://github.com/rshade/pulumicost-core/issues/266)
+  - Issue: [rshade/finfocus-core#266](https://github.com/rshade/finfocus-core/issues/266)
 - [ ] T024 [US2] Add Kubecost-specific metadata handling
-  - Issue: [rshade/pulumicost-core#266](https://github.com/rshade/pulumicost-core/issues/266)
+  - Issue: [rshade/finfocus-core#266](https://github.com/rshade/finfocus-core/issues/266)
 - [ ] T025 [US2] Update budget summary for namespace aggregation
-  - Issue: [rshade/pulumicost-core#266](https://github.com/rshade/pulumicost-core/issues/266)
+  - Issue: [rshade/finfocus-core#266](https://github.com/rshade/finfocus-core/issues/266)
 
 **Checkpoint**: At this point, User Stories 1 AND 2 should both work independently
 
@@ -121,22 +121,22 @@ output with correct provider attribution
 ### Tests for User Story 3 ⚠️
 
 - [ ] T026 [P] [US3] Budget health aggregation test
-  - Issue: [rshade/pulumicost-core#265](https://github.com/rshade/pulumicost-core/issues/265)
+  - Issue: [rshade/finfocus-core#265](https://github.com/rshade/finfocus-core/issues/265)
 - [ ] T027 [P] [US3] Multi-provider summary calculation test
-  - Issue: [rshade/pulumicost-core#265](https://github.com/rshade/pulumicost-core/issues/265)
+  - Issue: [rshade/finfocus-core#265](https://github.com/rshade/finfocus-core/issues/265)
 
 ### Implementation for User Story 3
 
 - [ ] T028 [US3] Implement budget health status calculation logic
-  - Issue: [rshade/pulumicost-core#267](https://github.com/rshade/pulumicost-core/issues/267)
+  - Issue: [rshade/finfocus-core#267](https://github.com/rshade/finfocus-core/issues/267)
 - [ ] T029 [US3] Add threshold-based alerting for budget warnings
-  - Issue: [rshade/pulumicost-core#267](https://github.com/rshade/pulumicost-core/issues/267)
+  - Issue: [rshade/finfocus-core#267](https://github.com/rshade/finfocus-core/issues/267)
 - [ ] T030 [US3] Implement forecasted spending calculations
-  - Issue: [rshade/pulumicost-core#267](https://github.com/rshade/pulumicost-core/issues/267)
+  - Issue: [rshade/finfocus-core#267](https://github.com/rshade/finfocus-core/issues/267)
 - [ ] T031 [US3] Add budget health aggregation across providers
-  - Issue: [rshade/pulumicost-core#267](https://github.com/rshade/pulumicost-core/issues/267)
+  - Issue: [rshade/finfocus-core#267](https://github.com/rshade/finfocus-core/issues/267)
 - [ ] T032 [US3] Update summary statistics for health status breakdown
-  - Issue: [rshade/pulumicost-core#267](https://github.com/rshade/pulumicost-core/issues/267)
+  - Issue: [rshade/finfocus-core#267](https://github.com/rshade/finfocus-core/issues/267)
 
 **Checkpoint**: All user stories should now be independently functional
 

--- a/specs/020-pluginsdk-mapping/plan.md
+++ b/specs/020-pluginsdk-mapping/plan.md
@@ -8,7 +8,7 @@
 Create a `pluginsdk/mapping/` subpackage providing shared helper functions for extracting SKU,
 region, and other pricing-relevant fields from Pulumi resource properties. The package will
 support AWS, Azure, and GCP cloud providers with provider-specific extraction logic, plus
-generic fallback extractors for custom use cases. This enables pulumicost-core to delegate
+generic fallback extractors for custom use cases. This enables finfocus-core to delegate
 cloud-specific property mapping to the canonical spec repository, keeping the core cloud-agnostic.
 
 ## Technical Context

--- a/specs/020-pluginsdk-mapping/quickstart.md
+++ b/specs/020-pluginsdk-mapping/quickstart.md
@@ -5,10 +5,10 @@
 
 ## Installation
 
-The mapping package is part of the pulumicost-spec SDK:
+The mapping package is part of the finfocus-spec SDK:
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk/mapping"
+import "github.com/rshade/finfocus-spec/sdk/go/pluginsdk/mapping"
 ```
 
 ## Basic Usage
@@ -20,7 +20,7 @@ package main
 
 import (
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk/mapping"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk/mapping"
 )
 
 func main() {
@@ -85,8 +85,8 @@ region := mapping.ExtractRegion(customProps, "customRegionField", "fallbackRegio
 package myplugin
 
 import (
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk/mapping"
-    pb "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk/mapping"
+    pb "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func (p *MyPlugin) GetProjectedCost(ctx context.Context, req *pb.GetProjectedCostRequest) (

--- a/specs/020-pluginsdk-mapping/research.md
+++ b/specs/020-pluginsdk-mapping/research.md
@@ -191,4 +191,4 @@ No new external dependencies required. The mapping package uses only Go stdlib:
 | GCP regions list becomes outdated | Include last-updated date; document refresh process |
 | New property naming conventions | Generic extractors accept custom key lists |
 | Performance regression | Benchmark tests with CI enforcement |
-| Breaking pulumicost-core integration | Document migration path; maintain backward compat |
+| Breaking finfocus-core integration | Document migration path; maintain backward compat |

--- a/specs/020-pluginsdk-mapping/spec.md
+++ b/specs/020-pluginsdk-mapping/spec.md
@@ -113,9 +113,9 @@ verifying the generic extractor finds values using fallback key lists.
 
 ### User Story 5 - Core System Decoupled from Cloud-Specific Logic (Priority: P1)
 
-The pulumicost-core maintainer needs to remove cloud-specific extraction logic from the core
+The finfocus-core maintainer needs to remove cloud-specific extraction logic from the core
 adapter to keep the core system cloud-agnostic. By importing the mapping package from
-pulumicost-spec, the core delegates all property extraction to the shared SDK.
+finfocus-spec, the core delegates all property extraction to the shared SDK.
 
 **Why this priority**: Decoupling is a primary architectural goal. Without this, the core
 remains tightly coupled to cloud-specific knowledge, making maintenance difficult.
@@ -126,11 +126,11 @@ replacing with mapping package imports while maintaining existing functionality.
 **Acceptance Scenarios**:
 
 1. **Given** the mapping package is published,
-   **When** pulumicost-core imports and uses mapping functions,
+   **When** finfocus-core imports and uses mapping functions,
    **Then** all existing extraction tests continue to pass
 2. **Given** a new cloud property naming convention is discovered,
    **When** the mapping package is updated,
-   **Then** pulumicost-core receives the fix without code changes
+   **Then** finfocus-core receives the fix without code changes
 
 ---
 
@@ -182,7 +182,7 @@ replacing with mapping package imports while maintaining existing functionality.
   or map is nil/empty
 - **FR-011**: All extraction functions MUST NOT panic on nil or empty input
 - **FR-012**: System MUST be importable as a Go package at
-  `github.com/rshade/pulumicost-spec/sdk/go/pluginsdk/mapping`
+  `github.com/rshade/finfocus-spec/sdk/go/pluginsdk/mapping`
 - **FR-013**: System MUST provide a known GCP regions list for validation during zone-to-region
   extraction; if derived region is not in list, return empty string
 - **FR-014**: System MUST provide `ExtractGCPRegionFromZone(zone string) string` function
@@ -209,7 +209,7 @@ replacing with mapping package imports while maintaining existing functionality.
 - **SC-002**: All extraction functions achieve 90%+ code coverage through unit tests
 - **SC-003**: Package provides complete documentation with usage examples for each cloud
   provider
-- **SC-004**: Existing pulumicost-core extraction logic can be fully replaced by mapping
+- **SC-004**: Existing finfocus-core extraction logic can be fully replaced by mapping
   package functions with no behavior change
 - **SC-005**: Zero panics occur when handling edge cases (nil input, empty maps, missing keys)
 - **SC-006**: Plugin developers can discover correct extraction function within 30 seconds
@@ -222,5 +222,5 @@ replacing with mapping package imports while maintaining existing functionality.
 - AWS availability zones follow the standard format of `{region}{letter}` (e.g., `us-east-1a`)
 - GCP zones follow the standard format of `{region}-{letter}` (e.g., `us-central1-a`)
 - Azure locations are direct region identifiers without transformation needed
-- The mapping package will be versioned and released alongside other pulumicost-spec SDK
+- The mapping package will be versioned and released alongside other finfocus-spec SDK
   components

--- a/specs/020-pluginsdk-mapping/tasks.md
+++ b/specs/020-pluginsdk-mapping/tasks.md
@@ -144,17 +144,17 @@ with zone-to-region validation
 
 ## Phase 7: User Story 5 - Core System Decoupling (Priority: P1)
 
-**Goal**: Documentation and integration guidance for pulumicost-core adoption
+**Goal**: Documentation and integration guidance for finfocus-core adoption
 
 **Independent Test**: Verify package is importable and documented for core migration
 
 ### Implementation for User Story 5
 
 - [x] T031 [US5] Update sdk/go/pluginsdk/README.md with mapping package documentation
-- [x] T032 [US5] Add migration guide section for pulumicost-core adapter replacement
+- [x] T032 [US5] Add migration guide section for finfocus-core adapter replacement
 - [x] T033 [US5] Add usage examples for all extraction functions in doc.go
 
-**Checkpoint**: Package ready for pulumicost-core adoption
+**Checkpoint**: Package ready for finfocus-core adoption
 
 ---
 
@@ -167,7 +167,7 @@ with zone-to-region validation
 - [x] T036 Add nil/empty input edge case tests for all functions
 - [x] T037 Run `make lint` and fix any issues
 - [x] T038 Run `make test` and verify all tests pass
-- [x] T038a Verify package is importable at github.com/rshade/pulumicost-spec/sdk/go/pluginsdk/mapping
+- [x] T038a Verify package is importable at github.com/rshade/finfocus-spec/sdk/go/pluginsdk/mapping
 - [x] T039 Run quickstart.md validation scenarios manually
 - [x] T040 Update sdk/go/CLAUDE.md with mapping package documentation
 
@@ -264,7 +264,7 @@ Task T011: "Implement ExtractAWSRegion"        # Uses T009
 
 - Covers most common use case
 - Validates package structure and patterns
-- Enables pulumicost-core migration for AWS resources
+- Enables finfocus-core migration for AWS resources
 
 ---
 

--- a/specs/021-pluginsdk-validation/contracts/api.go.txt
+++ b/specs/021-pluginsdk-validation/contracts/api.go.txt
@@ -1,7 +1,7 @@
 package pluginsdk
 
 import (
-	pb "github.com/rshade/pulumicost-spec/proto/pulumicost/v1"
+	pb "github.com/rshade/finfocus-spec/proto/finfocus/v1"
 )
 
 // ValidateProjectedCostRequest validates that a GetProjectedCostRequest is well-formed.

--- a/specs/021-pluginsdk-validation/data-model.md
+++ b/specs/021-pluginsdk-validation/data-model.md
@@ -4,7 +4,7 @@
 
 ### ProjectedCostValidation
 
-Validates `pulumicost.v1.GetProjectedCostRequest`.
+Validates `finfocus.v1.GetProjectedCostRequest`.
 
 **Fields Checked**:
 
@@ -19,7 +19,7 @@ Validates `pulumicost.v1.GetProjectedCostRequest`.
 
 ### ActualCostValidation
 
-Validates `pulumicost.v1.GetActualCostRequest`.
+Validates `finfocus.v1.GetActualCostRequest`.
 
 **Fields Checked**:
 

--- a/specs/021-pluginsdk-validation/quickstart.md
+++ b/specs/021-pluginsdk-validation/quickstart.md
@@ -11,8 +11,8 @@ helpers are used by both the Core (before sending requests) and Plugins (defense
 
 ```go
 import (
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    pb "github.com/rshade/pulumicost-spec/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    pb "github.com/rshade/finfocus-spec/proto/finfocus/v1"
     "google.golang.org/grpc/codes"
     "google.golang.org/grpc/status"
 )

--- a/specs/021-pluginsdk-validation/tasks.md
+++ b/specs/021-pluginsdk-validation/tasks.md
@@ -14,7 +14,7 @@
 
 **Goal**: Establish common dependencies and testing infrastructure.
 
-- [X] T003 Import `github.com/rshade/pulumicost-spec/proto/pulumicost/v1` in `sdk/go/pluginsdk/validation.go`
+- [X] T003 Import `github.com/rshade/finfocus-spec/proto/finfocus/v1` in `sdk/go/pluginsdk/validation.go`
 - [X] T004 [P] Define `TestValidateProjectedCostRequest` function in `sdk/go/pluginsdk/validation_test.go`
 - [X] T005 [P] Define `TestValidateActualCostRequest` function in `sdk/go/pluginsdk/validation_test.go`
 

--- a/specs/022-proto-add-arn/contracts/costsource.proto
+++ b/specs/022-proto-add-arn/contracts/costsource.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 import "google/protobuf/timestamp.proto";
 

--- a/specs/022-proto-add-arn/plan.md
+++ b/specs/022-proto-add-arn/plan.md
@@ -53,7 +53,7 @@ specs/018-proto-add-arn/
 
 ```text
 proto/
-└── pulumicost/
+└── finfocus/
     └── v1/
         └── costsource.proto  # Target file for modification
 
@@ -63,7 +63,7 @@ sdk/
     └── testing/              # Test case location
 ```
 
-**Structure Decision**: Standard repository structure for `pulumicost-spec`.
+**Structure Decision**: Standard repository structure for `finfocus-spec`.
 
 ## Complexity Tracking
 

--- a/specs/022-proto-add-arn/research.md
+++ b/specs/022-proto-add-arn/research.md
@@ -10,7 +10,7 @@
   terminology (Amazon Resource Name), it is often used colloquially in multi-cloud contexts to mean
   "the long, unique ID". However, to be strictly provider-agnostic, `canonical_id` might be better.
   BUT, `resource_id` is already generic. The prompt/spec specifically asked for `arn` to enable
-  `pulumicost-plugin-aws-ce`.
+  `finfocus-plugin-aws-ce`.
 * **Alternatives Considered**:
   * `canonical_id`: More generic, but `arn` was requested.
   * `provider_id`: Could be confused with the plugin ID.

--- a/specs/022-proto-add-arn/spec.md
+++ b/specs/022-proto-add-arn/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `018-proto-add-arn`  
 **Created**: 2025-12-14
 **Status**: Implemented  
-**Input**: See [GitHub Issue #157](https://github.com/rshade/pulumicost-spec/issues/157) - Add
+**Input**: See [GitHub Issue #157](https://github.com/rshade/finfocus-spec/issues/157) - Add
 dedicated `arn` field to `GetActualCostRequest` for canonical cloud identifier support.
 
 ## User Scenarios & Testing

--- a/specs/022-proto-add-arn/tasks.md
+++ b/specs/022-proto-add-arn/tasks.md
@@ -19,15 +19,15 @@
 
 **Goal**: Ensure environment is ready for proto modification.
 
-- [X] T001 Verify existence and content of proto/pulumicost/v1/costsource.proto
+- [X] T001 Verify existence and content of proto/finfocus/v1/costsource.proto
 - [X] T002 Verify buf CLI is installed and configured (run `buf --version`)
 
 ## Phase 2: Protocol Definition (Foundational)
 
 **Goal**: Update the source of truth (protobuf) with the new field.
 
-- [X] T003 [US1] Add `string arn = 5;` field to `GetActualCostRequest` message in proto/pulumicost/v1/costsource.proto
-- [X] T004 [US1] Add comments to the new `arn` field in proto/pulumicost/v1/costsource.proto
+- [X] T003 [US1] Add `string arn = 5;` field to `GetActualCostRequest` message in proto/finfocus/v1/costsource.proto
+- [X] T004 [US1] Add comments to the new `arn` field in proto/finfocus/v1/costsource.proto
   describing its purpose (Canonical Cloud Identifier)
 - [X] T005 [US1] Run `buf lint` to ensure proto style compliance
 - [X] T006 [US1] Run `buf breaking --against .git#branch=main` to ensure backward compatibility

--- a/specs/023-target-resources/contracts/proto-changes.md
+++ b/specs/023-target-resources/contracts/proto-changes.md
@@ -1,7 +1,7 @@
 # Proto Contract Changes: Target Resources
 
 **Feature**: 019-target-resources
-**File**: `proto/pulumicost/v1/costsource.proto`
+**File**: `proto/finfocus/v1/costsource.proto`
 
 ## Change Summary
 

--- a/specs/023-target-resources/data-model.md
+++ b/specs/023-target-resources/data-model.md
@@ -11,7 +11,7 @@ This feature extends an existing message rather than introducing new entities.
 
 ### GetRecommendationsRequest (Extended)
 
-**File**: `proto/pulumicost/v1/costsource.proto`
+**File**: `proto/finfocus/v1/costsource.proto`
 **Lines**: 652-667 (current), adding field 6
 
 ```protobuf
@@ -30,7 +30,7 @@ message GetRecommendationsRequest {
 
 ### ResourceDescriptor (Reused)
 
-**File**: `proto/pulumicost/v1/costsource.proto`
+**File**: `proto/finfocus/v1/costsource.proto`
 **Lines**: 181-218 (unchanged)
 
 | Field | Type | Required | Description |

--- a/specs/023-target-resources/plan.md
+++ b/specs/023-target-resources/plan.md
@@ -52,11 +52,11 @@ specs/019-target-resources/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 └── costsource.proto          # Add target_resources field to GetRecommendationsRequest
 
 sdk/go/
-├── proto/pulumicost/v1/      # Generated code (make generate)
+├── proto/finfocus/v1/      # Generated code (make generate)
 │   └── costsource.pb.go      # Updated with target_resources field
 └── testing/
     ├── contract.go           # Add MaxTargetResources + validation

--- a/specs/023-target-resources/quickstart.md
+++ b/specs/023-target-resources/quickstart.md
@@ -14,7 +14,7 @@ pre-deployment analysis, and batch resource queries.
 
 ```go
 import (
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 // Define target resources (e.g., from a Pulumi stack)

--- a/specs/023-target-resources/research.md
+++ b/specs/023-target-resources/research.md
@@ -111,7 +111,7 @@ proto patterns and SDK conventions established in this repository.
 
 ## External References
 
-- Existing ResourceDescriptor usage: `proto/pulumicost/v1/costsource.proto:181-218`
+- Existing ResourceDescriptor usage: `proto/finfocus/v1/costsource.proto:181-218`
 - Existing validation patterns: `sdk/go/testing/contract.go`
 - Mock plugin patterns: `sdk/go/testing/mock_plugin.go`
 - Constitution requirements: `.specify/memory/constitution.md`

--- a/specs/023-target-resources/tasks.md
+++ b/specs/023-target-resources/tasks.md
@@ -15,9 +15,9 @@
 
 ## Path Conventions
 
-- **Proto**: `proto/pulumicost/v1/costsource.proto`
+- **Proto**: `proto/finfocus/v1/costsource.proto`
 - **SDK Testing**: `sdk/go/testing/`
-- **Generated Code**: `sdk/go/proto/pulumicost/v1/` (via `make generate`)
+- **Generated Code**: `sdk/go/proto/finfocus/v1/` (via `make generate`)
 
 ---
 
@@ -25,8 +25,8 @@
 
 **Purpose**: Add target_resources field to proto and regenerate SDK
 
-- [x] T001 Add target_resources field to GetRecommendationsRequest in proto/pulumicost/v1/costsource.proto
-- [x] T002 Run `make generate` to regenerate Go SDK code in sdk/go/proto/pulumicost/v1/
+- [x] T001 Add target_resources field to GetRecommendationsRequest in proto/finfocus/v1/costsource.proto
+- [x] T002 Run `make generate` to regenerate Go SDK code in sdk/go/proto/finfocus/v1/
 - [x] T003 Run `make lint` to validate proto with buf lint and Go linting
 
 ---

--- a/specs/024-recommendation-action-types/contracts/recommendation_action_type.proto
+++ b/specs/024-recommendation-action-types/contracts/recommendation_action_type.proto
@@ -3,11 +3,11 @@
 // Date: 2025-12-17
 //
 // This file shows the proto definition changes for the RecommendationActionType enum.
-// The actual implementation will modify proto/pulumicost/v1/costsource.proto
+// The actual implementation will modify proto/finfocus/v1/costsource.proto
 
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 // RecommendationActionType indicates the type of action recommended.
 // Extended with 5 new values (7-11) for comprehensive FinOps platform coverage.

--- a/specs/024-recommendation-action-types/data-model.md
+++ b/specs/024-recommendation-action-types/data-model.md
@@ -119,7 +119,7 @@ to be used in:
 
 After `make generate`:
 
-### Go Constants (sdk/go/proto/pulumicost/v1/costsource.pb.go)
+### Go Constants (sdk/go/proto/finfocus/v1/costsource.pb.go)
 
 ```go
 const (

--- a/specs/024-recommendation-action-types/plan.md
+++ b/specs/024-recommendation-action-types/plan.md
@@ -57,10 +57,10 @@ specs/019-recommendation-action-types/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 └── costsource.proto     # RecommendationActionType enum (lines 613-621)
 
-sdk/go/proto/pulumicost/v1/
+sdk/go/proto/finfocus/v1/
 └── costsource.pb.go     # Generated Go code (regenerate with buf)
 
 sdk/go/testing/

--- a/specs/024-recommendation-action-types/quickstart.md
+++ b/specs/024-recommendation-action-types/quickstart.md
@@ -24,7 +24,7 @@ additional FinOps platform recommendation categories.
 
 ```go
 import (
-    pb "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    pb "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func (p *MyPlugin) GetRecommendations(ctx context.Context, req *pb.GetRecommendationsRequest) (

--- a/specs/024-recommendation-action-types/spec.md
+++ b/specs/024-recommendation-action-types/spec.md
@@ -69,7 +69,7 @@ updated SDK and verifying all existing functionality works unchanged.
 
 ### User Story 3 - Core CLI Categorization (Priority: P2)
 
-As a pulumicost CLI user running `pulumicost cost recommendations`, I want recommendations
+As a finfocus CLI user running `finfocus cost recommendations`, I want recommendations
 categorized by the full range of action types so that I can prioritize and filter
 recommendations effectively.
 
@@ -154,7 +154,7 @@ verifying CLI output correctly groups and labels recommendations.
 
 ## Out of Scope
 
-- CLI implementation changes (handled in pulumicost-core)
+- CLI implementation changes (handled in finfocus-core)
 - Plugin implementation updates (each plugin repository handles their own updates)
 - Changes to other enums or message types in the proto definition
 - Changes to JSON schema (this feature is proto-only)

--- a/specs/024-recommendation-action-types/tasks.md
+++ b/specs/024-recommendation-action-types/tasks.md
@@ -17,8 +17,8 @@
 
 This is a proto-first specification repository:
 
-- **Proto definitions**: `proto/pulumicost/v1/`
-- **Generated Go SDK**: `sdk/go/proto/pulumicost/v1/`
+- **Proto definitions**: `proto/finfocus/v1/`
+- **Generated Go SDK**: `sdk/go/proto/finfocus/v1/`
 - **Testing framework**: `sdk/go/testing/`
 - **Documentation**: `PLUGIN_DEVELOPER_GUIDE.md`, `CHANGELOG.md`
 
@@ -29,7 +29,7 @@ This is a proto-first specification repository:
 **Purpose**: Verify current state and prepare for changes
 
 - [ ] T001 Verify buf CLI is available via `make generate` dry-run
-- [ ] T002 Run `buf lint` to confirm current proto is valid in proto/pulumicost/v1/
+- [ ] T002 Run `buf lint` to confirm current proto is valid in proto/finfocus/v1/
 - [ ] T003 Run `buf breaking` baseline to establish compatibility reference
 - [ ] T004 Run existing tests via `make test` to confirm green baseline
 
@@ -70,19 +70,19 @@ serializes/deserializes them
 ### Implementation for User Story 1
 
 - [ ] T012 [US1] Add RECOMMENDATION_ACTION_TYPE_MIGRATE = 7 with documentation comments in
-  proto/pulumicost/v1/costsource.proto (line ~621)
+  proto/finfocus/v1/costsource.proto (line ~621)
 - [ ] T013 [US1] Add RECOMMENDATION_ACTION_TYPE_CONSOLIDATE = 8 with documentation comments in
-  proto/pulumicost/v1/costsource.proto
+  proto/finfocus/v1/costsource.proto
 - [ ] T014 [US1] Add RECOMMENDATION_ACTION_TYPE_SCHEDULE = 9 with documentation comments in
-  proto/pulumicost/v1/costsource.proto
+  proto/finfocus/v1/costsource.proto
 - [ ] T015 [US1] Add RECOMMENDATION_ACTION_TYPE_REFACTOR = 10 with documentation comments in
-  proto/pulumicost/v1/costsource.proto
+  proto/finfocus/v1/costsource.proto
 - [ ] T016 [US1] Add RECOMMENDATION_ACTION_TYPE_OTHER = 11 with documentation comments in
-  proto/pulumicost/v1/costsource.proto
-- [ ] T017 [US1] Run `buf lint` to validate proto syntax in proto/pulumicost/v1/
-- [ ] T018 [US1] Run `make generate` to regenerate Go SDK in sdk/go/proto/pulumicost/v1/
+  proto/finfocus/v1/costsource.proto
+- [ ] T017 [US1] Run `buf lint` to validate proto syntax in proto/finfocus/v1/
+- [ ] T018 [US1] Run `make generate` to regenerate Go SDK in sdk/go/proto/finfocus/v1/
 - [ ] T019 [US1] Verify generated Go constants exist for all 5 new values in
-  sdk/go/proto/pulumicost/v1/costsource.pb.go
+  sdk/go/proto/finfocus/v1/costsource.pb.go
 - [ ] T020 [US1] Run tests T005-T010 - verify they now PASS
 - [ ] T021 [US1] Update mock plugin to support new action types in sdk/go/testing/mock_plugin.go
 
@@ -125,7 +125,7 @@ existing functionality works unchanged
 **Independent Test**: Mock plugin responses with various action types, CLI correctly groups
 and labels recommendations
 
-**Note**: CLI implementation is out of scope for this repository (handled in pulumicost-core).
+**Note**: CLI implementation is out of scope for this repository (handled in finfocus-core).
 This phase focuses on SDK support for CLI integration.
 
 ### Implementation for User Story 3

--- a/specs/025-greenops-integration/plan.md
+++ b/specs/025-greenops-integration/plan.md
@@ -9,7 +9,7 @@
 
 ### Existing Infrastructure
 
-- **Proto**: `proto/pulumicost/v1/costsource.proto` defines the core gRPC service and messages.
+- **Proto**: `proto/finfocus/v1/costsource.proto` defines the core gRPC service and messages.
 - **SDK**: Go SDK is generated from the proto definitions.
 - **Validation**: `buf` is used for linting and breaking change detection.
 
@@ -42,7 +42,7 @@
 
 - [x] Data Model: [data-model.md](data-model.md)
 - [x] Quickstart: [quickstart.md](quickstart.md)
-- [ ] Protobuf Updates: Modify `proto/pulumicost/v1/costsource.proto`
+- [ ] Protobuf Updates: Modify `proto/finfocus/v1/costsource.proto`
 - [ ] SDK Generation: Run `make generate`
 
 ### Phase 2: Testing & Validation

--- a/specs/025-greenops-integration/research.md
+++ b/specs/025-greenops-integration/research.md
@@ -4,7 +4,7 @@
 
 ### 1. Protobuf Enum for MetricKind
 
-- **Decision**: Define `MetricKind` as a top-level enum in `proto/pulumicost/v1/costsource.proto`.
+- **Decision**: Define `MetricKind` as a top-level enum in `proto/finfocus/v1/costsource.proto`.
 - **Rationale**: It is a core part of the capability discovery and cost projection logic.
 - **Values**:
   - `METRIC_KIND_UNSPECIFIED = 0`

--- a/specs/025-greenops-integration/tasks.md
+++ b/specs/025-greenops-integration/tasks.md
@@ -19,7 +19,7 @@
 **Purpose**: Environment verification and branch readiness
 
 - [X] T001 Verify `buf` CLI version and project dependencies in repository root
-- [X] T002 [P] Review `proto/pulumicost/v1/costsource.proto` for insertion points
+- [X] T002 [P] Review `proto/finfocus/v1/costsource.proto` for insertion points
 - [X] T003 [P] Ensure `make generate` environment is functional
 
 ---
@@ -30,10 +30,10 @@
 
 **⚠️ CRITICAL**: No user story work can begin until the protocol is updated and SDK is regenerated.
 
-- [X] T004 Define `MetricKind` enum in `proto/pulumicost/v1/costsource.proto`
-- [X] T005 Update `SupportsResponse` message with `supported_metrics` in `proto/pulumicost/v1/costsource.proto`
-- [X] T006 Update `GetProjectedCostRequest` message with `utilization_percentage` in `proto/pulumicost/v1/costsource.proto`
-- [X] T007 Update `ResourceDescriptor` message with `utilization_percentage` override in `proto/pulumicost/v1/costsource.proto`
+- [X] T004 Define `MetricKind` enum in `proto/finfocus/v1/costsource.proto`
+- [X] T005 Update `SupportsResponse` message with `supported_metrics` in `proto/finfocus/v1/costsource.proto`
+- [X] T006 Update `GetProjectedCostRequest` message with `utilization_percentage` in `proto/finfocus/v1/costsource.proto`
+- [X] T007 Update `ResourceDescriptor` message with `utilization_percentage` override in `proto/finfocus/v1/costsource.proto`
 - [X] T008 [P] Run `buf lint` on `proto/` directory
 - [X] T009 [P] Run `buf breaking --against .git#branch=main`
 - [X] T010 Regenerate Go SDK using `make generate`
@@ -96,7 +96,7 @@ utilization and verify the correct value is used.
 
 - [X] T022 [P] Update GreenOps examples in `examples/plugins/greenops-plugin.json`
 - [X] T023 [P] Update `examples/requests/projected-cost-with-utilization.json`
-- [X] T024 [P] Add documentation comments to `proto/pulumicost/v1/costsource.proto` for units (gCO2e, kWh, L)
+- [X] T024 [P] Add documentation comments to `proto/finfocus/v1/costsource.proto` for units (gCO2e, kWh, L)
 - [X] T025 [P] Run `make benchmarks` to ensure no regression in cost projection performance
 - [X] T026 Run `quickstart.md` validation tasks
 

--- a/specs/026-focus-1-3-migration/contracts/contract_commitment.proto
+++ b/specs/026-focus-1-3-migration/contracts/contract_commitment.proto
@@ -1,14 +1,14 @@
 // Contract Commitment Dataset Contract
 // This file documents the new ContractCommitment proto message.
-// Actual implementation goes in proto/pulumicost/v1/focus.proto (or separate file)
+// Actual implementation goes in proto/finfocus/v1/focus.proto (or separate file)
 
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto;pbc";
+option go_package = "github.com/rshade/finfocus-spec/sdk/go/proto;pbc";
 
 // =============================================================================
 // NEW ENUM: FocusContractCommitmentCategory

--- a/specs/026-focus-1-3-migration/contracts/focus_1_3_fields.proto
+++ b/specs/026-focus-1-3-migration/contracts/focus_1_3_fields.proto
@@ -1,10 +1,10 @@
 // FOCUS 1.3 Field Extensions Contract
 // This file documents the proto field additions to FocusCostRecord.
-// Actual implementation goes in proto/pulumicost/v1/focus.proto
+// Actual implementation goes in proto/finfocus/v1/focus.proto
 
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 // NOTE: This is a CONTRACT DEFINITION showing the new fields.
 // These fields will be ADDED to the existing FocusCostRecord message.

--- a/specs/026-focus-1-3-migration/plan.md
+++ b/specs/026-focus-1-3-migration/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Migrate the PulumiCost FOCUS implementation from version 1.2 to 1.3 by:
+Migrate the FinFocus FOCUS implementation from version 1.2 to 1.3 by:
 
 1. Adding 8 new columns to FocusCostRecord proto message for split cost allocation and
    provider identification
@@ -60,14 +60,14 @@ specs/026-focus-1-3-migration/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 ├── focus.proto          # FocusCostRecord message (add 8 new fields)
 ├── contract.proto       # NEW: ContractCommitment message (12 fields)
 └── enums.proto          # Add new enums if needed
 
 sdk/go/
 ├── proto/               # Generated code (via buf generate)
-│   └── pulumicost/v1/
+│   └── finfocus/v1/
 │       ├── focus.pb.go
 │       └── contract.pb.go  # NEW
 ├── pluginsdk/
@@ -85,7 +85,7 @@ docs/
 ```
 
 **Structure Decision**: Follows existing repository structure with proto definitions in
-`proto/pulumicost/v1/`, generated code in `sdk/go/proto/`, and SDK implementation in
+`proto/finfocus/v1/`, generated code in `sdk/go/proto/`, and SDK implementation in
 `sdk/go/pluginsdk/`. New ContractCommitment proto may be added to existing focus.proto
 or as a separate contract.proto file.
 

--- a/specs/026-focus-1-3-migration/quickstart.md
+++ b/specs/026-focus-1-3-migration/quickstart.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This guide covers implementing FOCUS 1.3 features in your PulumiCost plugin.
+This guide covers implementing FOCUS 1.3 features in your FinFocus plugin.
 
 ## New Capabilities
 

--- a/specs/026-focus-1-3-migration/spec.md
+++ b/specs/026-focus-1-3-migration/spec.md
@@ -261,4 +261,4 @@ verifying they still pass.
 - [FOCUS Specification](https://focus.finops.org/)
 - [FOCUS GitHub Repository](https://github.com/FinOps-Open-Cost-and-Usage-Spec/FOCUS_Spec)
 - GitHub Issue #183: feat(focus): migrate to FOCUS 1.3 specification
-- Related PR: rshade/pulumicost-spec#99 - feat(focus): Implement FOCUS 1.2 integration [merged]
+- Related PR: rshade/finfocus-spec#99 - feat(focus): Implement FOCUS 1.2 integration [merged]

--- a/specs/026-focus-1-3-migration/tasks.md
+++ b/specs/026-focus-1-3-migration/tasks.md
@@ -16,7 +16,7 @@ and testing of each story.
 
 ## Path Conventions
 
-- **Proto definitions**: `proto/pulumicost/v1/`
+- **Proto definitions**: `proto/finfocus/v1/`
 - **Go SDK**: `sdk/go/`
 - **Testing framework**: `sdk/go/testing/`
 - **Plugin SDK**: `sdk/go/pluginsdk/`
@@ -30,7 +30,7 @@ and testing of each story.
 - [x] T001 Verify branch 026-focus-1-3-migration exists and is checked out
 - [x] T002 [P] Verify buf v1.32.1 is installed (`make generate` installs if needed)
 - [x] T003 [P] Verify Go 1.25.5+ and protobuf dependencies are available
-- [x] T004 Review existing `proto/pulumicost/v1/focus.proto` for field number conflicts
+- [x] T004 Review existing `proto/finfocus/v1/focus.proto` for field number conflicts
 
 ---
 
@@ -41,12 +41,12 @@ be implemented
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [x] T005 Add `FocusContractCommitmentCategory` enum to `proto/pulumicost/v1/focus.proto`
+- [x] T005 Add `FocusContractCommitmentCategory` enum to `proto/finfocus/v1/focus.proto`
   with values: UNSPECIFIED(0), SPEND(1), USAGE(2)
-- [x] T006 Add `ContractCommitment` message to `proto/pulumicost/v1/focus.proto`
+- [x] T006 Add `ContractCommitment` message to `proto/finfocus/v1/focus.proto`
   with 12 fields per contracts/contract_commitment.proto
 - [x] T006a Add FOCUS 1.3 specification reference comments to all new proto fields
-  in `proto/pulumicost/v1/focus.proto` (reference FOCUS 1.3 section numbers for
+  in `proto/finfocus/v1/focus.proto` (reference FOCUS 1.3 section numbers for
   each column: AllocatedMethodId, ServiceProviderName, etc.)
 - [x] T007 Mark `provider_name` field (1) as deprecated with `[deprecated = true]`
   option in FocusCostRecord
@@ -85,15 +85,15 @@ proto serialization and validation
 ### Implementation for User Story 1
 
 - [x] T015 [US1] Add `allocated_method_id` field (61) string to FocusCostRecord
-  in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+  in `proto/finfocus/v1/focus.proto` (completed in Phase 2)
 - [x] T016 [P] [US1] Add `allocated_method_details` field (62) string to
-  FocusCostRecord in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+  FocusCostRecord in `proto/finfocus/v1/focus.proto` (completed in Phase 2)
 - [x] T017 [P] [US1] Add `allocated_resource_id` field (63) string to
-  FocusCostRecord in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+  FocusCostRecord in `proto/finfocus/v1/focus.proto` (completed in Phase 2)
 - [x] T018 [P] [US1] Add `allocated_resource_name` field (64) string to
-  FocusCostRecord in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+  FocusCostRecord in `proto/finfocus/v1/focus.proto` (completed in Phase 2)
 - [x] T019 [US1] Add `allocated_tags` field (65) map<string,string> to
-  FocusCostRecord in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+  FocusCostRecord in `proto/finfocus/v1/focus.proto` (completed in Phase 2)
 - [x] T020 [US1] Run `make generate` after proto field additions (completed in Phase 2)
 - [x] T021 [US1] Implement `WithAllocation(methodId, methodDetails string)`
   builder method in `sdk/go/pluginsdk/focus_builder.go`
@@ -130,9 +130,9 @@ deprecation warning when both old and new fields set
 ### Implementation for User Story 2
 
 - [x] T029 [US2] Add `service_provider_name` field (59) string to FocusCostRecord
-  in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+  in `proto/finfocus/v1/focus.proto` (completed in Phase 2)
 - [x] T030 [P] [US2] Add `host_provider_name` field (60) string to FocusCostRecord
-  in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+  in `proto/finfocus/v1/focus.proto` (completed in Phase 2)
 - [x] T031 [US2] Run `make generate` after proto field additions (completed in Phase 2)
 - [x] T032 [US2] Implement `WithServiceProvider(name string)` builder method
   in `sdk/go/pluginsdk/focus_builder.go`
@@ -220,7 +220,7 @@ verify it accepts any string value (opaque reference)
 ### Implementation for User Story 4
 
 - [x] T056 [US4] Add `contract_applied` field (66) string to FocusCostRecord
-  in `proto/pulumicost/v1/focus.proto` (completed in Phase 2)
+  in `proto/finfocus/v1/focus.proto` (completed in Phase 2)
 - [x] T057 [US4] Run `make generate` after proto field addition (completed in Phase 2)
 - [x] T058 [US4] Implement `WithContractApplied(commitmentId string)` builder
   method in `sdk/go/pluginsdk/focus_builder.go` (completed in Phase 3)

--- a/specs/027-finops-validation/quickstart.md
+++ b/specs/027-finops-validation/quickstart.md
@@ -13,8 +13,8 @@ The simplest way to validate a FocusCostRecord:
 
 ```go
 import (
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func processRecord(record *pbc.FocusCostRecord) error {
@@ -33,8 +33,8 @@ For batch processing and data quality reports:
 
 ```go
 import (
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func validateBatch(records []*pbc.FocusCostRecord) map[int][]error {
@@ -60,7 +60,7 @@ When you need detailed error information:
 ```go
 import (
     "errors"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func handleValidationError(err error) {
@@ -116,8 +116,8 @@ import (
     "context"
     "fmt"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
     "google.golang.org/grpc/codes"
     "google.golang.org/grpc/status"
 )

--- a/specs/028-resource-id/checklists/requirements.md
+++ b/specs/028-resource-id/checklists/requirements.md
@@ -40,7 +40,7 @@ to planning
   - `arn` (field 8): Canonical cloud resource identifier for exact resource
     lookup
 - Technical Context section includes implementation guidance for dependent
-  repositories (pulumicost-core, pulumicost-plugin-aws-public, pluginsdk) - this
+  repositories (finfocus-core, finfocus-plugin-aws-public, pluginsdk) - this
   is intentional since protocol changes require coordinated implementation
 - Cross-provider ARN format examples included (AWS, Azure, GCP, Kubernetes,
   Cloudflare)

--- a/specs/028-resource-id/contracts/resource_descriptor.proto.diff
+++ b/specs/028-resource-id/contracts/resource_descriptor.proto.diff
@@ -1,5 +1,5 @@
 // Proto Diff: ResourceDescriptor Changes
-// File: proto/pulumicost/v1/costsource.proto
+// File: proto/finfocus/v1/costsource.proto
 // Message: ResourceDescriptor (lines ~216-257)
 
 // === BEFORE ===

--- a/specs/028-resource-id/data-model.md
+++ b/specs/028-resource-id/data-model.md
@@ -32,7 +32,7 @@ The `ResourceDescriptor` protobuf message is extended with two new optional fiel
 #### `id` (field 7)
 
 - **Purpose**: Request/response correlation in batch operations
-- **Set by**: Client (pulumicost-core)
+- **Set by**: Client (finfocus-core)
 - **Validated by**: None (opaque)
 - **Pass-through**: Plugins MUST copy to response unchanged
 - **Default**: Empty string (no correlation)
@@ -135,7 +135,7 @@ transitions apply.
 | id | None | N/A (always valid) |
 | arn | Optional format check | Log warning, fall back to fuzzy match |
 
-### Client Layer (pulumicost-core)
+### Client Layer (finfocus-core)
 
 | Field | Validation | On Invalid |
 |-------|------------|------------|

--- a/specs/028-resource-id/plan.md
+++ b/specs/028-resource-id/plan.md
@@ -13,7 +13,7 @@ Add two new fields to the `ResourceDescriptor` protobuf message:
   GCP Full Resource Name, etc.) for exact resource matching
 
 This is a backward-compatible protocol addition (minor version bump) enabling
-pulumicost-core to correlate batch recommendation responses and plugins to perform
+finfocus-core to correlate batch recommendation responses and plugins to perform
 precise resource lookups.
 
 ## Technical Context
@@ -26,7 +26,7 @@ precise resource lookups.
 **Project Type**: Single (gRPC specification + Go SDK)
 **Performance Goals**: Zero-allocation field access, O(1) correlation lookup
 **Constraints**: Backward-compatible proto changes only, no breaking wire format
-**Scale/Scope**: Used by all PulumiCost plugins and core
+**Scale/Scope**: Used by all FinFocus plugins and core
 
 ## Constitution Check
 
@@ -61,12 +61,12 @@ specs/028-resource-id/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 └── costsource.proto     # Add id (field 7) and arn (field 8) to ResourceDescriptor
 
 sdk/go/
 ├── proto/               # Regenerated gRPC code (make generate)
-│   └── pulumicost/v1/
+│   └── finfocus/v1/
 │       └── costsource.pb.go
 ├── pluginsdk/
 │   └── helpers.go       # Add WithID/WithARN builder methods (if needed)

--- a/specs/028-resource-id/quickstart.md
+++ b/specs/028-resource-id/quickstart.md
@@ -84,7 +84,7 @@ func (p *AWSPlugin) lookupByARN(arnStr string) (*Resource, error) {
 }
 ```
 
-## For pulumicost-core Developers
+## For finfocus-core Developers
 
 ### Setting Correlation IDs
 
@@ -208,7 +208,7 @@ type/sku/region/tags matching continues to work.
 
 ### Opting In
 
-1. Update to latest pulumicost-spec
+1. Update to latest finfocus-spec
 2. Run `make generate` to regenerate proto bindings
 3. Add correlation ID pass-through in recommendation handlers
 4. (Optional) Add ARN-based exact matching for improved accuracy

--- a/specs/028-resource-id/spec.md
+++ b/specs/028-resource-id/spec.md
@@ -216,7 +216,7 @@ identification.
 
 **Current Workarounds**:
 
-1. pulumicost-core sets the `ResourceID` on returned recommendations when
+1. finfocus-core sets the `ResourceID` on returned recommendations when
    there's exactly one resource in the request. This fails for batch requests.
 2. Plugins rely on type/sku/region/tags matching, which can be ambiguous when
    multiple similar resources exist.
@@ -281,7 +281,7 @@ message ResourceDescriptor {
 
 This section provides implementation guidance for dependent repositories.
 
-#### pulumicost-core
+#### finfocus-core
 
 **Location**: Recommendation analyzer and cost query components
 
@@ -326,7 +326,7 @@ This section provides implementation guidance for dependent repositories.
    }
    ```
 
-#### pulumicost-plugin-aws-public
+#### finfocus-plugin-aws-public
 
 **Location**: Recommendations provider implementation
 

--- a/specs/028-resource-id/tasks.md
+++ b/specs/028-resource-id/tasks.md
@@ -16,8 +16,8 @@ and testing.
 
 ## Path Conventions
 
-- **Proto**: `proto/pulumicost/v1/costsource.proto`
-- **Generated**: `sdk/go/proto/pulumicost/v1/` (auto-generated, do not edit)
+- **Proto**: `proto/finfocus/v1/costsource.proto`
+- **Generated**: `sdk/go/proto/finfocus/v1/` (auto-generated, do not edit)
 - **Tests**: `sdk/go/testing/`
 - **SDK Helpers**: `sdk/go/pluginsdk/`
 
@@ -33,7 +33,7 @@ and testing.
 > fail against existing code first.
 
 - [X] T001 Add `id` and `arn` fields to ResourceDescriptor in
-  `proto/pulumicost/v1/costsource.proto`
+  `proto/finfocus/v1/costsource.proto`
 - [X] T002 Run `make generate` to regenerate Go protobuf bindings
 - [X] T003 Run `buf lint` to validate proto changes
 - [X] T004 Run `buf breaking` to verify backward compatibility
@@ -48,7 +48,7 @@ and testing.
 
 **⚠️ CRITICAL**: No user story tests can be verified until this phase is complete
 
-- [X] T005 Verify generated `sdk/go/proto/pulumicost/v1/costsource.pb.go` includes
+- [X] T005 Verify generated `sdk/go/proto/finfocus/v1/costsource.pb.go` includes
   new fields
 - [X] T006 Run `go build ./...` to verify compilation
 - [X] T007 Run `make lint` to verify no lint errors

--- a/specs/029-grpc-web-support/checklists/requirements.md
+++ b/specs/029-grpc-web-support/checklists/requirements.md
@@ -48,7 +48,7 @@ planning
   - Updated assumptions to document per-org instance model as default
   - Per-request credentials deferred to future issue #220
 - **2025-12-29 (Update 2)**: Architecture clarifications
-  - Clarified pulumicost-core is CLI only, orchestrator is web platform responsibility
+  - Clarified finfocus-core is CLI only, orchestrator is web platform responsibility
   - Batch RPC deferred to future issue #221 (use client-side parallelism for now)
   - No proto changes required for this spec
 
@@ -57,6 +57,6 @@ planning
 - **Multi-tenant model**: Per-org plugin instances (not per-request credentials)
 - **Credential passing**: Environment variables at launch time
 - **Rationale**: Cloud SDK compatibility, process isolation, simpler plugin code
-- **Orchestrator responsibility**: Web platforms (e.g., Pulumi Insights), NOT pulumicost-core
-- **pulumicost-core role**: CLI tool that launches plugins locally via command line
+- **Orchestrator responsibility**: Web platforms (e.g., Pulumi Insights), NOT finfocus-core
+- **finfocus-core role**: CLI tool that launches plugins locally via command line
 - **Future enhancement**: Per-request credentials tracked in issue #220

--- a/specs/029-grpc-web-support/data-model.md
+++ b/specs/029-grpc-web-support/data-model.md
@@ -8,7 +8,7 @@ No new data model entities are introduced. This feature extends the *transport l
 
 ## API Contracts
 
-The API contract remains defined by `proto/pulumicost/v1/costsource.proto`.
+The API contract remains defined by `proto/finfocus/v1/costsource.proto`.
 
 ### Protocol Support
 

--- a/specs/029-grpc-web-support/plan.md
+++ b/specs/029-grpc-web-support/plan.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Enable multi-protocol support for PulumiCost plugins using connect-go, allowing:
+Enable multi-protocol support for FinFocus plugins using connect-go, allowing:
 
 - **gRPC**: Existing clients continue to work unchanged
 - **gRPC-Web**: Direct browser connectivity
@@ -60,8 +60,8 @@ specs/029-grpc-web-support/
 buf.gen.yaml                    # Add connect-go plugin
 
 # Generated files (new)
-sdk/go/proto/pulumicost/v1/
-└── pulumicostv1connect/
+sdk/go/proto/finfocus/v1/
+└── finfocusv1connect/
     └── costsource.connect.go   # Connect handlers (generated)
 
 # SDK changes

--- a/specs/029-grpc-web-support/quickstart.md
+++ b/specs/029-grpc-web-support/quickstart.md
@@ -9,7 +9,7 @@ package main
 
 import (
     "context"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func main() {
@@ -36,12 +36,12 @@ The Connect protocol supports JSON, making debugging easy:
 
 ```bash
 # Get plugin name
-curl -X POST http://localhost:8080/pulumicost.v1.CostSourceService/Name \
+curl -X POST http://localhost:8080/finfocus.v1.CostSourceService/Name \
   -H "Content-Type: application/json" \
   -d '{}'
 
 # Estimate cost for a resource
-curl -X POST http://localhost:8080/pulumicost.v1.CostSourceService/EstimateCost \
+curl -X POST http://localhost:8080/finfocus.v1.CostSourceService/EstimateCost \
   -H "Content-Type: application/json" \
   -d '{
     "resource": {
@@ -64,8 +64,8 @@ package main
 import (
     "context"
     "fmt"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk/client"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk/client"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func main() {
@@ -113,7 +113,7 @@ For browser-based access, you can use:
 1. **Connect Protocol with fetch** (simplest):
 
 ```javascript
-const response = await fetch('http://localhost:8080/pulumicost.v1.CostSourceService/Name', {
+const response = await fetch('http://localhost:8080/finfocus.v1.CostSourceService/Name', {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({})
@@ -127,7 +127,7 @@ console.log('Plugin name:', data.name);
 ```typescript
 import { createConnectTransport } from "@connectrpc/connect-web";
 import { createClient } from "@connectrpc/connect";
-import { CostSourceService } from "./gen/pulumicost/v1/costsource_connect";
+import { CostSourceService } from "./gen/finfocus/v1/costsource_connect";
 
 const transport = createConnectTransport({
   baseUrl: "http://localhost:8080",

--- a/specs/029-grpc-web-support/research.md
+++ b/specs/029-grpc-web-support/research.md
@@ -99,12 +99,12 @@
 
 ```bash
 # JSON request (Connect protocol)
-curl -X POST http://localhost:8080/pulumicost.v1.CostSourceService/Name \
+curl -X POST http://localhost:8080/finfocus.v1.CostSourceService/Name \
   -H "Content-Type: application/json" \
   -d '{}'
 
 # Binary protobuf request
-curl -X POST http://localhost:8080/pulumicost.v1.CostSourceService/Name \
+curl -X POST http://localhost:8080/finfocus.v1.CostSourceService/Name \
   -H "Content-Type: application/proto" \
   --data-binary @request.bin
 ```

--- a/specs/029-grpc-web-support/spec.md
+++ b/specs/029-grpc-web-support/spec.md
@@ -5,7 +5,7 @@
 **Status**: Draft
 **Input**: User description: "gRPC-Web support for browser-based plugin access enabling
 full lifecycle management, plus Go-based client support for batch resource queries"
-**Related Issue**: [#189](https://github.com/rshade/pulumicost-spec/issues/189)
+**Related Issue**: [#189](https://github.com/rshade/finfocus-spec/issues/189)
 
 ## User Scenarios & Testing _(mandatory)_
 
@@ -13,7 +13,7 @@ full lifecycle management, plus Go-based client support for batch resource queri
 
 A developer using the Pulumi Insights web dashboard wants to get a cost estimate for a
 resource they're about to deploy. The browser-based application needs to communicate
-directly with a running PulumiCost plugin to retrieve pricing information without
+directly with a running FinFocus plugin to retrieve pricing information without
 requiring a separate backend proxy.
 
 **Why this priority**: This is the core value proposition - enabling browser-based cost
@@ -25,7 +25,7 @@ EstimateCost RPC via gRPC-Web protocol and displays the returned cost estimate.
 
 **Acceptance Scenarios**:
 
-1. **Given** a PulumiCost plugin is running and accessible,
+1. **Given** a FinFocus plugin is running and accessible,
    **When** a browser client sends an EstimateCost request via gRPC-Web protocol,
    **Then** the plugin returns cost estimate data in a format the browser can parse.
 2. **Given** a browser client on a different origin than the plugin,
@@ -156,7 +156,7 @@ check endpoint and displaying status indicators.
 
 ### User Story 6 - Go Client Library for Plugin Integration (Priority: P2)
 
-A developer building a Go-based service that needs to integrate with PulumiCost plugins
+A developer building a Go-based service that needs to integrate with FinFocus plugins
 wants a simple client library that handles connection management, protocol negotiation,
 and error handling. The SDK should provide a typed Go client that makes plugin
 integration straightforward.
@@ -340,7 +340,7 @@ plugins and displays their status information.
 ### Key Entities
 
 - **Browser Client**: A web application running in a user's browser that needs to
-  communicate with PulumiCost plugins. Communicates via HTTP-based protocols.
+  communicate with FinFocus plugins. Communicates via HTTP-based protocols.
 - **Go Client**: A Go-based service or application (e.g., Pulumi Insights backend) that
   queries plugins programmatically. Uses the SDK-provided client library.
 - **Plugin Endpoint**: The network address and port where a plugin serves requests. May
@@ -417,7 +417,7 @@ plugins and displays their status information.
 - Plugin credentials are passed via environment variables at launch time, not via
   request headers. This ensures compatibility with standard cloud SDK credential chains.
 - The orchestrator is a web platform concern (e.g., Pulumi Insights), not part of
-  pulumicost-core. pulumicost-core is a CLI that launches plugins locally via command
+  finfocus-core. finfocus-core is a CLI that launches plugins locally via command
   line; multi-tenant orchestration is implemented by the consuming web service.
 
 ## Scope Boundaries
@@ -462,4 +462,4 @@ plugins and displays their status information.
 - Existing CostSourceService proto definitions (no changes required for this spec)
 - Current pluginsdk.Serve() implementation (will be extended)
 - gRPC reflection support (already implemented via #181)
-- Orchestrator implementation (web platform responsibility, not pulumicost-core)
+- Orchestrator implementation (web platform responsibility, not finfocus-core)

--- a/specs/029-plugin-info-rpc/contracts/costsource.proto
+++ b/specs/029-plugin-info-rpc/contracts/costsource.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
-option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto;pbc";
+option go_package = "github.com/rshade/finfocus-spec/sdk/go/proto;pbc";
 
 // ... (existing imports and messages) ...
 

--- a/specs/029-plugin-info-rpc/data-model.md
+++ b/specs/029-plugin-info-rpc/data-model.md
@@ -11,7 +11,7 @@ Represents the metadata of a loaded cost source plugin.
 | :------------- | :------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`         | `string`            | The display name of the plugin (e.g., "aws-cost-plugin").                                                                                      |
 | `version`      | `string`            | The semantic version of the plugin implementation (e.g., "v1.2.0").                                                                            |
-| `spec_version` | `string`            | The version of the `pulumicost-spec` protocol the plugin was compiled against (e.g., "v0.4.11").                                               |
+| `spec_version` | `string`            | The version of the `finfocus-spec` protocol the plugin was compiled against (e.g., "v0.4.11").                                               |
 | `providers`    | `[]string`          | List of cloud providers supported by this plugin (e.g., `["aws"]`).                                                                            |
 | `metadata`     | `map[string]string` | Optional key-value pairs for additional metadata (e.g., build hash, commit ID). Free-form; no key restrictions or size limits enforced by SDK. |
 

--- a/specs/029-plugin-info-rpc/plan.md
+++ b/specs/029-plugin-info-rpc/plan.md
@@ -51,7 +51,7 @@ specs/029-plugin-info-rpc/
 ```text
 # Single project structure
 proto/
-└── pulumicost/
+└── finfocus/
     └── v1/
         └── costsource.proto # RPC definition
 

--- a/specs/029-plugin-info-rpc/quickstart.md
+++ b/specs/029-plugin-info-rpc/quickstart.md
@@ -9,7 +9,7 @@
 ## Steps
 
 1. **Update Proto Definition**:
-   - Modify `proto/pulumicost/v1/costsource.proto` to include `GetPluginInfo` RPC and messages.
+   - Modify `proto/finfocus/v1/costsource.proto` to include `GetPluginInfo` RPC and messages.
 
 2. **Regenerate SDK**:
    - Run `make generate` (or `buf generate`) to update `sdk/go/proto/`.

--- a/specs/029-plugin-info-rpc/research.md
+++ b/specs/029-plugin-info-rpc/research.md
@@ -5,7 +5,7 @@
 
 ## 1. Proto Definition
 
-**Decision**: Add `GetPluginInfo` to `CostSource` service in `proto/pulumicost/v1/costsource.proto`.
+**Decision**: Add `GetPluginInfo` to `CostSource` service in `proto/finfocus/v1/costsource.proto`.
 
 **Rationale**:
 

--- a/specs/029-plugin-info-rpc/spec.md
+++ b/specs/029-plugin-info-rpc/spec.md
@@ -76,7 +76,7 @@ As the Core System, I want to handle plugins that do not implement `GetPluginInf
 ### Scope Clarification
 
 This feature implements the **plugin SDK side** of GetPluginInfo. The following are **consumer-side
-responsibilities** that plugin SDK users (e.g., pulumicost-core) must implement:
+responsibilities** that plugin SDK users (e.g., finfocus-core) must implement:
 
 - Calling GetPluginInfo with appropriate timeout
 - Handling Unimplemented errors from legacy plugins
@@ -84,7 +84,7 @@ responsibilities** that plugin SDK users (e.g., pulumicost-core) must implement:
 - Displaying plugin info in CLI tools
 
 > **Note**: Consumer-side requirements are marked with _(Consumer)_ below. A tracking issue will be
-> created in pulumicost-core to implement these once this spec version is released.
+> created in finfocus-core to implement these once this spec version is released.
 
 ### Functional Requirements
 
@@ -112,6 +112,6 @@ responsibilities** that plugin SDK users (e.g., pulumicost-core) must implement:
 ### Measurable Outcomes
 
 - **SC-001**: Core system successfully retrieves metadata (including spec version) from 100% of compliant plugins.
-- **SC-002** _(Consumer)_: Consumer tools (e.g., `pulumicost plugin list`) can display the spec
+- **SC-002** _(Consumer)_: Consumer tools (e.g., `finfocus plugin list`) can display the spec
   version for all compliant plugins by calling `GetPluginInfo`.
 - **SC-003**: System successfully initializes 100% of legacy plugins (non-compliant) without crashing, logging a compatibility warning instead.

--- a/specs/029-plugin-info-rpc/tasks.md
+++ b/specs/029-plugin-info-rpc/tasks.md
@@ -18,7 +18,7 @@ each story.
 
 ## Path Conventions
 
-- **Proto definitions**: `proto/pulumicost/v1/`
+- **Proto definitions**: `proto/finfocus/v1/`
 - **Generated code**: `sdk/go/proto/`
 - **SDK implementation**: `sdk/go/pluginsdk/`
 - **Testing framework**: `sdk/go/testing/`
@@ -29,10 +29,10 @@ each story.
 
 **Purpose**: Update protocol buffer definitions and regenerate Go SDK
 
-- [x] T001 Add GetPluginInfoRequest message to proto/pulumicost/v1/costsource.proto
-- [x] T002 Add GetPluginInfoResponse message to proto/pulumicost/v1/costsource.proto
+- [x] T001 Add GetPluginInfoRequest message to proto/finfocus/v1/costsource.proto
+- [x] T002 Add GetPluginInfoResponse message to proto/finfocus/v1/costsource.proto
   - Fields: name, version, spec_version, providers, metadata
-- [x] T003 Add GetPluginInfo RPC to CostSourceService in proto/pulumicost/v1/costsource.proto
+- [x] T003 Add GetPluginInfo RPC to CostSourceService in proto/finfocus/v1/costsource.proto
 - [x] T004 Run `make generate` to regenerate sdk/go/proto/ from updated proto definitions
 - [x] T005 Verify generated code compiles with `go build ./sdk/go/proto/...`
 

--- a/specs/030-forecasting-primitives/contracts/forecasting.proto.md
+++ b/specs/030-forecasting-primitives/contracts/forecasting.proto.md
@@ -4,7 +4,7 @@ This document defines the protocol buffer changes for the forecasting primitives
 
 ## New Enum: GrowthType
 
-**File**: `proto/pulumicost/v1/enums.proto`
+**File**: `proto/finfocus/v1/enums.proto`
 
 ```protobuf
 // GrowthType represents the mathematical model used for projecting cost growth.
@@ -32,7 +32,7 @@ enum GrowthType {
 
 ## Extended Message: ResourceDescriptor
 
-**File**: `proto/pulumicost/v1/costsource.proto`
+**File**: `proto/finfocus/v1/costsource.proto`
 
 Add the following fields after field 8 (arn):
 
@@ -69,7 +69,7 @@ message ResourceDescriptor {
 
 ## Extended Message: GetProjectedCostRequest
 
-**File**: `proto/pulumicost/v1/costsource.proto`
+**File**: `proto/finfocus/v1/costsource.proto`
 
 Add the following fields after field 2 (utilization_percentage):
 

--- a/specs/030-forecasting-primitives/plan.md
+++ b/specs/030-forecasting-primitives/plan.md
@@ -56,7 +56,7 @@ specs/030-forecasting-primitives/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 ├── costsource.proto     # Extended: ResourceDescriptor, GetProjectedCostRequest
 └── enums.proto          # New: GrowthType enum
 
@@ -70,7 +70,7 @@ examples/
 ```
 
 **Structure Decision**: Single project (gRPC spec repo). Proto changes in
-`proto/pulumicost/v1/`, generated SDK in `sdk/go/proto/`, helper code in `sdk/go/pricing/`.
+`proto/finfocus/v1/`, generated SDK in `sdk/go/proto/`, helper code in `sdk/go/pricing/`.
 
 ## Complexity Tracking
 

--- a/specs/030-forecasting-primitives/quickstart.md
+++ b/specs/030-forecasting-primitives/quickstart.md
@@ -16,7 +16,7 @@ costs. Two growth models are supported:
 
 ```go
 import (
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 // Create a resource with 10% monthly linear growth
@@ -107,7 +107,7 @@ req := &pbc.GetProjectedCostRequest{
 The SDK validates growth parameters automatically:
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/pricing"
+import "github.com/rshade/finfocus-spec/sdk/go/pricing"
 
 // Validate before sending request
 err := pricing.ValidateGrowthParams(

--- a/specs/030-forecasting-primitives/tasks.md
+++ b/specs/030-forecasting-primitives/tasks.md
@@ -16,7 +16,7 @@ proto implementation.
 
 ## Path Conventions
 
-- **Proto definitions**: `proto/pulumicost/v1/`
+- **Proto definitions**: `proto/finfocus/v1/`
 - **Generated code**: `sdk/go/proto/` (via buf generate)
 - **SDK helpers**: `sdk/go/pricing/`
 - **Conformance tests**: `sdk/go/testing/`
@@ -48,10 +48,10 @@ exist for tests to compile. This is an acceptable deviation: the enum is a found
 required for test compilation, not business logic. Tests will fail at runtime (missing fields)
 not compile time, satisfying the TDD spirit.
 
-- [X] T004 Add GrowthType enum to `proto/pulumicost/v1/enums.proto` with values:
+- [X] T004 Add GrowthType enum to `proto/finfocus/v1/enums.proto` with values:
   GROWTH_TYPE_UNSPECIFIED (0), GROWTH_TYPE_NONE (1), GROWTH_TYPE_LINEAR (2),
   GROWTH_TYPE_EXPONENTIAL (3)
-- [X] T005 Add import for enums.proto in `proto/pulumicost/v1/costsource.proto` if not present
+- [X] T005 Add import for enums.proto in `proto/finfocus/v1/costsource.proto` if not present
 - [X] T006 Run `buf lint` to validate new enum follows style conventions
 - [X] T007 Run `buf breaking` to confirm no breaking changes introduced
 - [X] T008 Run `make generate` to regenerate Go SDK code in `sdk/go/proto/`
@@ -85,9 +85,9 @@ response incorporates growth model
 ### Implementation for User Story 1
 
 - [X] T014 [US1] Add growth_type (field 9) and growth_rate (field 10) to ResourceDescriptor
-  message in `proto/pulumicost/v1/costsource.proto` per contracts/forecasting.proto.md
+  message in `proto/finfocus/v1/costsource.proto` per contracts/forecasting.proto.md
 - [X] T015 [US1] Add growth_type (field 3) and growth_rate (field 4) to GetProjectedCostRequest
-  message in `proto/pulumicost/v1/costsource.proto` per contracts/forecasting.proto.md
+  message in `proto/finfocus/v1/costsource.proto` per contracts/forecasting.proto.md
 - [X] T016 [US1] Add comprehensive proto comments to growth_type and growth_rate fields
   documenting semantics, valid ranges, and examples per Constitution V
 - [X] T017 [US1] Run `buf lint` to validate proto changes

--- a/specs/031-sdk-docs-consolidation/quickstart.md
+++ b/specs/031-sdk-docs-consolidation/quickstart.md
@@ -25,7 +25,7 @@ Start with inline code documentation changes that require minimal effort:
 **Action**: Add ownership semantics documentation
 
 ```go
-// NewClient creates a new PulumiCost client with the given configuration.
+// NewClient creates a new FinFocus client with the given configuration.
 //
 // HTTP Client Ownership:
 //   - If HTTPClient is nil, an internal HTTP client is created and owned by
@@ -78,7 +78,7 @@ package pluginsdk_test
 import (
     "context"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func ExampleClient_Close() {
@@ -127,8 +127,8 @@ import (
     "context"
     "testing"
 
-    plugintesting "github.com/rshade/pulumicost-spec/sdk/go/testing"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    plugintesting "github.com/rshade/finfocus-spec/sdk/go/testing"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 ```
 

--- a/specs/031-sdk-docs-consolidation/research.md
+++ b/specs/031-sdk-docs-consolidation/research.md
@@ -294,7 +294,7 @@ client := pluginsdk.NewClient(pluginsdk.ClientConfig{
 ### Documentation Pattern
 
 ```go
-// NewClient creates a new PulumiCost client with the given configuration.
+// NewClient creates a new FinFocus client with the given configuration.
 //
 // HTTP Client Ownership:
 //   - If HTTPClient is nil, an internal HTTP client is created and owned by

--- a/specs/032-jsonld-serialization/quickstart.md
+++ b/specs/032-jsonld-serialization/quickstart.md
@@ -4,10 +4,10 @@ Get started with JSON-LD serialization for FOCUS cost data in under 5 minutes.
 
 ## Installation
 
-The jsonld package is part of the pulumicost-spec Go SDK:
+The jsonld package is part of the finfocus-spec Go SDK:
 
 ```go
-import "github.com/rshade/pulumicost-spec/sdk/go/jsonld"
+import "github.com/rshade/finfocus-spec/sdk/go/jsonld"
 ```
 
 ## Basic Usage
@@ -21,9 +21,9 @@ import (
     "fmt"
     "time"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/jsonld"
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/jsonld"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func main() {

--- a/specs/032-jsonld-serialization/research.md
+++ b/specs/032-jsonld-serialization/research.md
@@ -81,7 +81,7 @@
 **Alternatives Considered**:
 
 - `urn:focus:v1:`: URN scheme, less web-friendly
-- `https://pulumicost.dev/focus/`: Project-specific, not spec-aligned
+- `https://finfocus.dev/focus/`: Project-specific, not spec-aligned
 - No namespace: Breaks RDF semantics
 
 ### 5. ID Generation Strategy

--- a/specs/032-plugin-dry-run/contracts/README.md
+++ b/specs/032-plugin-dry-run/contracts/README.md
@@ -9,8 +9,8 @@ This directory contains the gRPC/proto contract definitions for the dry-run feat
 Proto snippet showing all additions required for the dry-run feature. This is not a
 standalone proto file but a reference showing what will be merged into:
 
-- `proto/pulumicost/v1/enums.proto` - FieldSupportStatus enum
-- `proto/pulumicost/v1/costsource.proto` - Messages and RPC definition
+- `proto/finfocus/v1/enums.proto` - FieldSupportStatus enum
+- `proto/finfocus/v1/costsource.proto` - Messages and RPC definition
 
 ## Implementation Notes
 

--- a/specs/032-plugin-dry-run/contracts/dry_run.proto
+++ b/specs/032-plugin-dry-run/contracts/dry_run.proto
@@ -4,12 +4,12 @@
 // These definitions will be merged into the appropriate proto files.
 //
 // Target files:
-//   - proto/pulumicost/v1/enums.proto (FieldSupportStatus)
-//   - proto/pulumicost/v1/costsource.proto (messages and RPC)
+//   - proto/finfocus/v1/enums.proto (FieldSupportStatus)
+//   - proto/finfocus/v1/costsource.proto (messages and RPC)
 
 syntax = "proto3";
 
-package pulumicost.v1;
+package finfocus.v1;
 
 // =============================================================================
 // Addition to enums.proto

--- a/specs/032-plugin-dry-run/plan.md
+++ b/specs/032-plugin-dry-run/plan.md
@@ -58,7 +58,7 @@ specs/032-plugin-dry-run/
 ### Source Code (repository root)
 
 ```text
-proto/pulumicost/v1/
+proto/finfocus/v1/
 ├── costsource.proto     # Add DryRun RPC, DryRunRequest/Response messages,
 │                        # FieldMapping message, FieldSupportStatus enum,
 │                        # dry_run flag to GetActualCostRequest/GetProjectedCostRequest
@@ -66,7 +66,7 @@ proto/pulumicost/v1/
 
 sdk/go/
 ├── proto/               # Generated code (buf generate)
-│   └── pulumicost/v1/
+│   └── finfocus/v1/
 │       └── costsource.pb.go
 ├── pluginsdk/           # SDK helpers for dry-run implementation
 │   ├── dry_run.go       # DryRunHandler helper, field mapping utilities

--- a/specs/032-plugin-dry-run/quickstart.md
+++ b/specs/032-plugin-dry-run/quickstart.md
@@ -27,7 +27,7 @@ import (
     "google.golang.org/grpc/codes"
     "google.golang.org/grpc/status"
 
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 func main() {
@@ -145,7 +145,7 @@ package main
 import (
     "context"
 
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 type MyPlugin struct {

--- a/specs/032-plugin-dry-run/research.md
+++ b/specs/032-plugin-dry-run/research.md
@@ -11,7 +11,7 @@
 
 **Findings**:
 
-The `FocusCostRecord` message in `proto/pulumicost/v1/focus.proto` contains ~50 fields
+The `FocusCostRecord` message in `proto/finfocus/v1/focus.proto` contains ~50 fields
 organized into these sections:
 
 | Section | Field Range | Example Fields |

--- a/specs/032-plugin-dry-run/spec.md
+++ b/specs/032-plugin-dry-run/spec.md
@@ -188,6 +188,6 @@ type and comparing the returned field lists.
 
 ## Dependencies
 
-- Existing CostSource gRPC service definition (proto/pulumicost/v1/costsource.proto)
+- Existing CostSource gRPC service definition (proto/finfocus/v1/costsource.proto)
 - FOCUS field definitions in the SDK
 - Plugin registry for resource type identification

--- a/specs/032-plugin-dry-run/tasks.md
+++ b/specs/032-plugin-dry-run/tasks.md
@@ -18,8 +18,8 @@ testing of each story.
 
 Based on plan.md project structure:
 
-- **Proto definitions**: `proto/pulumicost/v1/`
-- **Generated code**: `sdk/go/proto/pulumicost/v1/`
+- **Proto definitions**: `proto/finfocus/v1/`
+- **Generated code**: `sdk/go/proto/finfocus/v1/`
 - **SDK helpers**: `sdk/go/pluginsdk/`
 - **Testing framework**: `sdk/go/testing/`
 - **Examples**: `examples/requests/dry_run/`
@@ -31,7 +31,7 @@ Based on plan.md project structure:
 **Purpose**: Project initialization and basic structure
 
 - [x] T001 Create examples directory structure at examples/requests/dry_run/
-- [x] T002 [P] Verify current field numbers in proto/pulumicost/v1/costsource.proto for
+- [x] T002 [P] Verify current field numbers in proto/finfocus/v1/costsource.proto for
       safe field additions
 
 ---
@@ -69,24 +69,24 @@ first and MUST FAIL because the proto messages don't exist yet. This defines the
 
 ### Proto Schema Changes
 
-- [x] T008 Add FieldSupportStatus enum to proto/pulumicost/v1/enums.proto with values:
+- [x] T008 Add FieldSupportStatus enum to proto/finfocus/v1/enums.proto with values:
       UNSPECIFIED, SUPPORTED, UNSUPPORTED, CONDITIONAL, DYNAMIC
-- [x] T009 [P] Add FieldMapping message to proto/pulumicost/v1/costsource.proto with
+- [x] T009 [P] Add FieldMapping message to proto/finfocus/v1/costsource.proto with
       fields: field_name, support_status, condition_description, expected_type
-- [x] T010 [P] Add DryRunRequest message to proto/pulumicost/v1/costsource.proto with
+- [x] T010 [P] Add DryRunRequest message to proto/finfocus/v1/costsource.proto with
       fields: resource (ResourceDescriptor), simulation_parameters (map)
-- [x] T011 [P] Add DryRunResponse message to proto/pulumicost/v1/costsource.proto with
+- [x] T011 [P] Add DryRunResponse message to proto/finfocus/v1/costsource.proto with
       fields: field_mappings, configuration_valid, configuration_errors, resource_type_supported
-- [x] T012 Add DryRun RPC to CostSourceService in proto/pulumicost/v1/costsource.proto
-- [x] T013 Add dry_run field to GetActualCostRequest in proto/pulumicost/v1/costsource.proto
+- [x] T012 Add DryRun RPC to CostSourceService in proto/finfocus/v1/costsource.proto
+- [x] T013 Add dry_run field to GetActualCostRequest in proto/finfocus/v1/costsource.proto
 - [x] T014 [P] Add dry_run_result field to GetActualCostResponse in
-      proto/pulumicost/v1/costsource.proto
+      proto/finfocus/v1/costsource.proto
 - [x] T015 [P] Add dry_run field to GetProjectedCostRequest in
-      proto/pulumicost/v1/costsource.proto
+      proto/finfocus/v1/costsource.proto
 - [x] T016 [P] Add dry_run_result field to GetProjectedCostResponse in
-      proto/pulumicost/v1/costsource.proto
+      proto/finfocus/v1/costsource.proto
 - [x] T017 Update SupportsResponse capabilities documentation in
-      proto/pulumicost/v1/costsource.proto to include "dry_run" key
+      proto/finfocus/v1/costsource.proto to include "dry_run" key
 
 ### Code Generation & Validation
 

--- a/specs/033-cors-headers-config/plan.md
+++ b/specs/033-cors-headers-config/plan.md
@@ -15,7 +15,7 @@ follows the existing builder pattern with `With*` methods and uses nil-defaults 
 **Primary Dependencies**: net/http (stdlib), strings (stdlib) - no new dependencies
 **Storage**: N/A (stateless configuration extension)
 **Testing**: Go testing package with table-driven tests, existing TestHarness for integration
-**Target Platform**: Linux/macOS/Windows servers running PulumiCost plugins
+**Target Platform**: Linux/macOS/Windows servers running FinFocus plugins
 **Project Type**: Single SDK package extension
 **Performance Goals**: <1 microsecond overhead per CORS request (SC-005)
 **Constraints**: 100% backward compatibility, defensive slice copying

--- a/specs/033-cors-headers-config/quickstart.md
+++ b/specs/033-cors-headers-config/quickstart.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-This guide shows how to customize CORS headers in your PulumiCost plugin for security compliance
+This guide shows how to customize CORS headers in your FinFocus plugin for security compliance
 and observability requirements.
 
 ## Default Behavior

--- a/specs/034-sdk-polish/contracts/client-timeout-api.md
+++ b/specs/034-sdk-polish/contracts/client-timeout-api.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This contract documents the PulumiCost Go SDK client configuration API for timeout handling and context management.
+This contract documents the FinFocus Go SDK client configuration API for timeout handling and context management.
 
 ---
 

--- a/specs/034-sdk-polish/plan.md
+++ b/specs/034-sdk-polish/plan.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-SDK Polish v0.4.15 enhances the PulumiCost Go SDK with configurable per-client timeouts, user-friendly error
+SDK Polish v0.4.15 enhances the FinFocus Go SDK with configurable per-client timeouts, user-friendly error
 messages for GetPluginInfo RPC calls, and performance conformance testing. Technical approach involves
 extending ClientConfig with timeout support, improving error message formatting in Server.GetPluginInfo,
 and adding performance validation to the conformance test framework.

--- a/specs/034-sdk-polish/quickstart.md
+++ b/specs/034-sdk-polish/quickstart.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-SDK Polish v0.4.15 adds three enhancements to the PulumiCost Go SDK:
+SDK Polish v0.4.15 adds three enhancements to the FinFocus Go SDK:
 
 1. **Configurable Client Timeouts** - Per-client timeout configuration with context deadline support
 2. **User-Friendly GetPluginInfo Errors** - Improved error messages for better developer experience
@@ -33,7 +33,7 @@ import (
     "log"
     "time"
 
-    pluginsdk "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    pluginsdk "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 func main() {
@@ -153,8 +153,8 @@ import (
     "context"
     "log"
 
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
-    pluginsdk "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+    pluginsdk "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 )
 
 // MyPlugin implements Plugin interface and optional PluginInfoProvider
@@ -281,9 +281,9 @@ package main
 import (
     "os"
 
-    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
-    "github.com/rshade/pulumicost-spec/sdk/go/testing"
-    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+    "github.com/rshade/finfocus-spec/sdk/go/testing"
+    pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
 type MyPlugin struct{}
@@ -643,7 +643,7 @@ func (s *Server) GetPluginInfo(ctx context.Context, req *pbc.GetPluginInfoReques
 
 ## Summary
 
-SDK Polish v0.4.15 enhances the PulumiCost Go SDK with:
+SDK Polish v0.4.15 enhances the FinFocus Go SDK with:
 
 - ✅ Configurable per-client timeouts with context deadline support
 - ✅ User-friendly GetPluginInfo error messages (automatic server-side validation)

--- a/specs/035-project-rename-finfocus/contracts/package-rename.md
+++ b/specs/035-project-rename-finfocus/contracts/package-rename.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the API contract changes resulting from the PulumiCost to
+This document describes the API contract changes resulting from the FinFocus to
 FinFocus rename. Since this is a mechanical rename rather than new functionality,
 the contracts focus on package and module path changes.
 
@@ -10,15 +10,15 @@ the contracts focus on package and module path changes.
 
 ### Package Declaration Change
 
-**Old Package**: `pulumicost.v1`
+**Old Package**: `finfocus.v1`
 **New Package**: `finfocus.v1`
 
 ### Proto File Structure
 
 ```protobuf
 // Before
-package pulumicost.v1;
-option go_package = "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1;pbc";
+package finfocus.v1;
+option go_package = "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pbc";
 
 // After
 package finfocus.v1;
@@ -29,7 +29,7 @@ option go_package = "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pb
 
 ```text
 Before:
-proto/pulumicost/
+proto/finfocus/
 ├── v1/
 │   ├── costsource.proto
 │   └── budget.proto
@@ -59,16 +59,16 @@ Message definitions remain **unchanged**:
 
 ### Module Path Change
 
-**Old Module**: `github.com/rshade/pulumicost-spec`
+**Old Module**: `github.com/rshade/finfocus-spec`
 **New Module**: `github.com/rshade/finfocus-spec`
 
 ### Import Path Changes
 
 | Purpose      | Old Import                                                     | New Import                                                 |
 | ------------ | -------------------------------------------------------------- | ---------------------------------------------------------- |
-| Plugin SDK   | `github.com/rshade/pulumicost-spec/sdk/go/pluginsdk`           | `github.com/rshade/finfocus-spec/sdk/go/pluginsdk`         |
-| Pulumi API   | `github.com/rshade/pulumicost-spec/sdk/go/pulumiapi`           | `github.com/rshade/finfocus-spec/sdk/go/pulumiapi`         |
-| Proto Client | `github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1` | `github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1` |
+| Plugin SDK   | `github.com/rshade/finfocus-spec/sdk/go/pluginsdk`           | `github.com/rshade/finfocus-spec/sdk/go/pluginsdk`         |
+| Pulumi API   | `github.com/rshade/finfocus-spec/sdk/go/pulumiapi`           | `github.com/rshade/finfocus-spec/sdk/go/pulumiapi`         |
+| Proto Client | `github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1` | `github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1` |
 
 ### Package Alias
 
@@ -89,7 +89,7 @@ MINOR version bump in pre-1.0 semantic versioning.
 ```json
 // Before
 {
-  "package-name": "pulumicost-spec",
+  "package-name": "finfocus-spec",
   "extra-files": [
     ...
   ]
@@ -132,7 +132,7 @@ MINOR version bump in pre-1.0 semantic versioning.
 
    ```go
    // Before
-   import pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+   import pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 
    // After
    import pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
@@ -165,9 +165,9 @@ MINOR version bump in pre-1.0 semantic versioning.
 All changes must pass the following validation:
 
 1. `make generate` produces clean proto code in `sdk/go/proto/finfocus/v1/`
-2. `make test` passes with zero `pulumicost-spec` imports
+2. `make test` passes with zero `finfocus-spec` imports
 3. `make validate` passes all linting and schema checks
-4. `rg pulumicost` returns only historical references
+4. `rg finfocus` returns only historical references
 
 ## Compliance with Constitution
 

--- a/specs/035-project-rename-finfocus/data-model.md
+++ b/specs/035-project-rename-finfocus/data-model.md
@@ -4,14 +4,14 @@
 
 | Component | Old Package | New Package |
 |-----------|-------------|-------------|
-| Core | `pulumicost.v1` | `finfocus.v1` |
+| Core | `finfocus.v1` | `finfocus.v1` |
 
 ## Go Module Mapping
 
 | Component | Old Path | New Path |
 |-----------|----------|----------|
-| Root Module | `github.com/rshade/pulumicost-spec` | `github.com/rshade/finfocus-spec` |
-| Proto SDK | `.../sdk/go/proto/pulumicost/v1` | `.../sdk/go/proto/finfocus/v1` |
+| Root Module | `github.com/rshade/finfocus-spec` | `github.com/rshade/finfocus-spec` |
+| Proto SDK | `.../sdk/go/proto/finfocus/v1` | `.../sdk/go/proto/finfocus/v1` |
 | Go Alias | `pbc` | `pbc` (Unchanged) |
 
 ## Implementation Constants

--- a/specs/035-project-rename-finfocus/plan.md
+++ b/specs/035-project-rename-finfocus/plan.md
@@ -8,12 +8,12 @@
 
 ## Summary
 
-This feature implements a comprehensive rename of the project from PulumiCost to
+This feature implements a comprehensive rename of the project from FinFocus to
 FinFocus, aligning the repository with the FinOps FOCUS specification. The
 technical approach involves:
 
-1. **Protocol rename**: Updating all protobuf package declarations from `pulumicost.v1` to `finfocus.v1`
-2. **Module rename**: Changing the Go module from `github.com/rshade/pulumicost-spec` to `github.com/rshade/finfocus-spec`
+1. **Protocol rename**: Updating all protobuf package declarations from `finfocus.v1` to `finfocus.v1`
+2. **Module rename**: Changing the Go module from `github.com/rshade/finfocus-spec` to `github.com/rshade/finfocus-spec`
 3. **Global text replacement**: Performing case-sensitive find/replace of branding references
 4. **Release management**: Updating `release-please` configuration and resetting version to v0.5.0
 5. **CI/CD updates**: Ensuring all workflows reference the new module paths
@@ -41,7 +41,7 @@ _GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 
 - [x] **Contract First**: Does this change start with Proto definitions?
   - **Status**: PASS - The rename begins with updating `.proto` package declarations from
-    `pulumicost.v1` to `finfocus.v1`, consistent with the "Proto definitions are the
+    `finfocus.v1` to `finfocus.v1`, consistent with the "Proto definitions are the
     source of truth" principle.
 - [x] **Spec Consumes**: Does implementation avoid embedding complex pricing logic/calculators?
   - **Status**: PASS - This is a purely mechanical rename; no pricing logic or calculations are added or modified.
@@ -77,7 +77,7 @@ specs/[###-feature]/
 
 ```text
 proto/
-├── finfocus/v1/         # Renamed from pulumicost/v1/
+├── finfocus/v1/         # Renamed from finfocus/v1/
 │   ├── costsource.proto
 │   └── budget.proto
 ├── buf.yaml

--- a/specs/035-project-rename-finfocus/quickstart.md
+++ b/specs/035-project-rename-finfocus/quickstart.md
@@ -14,7 +14,7 @@ Update your imports:
 ```go
 import (
     // Old
-    // pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    // pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
     
     // New
     pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"

--- a/specs/035-project-rename-finfocus/research.md
+++ b/specs/035-project-rename-finfocus/research.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-This document consolidates research findings for the project rename from PulumiCost to
+This document consolidates research findings for the project rename from FinFocus to
 FinFocus. All clarifications from the feature specification have been resolved.
 
 ## Research Decisions
@@ -85,8 +85,8 @@ FinFocus. All clarifications from the feature specification have been resolved.
 
 **Examples of Contextual Replacement**:
 
-- In CHANGELOG.md: Keep historical entries mentioning "PulumiCost" unchanged
-- In docs/: Preserve legacy notes like "formerly known as PulumiCost" in migration guides
+- In CHANGELOG.md: Keep historical entries mentioning "FinFocus" unchanged
+- In docs/: Preserve legacy notes like "formerly known as FinFocus" in migration guides
 - In README.md: Update active branding but keep acknowledgments of original project name
 - In specs/: Leave historical references in feature specifications unchanged
 
@@ -99,18 +99,18 @@ FinFocus. All clarifications from the feature specification have been resolved.
 
 ### Global Rename Strategy
 
-We will perform a contextual find/replace of "PulumiCost" and "pulumicost" across the
+We will perform a contextual find/replace of "FinFocus" and "finfocus" across the
 codebase, documentation, and CI/CD configurations.
 
 **Replacements Map**:
 
 | Category      | Search Term                         | Replace With                            | Notes                              |
 | ------------- | ----------------------------------- | --------------------------------------- | ---------------------------------- |
-| Proto Package | `pulumicost.v1`                     | `finfocus.v1`                           | Wire breaking change               |
-| Go Module     | `github.com/rshade/pulumicost-spec` | `github.com/rshade/finfocus-spec`       | Import breaking change             |
-| Brand (Title) | `PulumiCost`                        | `FinFocus`                              |                                    |
+| Proto Package | `finfocus.v1`                     | `finfocus.v1`                           | Wire breaking change               |
+| Go Module     | `github.com/rshade/finfocus-spec` | `github.com/rshade/finfocus-spec`       | Import breaking change             |
+| Brand (Title) | `FinFocus`                        | `FinFocus`                              |                                    |
 | Path Alias    | `pbc`                               | `pbc`                                   | Preserved for internal consistency |
-| Directory     | `proto/pulumicost`                  | `proto/finfocus`                        |                                    |
+| Directory     | `proto/finfocus`                  | `proto/finfocus`                        |                                    |
 | Tagline       | `Production-ready specification...` | `FinFocus: Focusing your finances left` |                                    |
 
 **Rationale**: To establish the "FinFocus" identity, a complete transition is required for
@@ -123,8 +123,8 @@ a clean brand for all active development.
 Based on best practices for Go module and protobuf package renames, the optimal order is:
 
 1. **Protobuf package rename** (first)
-   - Update `package pulumicost.v1` to `package finfocus.v1` in all `.proto` files
-   - Move `proto/pulumicost/` directory to `proto/finfocus/`
+   - Update `package finfocus.v1` to `package finfocus.v1` in all `.proto` files
+   - Move `proto/finfocus/` directory to `proto/finfocus/`
    - Update `go_package` options to reference new paths
 
 2. **Go module rename**
@@ -132,8 +132,8 @@ Based on best practices for Go module and protobuf package renames, the optimal 
    - Update all internal imports to match the new module path
 
 3. **Global text replacement**
-   - Case-sensitive find/replace of `pulumicost` → `finfocus` (lowercase)
-   - Case-sensitive find/replace of `PulumiCost` → `FinFocus` (PascalCase)
+   - Case-sensitive find/replace of `finfocus` → `finfocus` (lowercase)
+   - Case-sensitive find/replace of `FinFocus` → `FinFocus` (PascalCase)
    - Case-sensitive find/replace of `PULUMICOST` → `FINFOCUS` (UPPERCASE)
    - Preserve historical context in documentation
 
@@ -181,7 +181,7 @@ This justifies the version bump to v0.5.0 (MINOR version in pre-1.0 semantic ver
 | Risk                                       | Likelihood | Impact | Mitigation                                                         |
 | ------------------------------------------ | ---------- | ------ | ------------------------------------------------------------------ |
 | Missed imports causing build failures      | Medium     | High   | Run `go test ./...` and `make validate` before committing          |
-| Documentation drift (old brand references) | High       | Low    | Use `rg` (ripgrep) to search for remaining `pulumicost` references |
+| Documentation drift (old brand references) | High       | Low    | Use `rg` (ripgrep) to search for remaining `finfocus` references |
 | Release-please version confusion           | Low        | Medium | Test with `release-please` dry-run mode before merging             |
 | Generated code conflicts                   | Low        | High   | Ensure `make clean` is run before `make generate`                  |
 

--- a/specs/035-project-rename-finfocus/spec.md
+++ b/specs/035-project-rename-finfocus/spec.md
@@ -80,7 +80,7 @@ verifying the proposed version and manifest updates.
 
 ### Edge Cases
 
-- **Mixed Imports**: Ensuring no `pulumicost` imports remain in the `sdk/go` directory.
+- **Mixed Imports**: Ensuring no `finfocus` imports remain in the `sdk/go` directory.
 - **Documentation Drift**: Ensuring `README.md` and `docs/` are fully updated to prevent branding inconsistency.
 - **Generated Code Persistence**: Ensuring `make clean` and `make generate` work correctly with the new structure.
 
@@ -88,11 +88,11 @@ verifying the proposed version and manifest updates.
 
 ### Functional Requirements
 
-- **FR-001**: System MUST rename all Protobuf packages from `pulumicost.v1` to `finfocus.v1`.
+- **FR-001**: System MUST rename all Protobuf packages from `finfocus.v1` to `finfocus.v1`.
 - **FR-002**: System MUST update `go.mod` to `github.com/rshade/finfocus-spec`.
 - **FR-003**: System MUST perform a global case-insensitive find/replace of
-  `pulumicost` to `finfocus` (respecting casing: `PulumiCost` -> `FinFocus`).
-- **FR-004**: System MUST move `proto/pulumicost/` directory to `proto/finfocus/`.
+  `finfocus` to `finfocus` (respecting casing: `FinFocus` -> `FinFocus`).
+- **FR-004**: System MUST move `proto/finfocus/` directory to `proto/finfocus/`.
 - **FR-005**: System MUST update `release-please-config.json` and
   `.release-please-manifest.json` to reflect the new project name and version
   (v0.5.0).
@@ -105,7 +105,7 @@ verifying the proposed version and manifest updates.
 
 ### Key Entities
 
-- **Protobuf Contract**: The wire protocol definition transitioning from `pulumicost.v1` to `finfocus.v1`.
+- **Protobuf Contract**: The wire protocol definition transitioning from `finfocus.v1` to `finfocus.v1`.
 - **Go SDK Module**: The Go module identity in `go.mod`.
 - **Release Manifest**: The `release-please` state files tracking versions.
 
@@ -115,8 +115,8 @@ verifying the proposed version and manifest updates.
 
 - **SC-001**: 100% of `.proto` files use the `finfocus.v1` package name.
 - **SC-002**: `make generate` completes without errors and populates `sdk/go/proto/finfocus/v1`.
-- **SC-003**: `make test` passes with zero remaining imports of `github.com/rshade/pulumicost-spec`.
-- **SC-004**: All occurrences of the string "PulumiCost" (case-insensitive) in the
+- **SC-003**: `make test` passes with zero remaining imports of `github.com/rshade/finfocus-spec`.
+- **SC-004**: All occurrences of the string "FinFocus" (case-insensitive) in the
   `docs/` directory are replaced with "FinFocus", unless referring to historical
   context.
 - **SC-005**: `release-please` configuration is valid and points to the new repository and package names.

--- a/specs/035-project-rename-finfocus/tasks.md
+++ b/specs/035-project-rename-finfocus/tasks.md
@@ -34,9 +34,9 @@ work.
 
 **Purpose**: Project analysis and preparation
 
-- [ ] T001 Verify current state: list all `.proto` files in proto/pulumicost/v1/
+- [ ] T001 Verify current state: list all `.proto` files in proto/finfocus/v1/
 - [ ] T002 Verify current state: check go.mod module name is
-      github.com/rshade/pulumicost-spec
+      github.com/rshade/finfocus-spec
 - [ ] T003 Verify current state: identify all CI/CD workflow files in .github/workflows/
 - [ ] T004 Backup current release-please configurations: copy release-please-config.json
       and .release-please-manifest.json to /tmp/
@@ -62,21 +62,21 @@ work.
 ## Phase 3: User Story 1 - Protocol Branding (Priority: P1) 🎯 MVP
 
 **Goal**: Rename all gRPC definitions to reflect the FinFocus brand (package
-pulumicost.v1 → finfocus.v1)
+finfocus.v1 → finfocus.v1)
 
 **Independent Test**: Verify that `.proto` files use `package finfocus.v1` and gRPC
 services are correctly named (services remain generic)
 
 ### Implementation for User Story 1
 
-- [ ] T009 [P] [US1] Update package declaration in proto/pulumicost/v1/costsource.proto from `pulumicost.v1` to `finfocus.v1`
-- [ ] T010 [P] [US1] Update go_package option in proto/pulumicost/v1/costsource.proto to `github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pbc`
-- [ ] T011 [P] [US1] Update package declaration in proto/pulumicost/v1/budget.proto from `pulumicost.v1` to `finfocus.v1`
-- [ ] T012 [P] [US1] Update go_package option in proto/pulumicost/v1/budget.proto to `github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pbc`
-- [ ] T013 [US1] Move proto/pulumicost/v1/costsource.proto to proto/finfocus/v1/costsource.proto
-- [ ] T014 [US1] Move proto/pulumicost/v1/budget.proto to proto/finfocus/v1/budget.proto
-- [ ] T015 [US1] Remove empty proto/pulumicost/v1/ directory: rmdir proto/pulumicost/v1 proto/pulumicost
-- [ ] T016 [P] [US1] Update buf.yaml to reference proto/finfocus/v1 instead of proto/pulumicost/v1 (if applicable)
+- [ ] T009 [P] [US1] Update package declaration in proto/finfocus/v1/costsource.proto from `finfocus.v1` to `finfocus.v1`
+- [ ] T010 [P] [US1] Update go_package option in proto/finfocus/v1/costsource.proto to `github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pbc`
+- [ ] T011 [P] [US1] Update package declaration in proto/finfocus/v1/budget.proto from `finfocus.v1` to `finfocus.v1`
+- [ ] T012 [P] [US1] Update go_package option in proto/finfocus/v1/budget.proto to `github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pbc`
+- [ ] T013 [US1] Move proto/finfocus/v1/costsource.proto to proto/finfocus/v1/costsource.proto
+- [ ] T014 [US1] Move proto/finfocus/v1/budget.proto to proto/finfocus/v1/budget.proto
+- [ ] T015 [US1] Remove empty proto/finfocus/v1/ directory: rmdir proto/finfocus/v1 proto/finfocus
+- [ ] T016 [P] [US1] Update buf.yaml to reference proto/finfocus/v1 instead of proto/finfocus/v1 (if applicable)
 - [ ] T017 [P] [US1] Update .github/workflows/proto.yml to use proto/finfocus/v1
       paths for buf lint/breaking checks
 - [ ] T018 [US1] Regenerate proto code: run `make generate` to populate sdk/go/proto/finfocus/v1/
@@ -95,32 +95,32 @@ services are correctly named (services remain generic)
 **Goal**: Update Go module to github.com/rshade/finfocus-spec and update all internal imports
 
 **Independent Test**: Run `go test ./...` and verify all imports use the new
-finfocus-spec path (zero pulumicost-spec imports remain)
+finfocus-spec path (zero finfocus-spec imports remain)
 
 ### Implementation for User Story 2
 
 - [ ] T021 [US2] Update go.mod module declaration from
-      `github.com/rshade/pulumicost-spec` to `github.com/rshade/finfocus-spec`
+      `github.com/rshade/finfocus-spec` to `github.com/rshade/finfocus-spec`
 - [ ] T022 [P] [US2] Update internal imports in sdk/go/pulumiapi/\*.go from
-      `github.com/rshade/pulumicost-spec/sdk/go/` to
+      `github.com/rshade/finfocus-spec/sdk/go/` to
       `github.com/rshade/finfocus-spec/sdk/go/`
 - [ ] T023 [P] [US2] Update internal imports in sdk/go/pluginsdk/\*.go from
-      `github.com/rshade/pulumicost-spec/sdk/go/` to
+      `github.com/rshade/finfocus-spec/sdk/go/` to
       `github.com/rshade/finfocus-spec/sdk/go/`
 - [ ] T024 [P] [US2] Update internal imports in sdk/go/internal/\*.go from
-      `github.com/rshade/pulumicost-spec/sdk/go/` to
+      `github.com/rshade/finfocus-spec/sdk/go/` to
       `github.com/rshade/finfocus-spec/sdk/go/`
 - [ ] T025 [P] [US2] Update proto import in sdk/go/\*_/_\_test.go from
-      `pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"` to
+      `pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"` to
       `pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"`
 - [ ] T026 [P] [US2] Update examples/\*_/_.go imports from
-      `github.com/rshade/pulumicost-spec/sdk/go/` to
+      `github.com/rshade/finfocus-spec/sdk/go/` to
       `github.com/rshade/finfocus-spec/sdk/go/`
 - [ ] T027 [US2] Run go mod tidy to resolve dependencies: `go mod tidy` at repository root
 - [ ] T028 [US2] Verify module rename: run `go list -m` and confirm output is
       `github.com/rshade/finfocus-spec`
-- [ ] T029 [US2] Search for remaining pulumicost-spec imports: run
-      `rg "github.com/rshade/pulumicost-spec"` and verify only historical
+- [ ] T029 [US2] Search for remaining finfocus-spec imports: run
+      `rg "github.com/rshade/finfocus-spec"` and verify only historical
       references remain
 - [ ] T030 [US2] Verify tests pass: run `make test` and confirm all tests pass
       with new module path
@@ -137,7 +137,7 @@ finfocus-spec path (zero pulumicost-spec imports remain)
 
 ### Implementation for User Story 3
 
-- [ ] T031 [P] [US3] Update package-name in release-please-config.json from `pulumicost-spec` to `finfocus-spec`
+- [ ] T031 [P] [US3] Update package-name in release-please-config.json from `finfocus-spec` to `finfocus-spec`
 - [ ] T032 [US3] Reset root version in .release-please-manifest.json to `0.5.0` (complete reset as per research decision)
 - [ ] T033 [P] [US3] Update .github/workflows/ci.yml to use new module name in
       cache keys (e.g., go-mod-cache: github.com/rshade/finfocus-spec)
@@ -158,10 +158,10 @@ finfocus-spec path (zero pulumicost-spec imports remain)
 
 **Purpose**: Global text replacement, documentation updates, and final validation
 
-- [ ] T038 [P] Perform global case-sensitive find/replace: `pulumicost` →
+- [ ] T038 [P] Perform global case-sensitive find/replace: `finfocus` →
       `finfocus` (lowercase) across entire repository (excluding historical
       files like specs/)
-- [ ] T039 [P] Perform global case-sensitive find/replace: `PulumiCost` →
+- [ ] T039 [P] Perform global case-sensitive find/replace: `FinFocus` →
       `FinFocus` (PascalCase) across entire repository (excluding historical
       files like specs/)
 - [ ] T040 [P] Perform global case-sensitive find/replace: `PULUMICOST` →
@@ -172,19 +172,19 @@ finfocus-spec path (zero pulumicost-spec imports remain)
 - [ ] T042 [P] Update docs/ directory: search and replace brand references while
       preserving historical context (contextual replacement per research
       decision)
-- [ ] T043 [P] Update CLAUDE.md references to pulumicost-spec where appropriate (preserve historical notes)
-- [ ] T044 [P] Update GEMINI.md references to pulumicost-spec where appropriate (preserve historical notes)
-- [ ] T045 [P] Update AGENTS.md references to pulumicost-spec where appropriate (preserve historical notes)
+- [ ] T043 [P] Update CLAUDE.md references to finfocus-spec where appropriate (preserve historical notes)
+- [ ] T044 [P] Update GEMINI.md references to finfocus-spec where appropriate (preserve historical notes)
+- [ ] T045 [P] Update AGENTS.md references to finfocus-spec where appropriate (preserve historical notes)
 - [ ] T046 [P] Update any other documentation files (docs/\*.md) with FinFocus branding (contextual replacement)
 - [ ] T047 Final validation: run `make generate` and confirm clean proto code generation
 - [ ] T048 Final validation: run `make test` and confirm all tests pass
 - [ ] T049 Final validation: run `make validate` (linting and schema
       validation) and confirm all checks pass
-- [ ] T050 [P] Search for remaining pulumicost brand references: run
-      `rg -i "pulumicost"` and verify only historical context remains (in
+- [ ] T050 [P] Search for remaining finfocus brand references: run
+      `rg -i "finfocus"` and verify only historical context remains (in
       specs/, docs with legacy notes)
-- [ ] T051 [P] Search for remaining PulumiCost brand references: run
-      `rg "PulumiCost"` and verify only historical context remains
+- [ ] T051 [P] Search for remaining FinFocus brand references: run
+      `rg "FinFocus"` and verify only historical context remains
 - [ ] T052 Verify wire protocol compatibility: run `make generate` and confirm
       generated proto files maintain service and message structure
 - [ ] T053 Validate success criteria: verify SC-001 through SC-005 from spec.md
@@ -218,7 +218,7 @@ finfocus-spec path (zero pulumicost-spec imports remain)
 - **User Story 2 (P2)**: SDK Module Transition
   - **BLOCKS ON**: US1 completion (proto must be renamed before Go module)
   - Must complete before US3 (release config should be done after module rename)
-  - Independently testable: Run `go test ./...` and verify zero pulumicost-spec imports
+  - Independently testable: Run `go test ./...` and verify zero finfocus-spec imports
 
 - **User Story 3 (P3)**: Automated Release Management
   - **BLOCKS ON**: US2 completion (module path must be updated before release config)
@@ -261,9 +261,9 @@ Task: "Update examples/**/*.go imports"
 
 ```bash
 # Launch all global replacements together (parallel):
-Task: "Perform global case-sensitive find/replace: pulumicost →
+Task: "Perform global case-sensitive find/replace: finfocus →
       finfocus"
-Task: "Perform global case-sensitive find/replace: PulumiCost →
+Task: "Perform global case-sensitive find/replace: FinFocus →
       FinFocus"
 Task: "Perform global case-sensitive find/replace: PULUMICOST →
       FINFOCUS"


### PR DESCRIPTION
This pull request renames all references to the "PulumiCost" ecosystem and its agents to "FinFocus" across the specialized Claude agent configuration files and documentation. The update ensures that the agent guidance, descriptions, detection rules, and invariants are consistent with the new FinFocus branding and repository structure.

Key changes include:

**Agent Configuration and Naming Updates:**

* All agent files (`pulumicost-senior-engineer.md`, `pulumicost-technical-writer.md`, `pulumicost-product-manager.md`) have been renamed and updated to `finfocus-senior-engineer.md`, `finfocus-technical-writer.md`, and `finfocus-product-manager.md`, with corresponding changes to their `name` and `description` fields, example scenarios, and repository detection logic. [[1]](diffhunk://#diff-f467c33d9e8149b344c5b1a4678af2e86c63a0682d45d310d193fd02f7543e8eL2-R16) [[2]](diffhunk://#diff-8a8aaa84304c775fffef6ae9c7b46c9dd44915b869680567ee30b4acbb08d15cL2-R15) [[3]](diffhunk://#diff-1acbd95977c6c014241b5ffd762d0c3b8512eab191f1335feefe3c21e059ac4aL2-R15)

**Repository and Ecosystem References:**

* All documentation and agent guidance in `.claude/agents/CLAUDE.md` have been updated to reference the FinFocus ecosystem, repositories (`finfocus-spec`, `finfocus-core`, `finfocus-plugin-*`), and related file paths instead of PulumiCost. [[1]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L7-R25) [[2]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L49-R49) [[3]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L72-R72) [[4]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L91-R91) [[5]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L123-R129) [[6]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L186-R186) [[7]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L207-R221) [[8]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L325-R325)

**Program Invariants and File Paths:**

* All hardcoded file paths, plugin discovery locations, and proto/schema references have been updated from PulumiCost to FinFocus (e.g., `~/.finfocus/plugins/...`, `proto/finfocus/...`). [[1]](diffhunk://#diff-f467c33d9e8149b344c5b1a4678af2e86c63a0682d45d310d193fd02f7543e8eL29-R29) [[2]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L91-R91) [[3]](diffhunk://#diff-b4c820106980684c1b7573b8327c5f7729d0eee56e59958a3a589a80e38bd7e0L123-R129)

**Role Descriptions and Responsibilities:**

* Role descriptions and responsibilities for each agent have been reworded to refer to FinFocus, ensuring clarity and consistency throughout all agent documentation. [[1]](diffhunk://#diff-8a8aaa84304c775fffef6ae9c7b46c9dd44915b869680567ee30b4acbb08d15cL80-R80) [[2]](diffhunk://#diff-1acbd95977c6c014241b5ffd762d0c3b8512eab191f1335feefe3c21e059ac4aL2-R15) [[3]](diffhunk://#diff-f467c33d9e8149b344c5b1a4678af2e86c63a0682d45d310d193fd02f7543e8eL2-R16)

These changes ensure that all agent configurations and documentation are now fully aligned with the FinFocus ecosystem and repository structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plugin APIs for projected/actual cost, pricing specs, and cost estimation; server config now exposes plugin info.

* **Improvements**
  * Standardized environment variable names and improved log-file handling with validation and safe fallbacks.
  * Updated observability dashboard and alert defaults to reflect rebranding and environment options.

* **Tests**
  * Added a conformance performance test for plugin info retrieval.

* **Chores**
  * Rebranded documentation, examples, and comments to FinFocus.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->