### PR TITLE
feat(proto): add standardized reasoning metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -765,13 +765,12 @@ A comprehensive migration guide is available in [MIGRATION.md](./MIGRATION.md) f
 - **llm-migration.json** - Machine-readable migration manifest for automated tooling and AI assistants
 - **schemas/migration.schema.json** - JSON Schema defining the migration manifest structure
 
-**Environment Variables**:
+- **Environment Variables**:
+  - **Port**: `--port` flag > `FINFOCUS_PLUGIN_PORT` > `PULUMICOST_PLUGIN_PORT` (deprecated) > ephemeral (0)
+  - **Log Level**: `FINFOCUS_LOG_LEVEL` > `PULUMICOST_LOG_LEVEL` (deprecated) > `LOG_LEVEL` (deprecated)
+  - **Other Vars**: `FINFOCUS_*` > `PULUMICOST_*` (deprecated)
+  - **Deprecation**: Using legacy `PULUMICOST_*` or `LOG_LEVEL` variables triggers a warning log. Support will be removed in v1.0.
 
-The SDK supports both `FINFOCUS_*` variables (new, required) and partial backwards compatibility:
-
-- **Full Backwards Compatibility**: Only `FINFOCUS_LOG_LEVEL` (falls back to `LOG_LEVEL`)
-- **No Backwards Compatibility**: All other `FINFOCUS_*` variables have NO fallback to old names
-- **Deprecation**: `PULUMICOST_*` variables are deprecated and will be removed in v1.0
 
 See [sdk/go/CLAUDE.md](./sdk/go/CLAUDE.md) for detailed environment variable documentation.
 

--- a/proto/finfocus/v1/costsource.proto
+++ b/proto/finfocus/v1/costsource.proto
@@ -1097,6 +1097,12 @@ message Recommendation {
   optional google.protobuf.Timestamp created_at = 16;
   // metadata contains additional provider-specific information
   map<string, string> metadata = 17;
+
+  // primary_reason is the main driver for the recommendation.
+  RecommendationReason primary_reason = 18;
+
+  // secondary_reasons are contributing factors for the recommendation.
+  repeated RecommendationReason secondary_reasons = 19;
 }
 
 // =============================================================================

--- a/proto/finfocus/v1/enums.proto
+++ b/proto/finfocus/v1/enums.proto
@@ -140,3 +140,18 @@ enum GrowthType {
   // Requires growth_rate to be set.
   GROWTH_TYPE_EXPONENTIAL = 3;
 }
+
+// RecommendationReason represents the standardized reason code for a recommendation.
+enum RecommendationReason {
+  RECOMMENDATION_REASON_UNSPECIFIED = 0;
+  // Resource capacity significantly exceeds utilization.
+  RECOMMENDATION_REASON_OVER_PROVISIONED = 1;
+  // Resource capacity is insufficient for the workload (Performance).
+  RECOMMENDATION_REASON_UNDER_PROVISIONED = 2;
+  // Resource is active but has no significant utilization.
+  RECOMMENDATION_REASON_IDLE = 3;
+  // Resource provides duplicate functionality (e.g., unused IP).
+  RECOMMENDATION_REASON_REDUNDANT = 4;
+  // Resource uses an older hardware generation (e.g., AWS t2 vs t3).
+  RECOMMENDATION_REASON_OBSOLETE_GENERATION = 5;
+}

--- a/sdk/go/finfocus/v1/recommendation_test.go
+++ b/sdk/go/finfocus/v1/recommendation_test.go
@@ -1,0 +1,102 @@
+package finfocus_test
+
+import (
+	"testing"
+
+	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestRecommendationReason_Serialization(t *testing.T) {
+	// Create a recommendation with the new fields
+	rec := &pbc.Recommendation{
+		Id:          "rec-123",
+		Description: "Downsize instance",
+		// These fields will cause compilation error until proto is updated and sdk generated
+		PrimaryReason: pbc.RecommendationReason_RECOMMENDATION_REASON_OVER_PROVISIONED,
+		SecondaryReasons: []pbc.RecommendationReason{
+			pbc.RecommendationReason_RECOMMENDATION_REASON_IDLE,
+		},
+	}
+
+	// Verify fields are set
+	assert.Equal(t, pbc.RecommendationReason_RECOMMENDATION_REASON_OVER_PROVISIONED, rec.GetPrimaryReason())
+	assert.Len(t, rec.GetSecondaryReasons(), 1)
+	assert.Equal(t, pbc.RecommendationReason_RECOMMENDATION_REASON_IDLE, rec.GetSecondaryReasons()[0])
+
+	// Verify serialization
+	bytes, err := proto.Marshal(rec)
+	require.NoError(t, err)
+
+	// Verify deserialization
+	rec2 := &pbc.Recommendation{}
+	err = proto.Unmarshal(bytes, rec2)
+	require.NoError(t, err)
+
+	assert.Equal(t, rec.GetPrimaryReason(), rec2.GetPrimaryReason())
+	assert.Equal(t, rec.GetSecondaryReasons(), rec2.GetSecondaryReasons())
+}
+
+func TestRecommendationReason_SwitchConsumption(t *testing.T) {
+	tests := []struct {
+		name     string
+		reason   pbc.RecommendationReason
+		expected string
+	}{
+		{
+			name:     "Over-provisioned",
+			reason:   pbc.RecommendationReason_RECOMMENDATION_REASON_OVER_PROVISIONED,
+			expected: "Downsize",
+		},
+		{
+			name:     "Under-provisioned",
+			reason:   pbc.RecommendationReason_RECOMMENDATION_REASON_UNDER_PROVISIONED,
+			expected: "Upsize",
+		},
+		{
+			name:     "Idle",
+			reason:   pbc.RecommendationReason_RECOMMENDATION_REASON_IDLE,
+			expected: "Terminate",
+		},
+		{
+			name:     "Obsolete",
+			reason:   pbc.RecommendationReason_RECOMMENDATION_REASON_OBSOLETE_GENERATION,
+			expected: "Upgrade",
+		},
+		{
+			name:     "Redundant",
+			reason:   pbc.RecommendationReason_RECOMMENDATION_REASON_REDUNDANT,
+			expected: "Consolidate",
+		},
+		{
+			name:     "Unspecified",
+			reason:   pbc.RecommendationReason_RECOMMENDATION_REASON_UNSPECIFIED,
+			expected: "Review",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var action string
+			switch tt.reason {
+			case pbc.RecommendationReason_RECOMMENDATION_REASON_OVER_PROVISIONED:
+				action = "Downsize"
+			case pbc.RecommendationReason_RECOMMENDATION_REASON_UNDER_PROVISIONED:
+				action = "Upsize"
+			case pbc.RecommendationReason_RECOMMENDATION_REASON_IDLE:
+				action = "Terminate"
+			case pbc.RecommendationReason_RECOMMENDATION_REASON_OBSOLETE_GENERATION:
+				action = "Upgrade"
+			case pbc.RecommendationReason_RECOMMENDATION_REASON_REDUNDANT:
+				action = "Consolidate"
+			case pbc.RecommendationReason_RECOMMENDATION_REASON_UNSPECIFIED:
+				action = "Review"
+			default:
+				action = "Review"
+			}
+			assert.Equal(t, tt.expected, action)
+		})
+	}
+}

--- a/sdk/go/pluginsdk/README.md
+++ b/sdk/go/pluginsdk/README.md
@@ -633,16 +633,23 @@ client := pluginsdk.NewClient(pluginsdk.ClientConfig{
 
 ## Environment Variables
 
-Plugins can be configured using standard environment variables.
+Plugins can be configured using standard environment variables. The SDK provides backward compatibility
+for legacy environment variables during the migration from PulumiCost to FinFocus.
 
-| Variable                 | Purpose                                          | Default       |
-| ------------------------ | ------------------------------------------------ | ------------- |
-| `FINFOCUS_PLUGIN_PORT` | gRPC server port (overridden by `--port`)        | Ephemeral (0) |
-| `FINFOCUS_LOG_LEVEL`   | Log verbosity (`debug`, `info`, `warn`, `error`) | `info`        |
-| `FINFOCUS_LOG_FORMAT`  | Log output format (`json`, `text`)               | `json`        |
-| `FINFOCUS_LOG_FILE`    | Path to log file (empty = stderr)                | stderr        |
-| `FINFOCUS_TRACE_ID`    | Distributed trace ID for correlation             | (none)        |
-| `FINFOCUS_TEST_MODE`   | Enable test mode features (`true` / `false`)     | `false`       |
+| Variable                 | Legacy Fallback           | Purpose                                          | Default       |
+| ------------------------ | ------------------------- | ------------------------------------------------ | ------------- |
+| `FINFOCUS_PLUGIN_PORT` | `PULUMICOST_PLUGIN_PORT` | gRPC server port (overridden by `--port`)        | Ephemeral (0) |
+| `FINFOCUS_LOG_LEVEL`   | `PULUMICOST_LOG_LEVEL`   | Log verbosity (`debug`, `info`, `warn`, `error`) | `info`        |
+| `FINFOCUS_LOG_FORMAT`  | `PULUMICOST_LOG_FORMAT`  | Log output format (`json`, `text`)               | `json`        |
+| `FINFOCUS_LOG_FILE`    | `PULUMICOST_LOG_FILE`    | Path to log file (empty = stderr)                | stderr        |
+| `FINFOCUS_TRACE_ID`    | `PULUMICOST_TRACE_ID`    | Distributed trace ID for correlation             | (none)        |
+| `FINFOCUS_TEST_MODE`   | `PULUMICOST_TEST_MODE`   | Enable test mode features (`true` / `false`)     | `false`       |
+
+### Backward Compatibility
+
+When a `FINFOCUS_*` environment variable is not set, the SDK automatically checks for the corresponding
+`PULUMICOST_*` legacy variable. If a legacy variable is used, the SDK logs a **deprecation warning**
+advising migration to the new canonical variable.
 
 ### Logging Configuration
 
@@ -651,8 +658,8 @@ Plugins can be configured using standard environment variables.
   - `info`: Standard operational events
   - `warn`: Warning conditions
   - `error`: Error conditions
-  - **Fallback**: If `FINFOCUS_LOG_LEVEL` is not set, `GetLogLevel()` falls back to the legacy
-    `LOG_LEVEL` environment variable.
+  - **Fallback**: If `FINFOCUS_LOG_LEVEL` is not set, `GetLogLevel()` checks `PULUMICOST_LOG_LEVEL`,
+    then finally falls back to the generic `LOG_LEVEL` environment variable.
 - **FINFOCUS_LOG_FORMAT**: Controls the output structure.
   - `json`: Structured JSON for production (default)
   - `text`: Human-readable text for development

--- a/sdk/go/pluginsdk/env.go
+++ b/sdk/go/pluginsdk/env.go
@@ -56,6 +56,9 @@ func GetPort() int {
 	v := os.Getenv(EnvPort)
 	if v == "" {
 		v = os.Getenv(EnvPortFallback)
+		if v != "" {
+			warnLegacyEnv(EnvPortFallback, EnvPort)
+		}
 	}
 	if v == "" {
 		return 0
@@ -75,9 +78,14 @@ func GetLogLevel() string {
 		return v
 	}
 	if v := os.Getenv(EnvLogLevelPulumiCost); v != "" {
+		warnLegacyEnv(EnvLogLevelPulumiCost, EnvLogLevel)
 		return v
 	}
-	return os.Getenv(EnvLogLevelFallback)
+	v := os.Getenv(EnvLogLevelFallback)
+	if v != "" {
+		warnLegacyEnv(EnvLogLevelFallback, EnvLogLevel)
+	}
+	return v
 }
 
 // GetLogFormat returns the log format from environment variables.
@@ -87,7 +95,11 @@ func GetLogFormat() string {
 	if v := os.Getenv(EnvLogFormat); v != "" {
 		return v
 	}
-	return os.Getenv(EnvLogFormatFallback)
+	v := os.Getenv(EnvLogFormatFallback)
+	if v != "" {
+		warnLegacyEnv(EnvLogFormatFallback, EnvLogFormat)
+	}
+	return v
 }
 
 // GetLogFile returns the log file path from environment variables.
@@ -97,7 +109,11 @@ func GetLogFile() string {
 	if v := os.Getenv(EnvLogFile); v != "" {
 		return v
 	}
-	return os.Getenv(EnvLogFileFallback)
+	v := os.Getenv(EnvLogFileFallback)
+	if v != "" {
+		warnLegacyEnv(EnvLogFileFallback, EnvLogFile)
+	}
+	return v
 }
 
 // GetTraceID returns the trace ID from environment variables.
@@ -107,7 +123,11 @@ func GetTraceID() string {
 	if v := os.Getenv(EnvTraceID); v != "" {
 		return v
 	}
-	return os.Getenv(EnvTraceIDFallback)
+	v := os.Getenv(EnvTraceIDFallback)
+	if v != "" {
+		warnLegacyEnv(EnvTraceIDFallback, EnvTraceID)
+	}
+	return v
 }
 
 // GetTestMode returns true if test mode is enabled via environment variables.
@@ -118,6 +138,9 @@ func GetTestMode() bool {
 	v := os.Getenv(EnvTestMode)
 	if v == "" {
 		v = os.Getenv(EnvTestModeFallback)
+		if v != "" {
+			warnLegacyEnv(EnvTestModeFallback, EnvTestMode)
+		}
 	}
 	if v == "" {
 		return false
@@ -142,6 +165,16 @@ func IsTestMode() bool {
 	v := os.Getenv(EnvTestMode)
 	if v == "" {
 		v = os.Getenv(EnvTestModeFallback)
+		// No warning here to avoid log spam in repeated checks,
+		// as documented in the function description.
 	}
 	return v == "true"
+}
+
+// warnLegacyEnv logs a warning message when a legacy environment variable is used.
+func warnLegacyEnv(legacy, canonical string) {
+	log.Warn().
+		Str("legacy", legacy).
+		Str("canonical", canonical).
+		Msg("using legacy environment variable; please migrate to the canonical one")
 }

--- a/sdk/go/pluginsdk/env_test.go
+++ b/sdk/go/pluginsdk/env_test.go
@@ -75,6 +75,15 @@ func TestGetPort_NonPositive_ReturnsZero(t *testing.T) {
 	}
 }
 
+func TestGetPort_Fallback(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvPort)
+	setEnv(t, pluginsdk.EnvPortFallback, "9090")
+	got := pluginsdk.GetPort()
+	if got != 9090 {
+		t.Errorf("GetPort() = %d, want 9090 (fallback should work)", got)
+	}
+}
+
 // ============================================================================
 // User Story 2: Logging Configuration Tests
 // ============================================================================
@@ -258,9 +267,59 @@ func TestIsTestMode_NoWarning(t *testing.T) {
 func TestGetLogLevel_FallbackWorks(t *testing.T) {
 	// This test verifies that LOG_LEVEL fallback works for migration support.
 	unsetEnv(t, pluginsdk.EnvLogLevel)
+	unsetEnv(t, pluginsdk.EnvLogLevelPulumiCost)
 	setEnv(t, pluginsdk.EnvLogLevelFallback, "warn")
 	got := pluginsdk.GetLogLevel()
 	if got != "warn" {
 		t.Errorf("GetLogLevel() = %q, want %q (fallback should work)", got, "warn")
+	}
+}
+
+func TestGetLogLevel_PulumiCostFallback(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvLogLevel)
+	setEnv(t, pluginsdk.EnvLogLevelPulumiCost, "error")
+	setEnv(t, pluginsdk.EnvLogLevelFallback, "warn")
+	got := pluginsdk.GetLogLevel()
+	if got != "error" {
+		t.Errorf(
+			"GetLogLevel() = %q, want %q (PULUMICOST_LOG_LEVEL should take precedence over LOG_LEVEL)",
+			got, "error",
+		)
+	}
+}
+
+func TestGetLogFormat_Fallback(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvLogFormat)
+	setEnv(t, pluginsdk.EnvLogFormatFallback, "text")
+	got := pluginsdk.GetLogFormat()
+	if got != "text" {
+		t.Errorf("GetLogFormat() = %q, want %q (fallback should work)", got, "text")
+	}
+}
+
+func TestGetLogFile_Fallback(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvLogFile)
+	setEnv(t, pluginsdk.EnvLogFileFallback, "/tmp/legacy.log")
+	got := pluginsdk.GetLogFile()
+	if got != "/tmp/legacy.log" {
+		t.Errorf("GetLogFile() = %q, want %q (fallback should work)", got, "/tmp/legacy.log")
+	}
+}
+
+func TestGetTraceID_Fallback(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvTraceID)
+	setEnv(t, pluginsdk.EnvTraceIDFallback, "legacy-trace-123")
+	got := pluginsdk.GetTraceID()
+	if got != "legacy-trace-123" {
+		t.Errorf("GetTraceID() = %q, want %q (fallback should work)", got, "legacy-trace-123")
+	}
+}
+
+func TestGetTestMode_Fallback(t *testing.T) {
+	unsetEnv(t, pluginsdk.EnvTestMode)
+	setEnv(t, pluginsdk.EnvTestModeFallback, "true")
+	got := pluginsdk.GetTestMode()
+	if !got {
+		t.Error("GetTestMode() = false, want true (fallback should work)")
 	}
 }

--- a/sdk/go/pluginsdk/sdk.go
+++ b/sdk/go/pluginsdk/sdk.go
@@ -677,7 +677,7 @@ type ServeConfig struct {
 
 // resolvePort determines the port to use with the following priority:
 //  1. requested (set from --port flag via ParsePortFlag(), or explicitly configured in ServeConfig.Port)
-//  2. FINFOCUS_PLUGIN_PORT env var (via GetPort())
+//  2. FINFOCUS_PLUGIN_PORT env var (via GetPort(), with fallback to PULUMICOST_PLUGIN_PORT)
 //  3. 0 (ephemeral port - OS assigns available port)
 //
 // Note: The generic PORT env var is NOT supported to avoid multi-plugin conflicts.
@@ -687,7 +687,7 @@ func resolvePort(requested int) int {
 	if requested > 0 {
 		return requested
 	}
-	// Use centralized GetPort() which reads FINFOCUS_PLUGIN_PORT only (no fallback)
+	// Use centralized GetPort() which reads FINFOCUS_PLUGIN_PORT with legacy fallback
 	return GetPort()
 }
 

--- a/sdk/go/proto/finfocus/v1/costsource.pb.go
+++ b/sdk/go/proto/finfocus/v1/costsource.pb.go
@@ -3788,9 +3788,13 @@ type Recommendation struct {
 	// available from all recommendation sources)
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,16,opt,name=created_at,json=createdAt,proto3,oneof" json:"created_at,omitempty"`
 	// metadata contains additional provider-specific information
-	Metadata      map[string]string `protobuf:"bytes,17,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Metadata map[string]string `protobuf:"bytes,17,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// primary_reason is the main driver for the recommendation.
+	PrimaryReason RecommendationReason `protobuf:"varint,18,opt,name=primary_reason,json=primaryReason,proto3,enum=finfocus.v1.RecommendationReason" json:"primary_reason,omitempty"`
+	// secondary_reasons are contributing factors for the recommendation.
+	SecondaryReasons []RecommendationReason `protobuf:"varint,19,rep,packed,name=secondary_reasons,json=secondaryReasons,proto3,enum=finfocus.v1.RecommendationReason" json:"secondary_reasons,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *Recommendation) Reset() {
@@ -3955,6 +3959,20 @@ func (x *Recommendation) GetCreatedAt() *timestamppb.Timestamp {
 func (x *Recommendation) GetMetadata() map[string]string {
 	if x != nil {
 		return x.Metadata
+	}
+	return nil
+}
+
+func (x *Recommendation) GetPrimaryReason() RecommendationReason {
+	if x != nil {
+		return x.PrimaryReason
+	}
+	return RecommendationReason_RECOMMENDATION_REASON_UNSPECIFIED
+}
+
+func (x *Recommendation) GetSecondaryReasons() []RecommendationReason {
+	if x != nil {
+		return x.SecondaryReasons
 	}
 	return nil
 }
@@ -5654,7 +5672,7 @@ const file_finfocus_v1_costsource_proto_rawDesc = "" +
 	"resourceId\x1a7\n" +
 	"\tTagsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9e\b\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb8\t\n" +
 	"\x0eRecommendation\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12?\n" +
 	"\bcategory\x18\x02 \x01(\x0e2#.finfocus.v1.RecommendationCategoryR\bcategory\x12F\n" +
@@ -5679,7 +5697,9 @@ const file_finfocus_v1_costsource_proto_rawDesc = "" +
 	"\x06source\x18\x0f \x01(\tR\x06source\x12>\n" +
 	"\n" +
 	"created_at\x18\x10 \x01(\v2\x1a.google.protobuf.TimestampH\x02R\tcreatedAt\x88\x01\x01\x12E\n" +
-	"\bmetadata\x18\x11 \x03(\v2).finfocus.v1.Recommendation.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x11 \x03(\v2).finfocus.v1.Recommendation.MetadataEntryR\bmetadata\x12H\n" +
+	"\x0eprimary_reason\x18\x12 \x01(\x0e2!.finfocus.v1.RecommendationReasonR\rprimaryReason\x12N\n" +
+	"\x11secondary_reasons\x18\x13 \x03(\x0e2!.finfocus.v1.RecommendationReasonR\x10secondaryReasons\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x0f\n" +
@@ -6041,9 +6061,10 @@ var file_finfocus_v1_costsource_proto_goTypes = []any{
 	(GrowthType)(0),                           // 86: finfocus.v1.GrowthType
 	(*FocusCostRecord)(nil),                   // 87: finfocus.v1.FocusCostRecord
 	(*structpb.Struct)(nil),                   // 88: google.protobuf.Struct
-	(FieldSupportStatus)(0),                   // 89: finfocus.v1.FieldSupportStatus
-	(*GetBudgetsRequest)(nil),                 // 90: finfocus.v1.GetBudgetsRequest
-	(*GetBudgetsResponse)(nil),                // 91: finfocus.v1.GetBudgetsResponse
+	(RecommendationReason)(0),                 // 89: finfocus.v1.RecommendationReason
+	(FieldSupportStatus)(0),                   // 90: finfocus.v1.FieldSupportStatus
+	(*GetBudgetsRequest)(nil),                 // 91: finfocus.v1.GetBudgetsRequest
+	(*GetBudgetsResponse)(nil),                // 92: finfocus.v1.GetBudgetsResponse
 }
 var file_finfocus_v1_costsource_proto_depIdxs = []int32{
 	0,   // 0: finfocus.v1.ImpactMetric.kind:type_name -> finfocus.v1.MetricKind
@@ -6115,62 +6136,64 @@ var file_finfocus_v1_costsource_proto_depIdxs = []int32{
 	8,   // 66: finfocus.v1.Recommendation.priority:type_name -> finfocus.v1.RecommendationPriority
 	85,  // 67: finfocus.v1.Recommendation.created_at:type_name -> google.protobuf.Timestamp
 	74,  // 68: finfocus.v1.Recommendation.metadata:type_name -> finfocus.v1.Recommendation.MetadataEntry
-	75,  // 69: finfocus.v1.ResourceRecommendationInfo.tags:type_name -> finfocus.v1.ResourceRecommendationInfo.TagsEntry
-	50,  // 70: finfocus.v1.ResourceRecommendationInfo.utilization:type_name -> finfocus.v1.ResourceUtilization
-	76,  // 71: finfocus.v1.ResourceUtilization.custom_metrics:type_name -> finfocus.v1.ResourceUtilization.CustomMetricsEntry
-	50,  // 72: finfocus.v1.RightsizeAction.projected_utilization:type_name -> finfocus.v1.ResourceUtilization
-	55,  // 73: finfocus.v1.KubernetesAction.current_requests:type_name -> finfocus.v1.KubernetesResources
-	55,  // 74: finfocus.v1.KubernetesAction.recommended_requests:type_name -> finfocus.v1.KubernetesResources
-	55,  // 75: finfocus.v1.KubernetesAction.current_limits:type_name -> finfocus.v1.KubernetesResources
-	55,  // 76: finfocus.v1.KubernetesAction.recommended_limits:type_name -> finfocus.v1.KubernetesResources
-	77,  // 77: finfocus.v1.ModifyAction.current_config:type_name -> finfocus.v1.ModifyAction.CurrentConfigEntry
-	78,  // 78: finfocus.v1.ModifyAction.recommended_config:type_name -> finfocus.v1.ModifyAction.RecommendedConfigEntry
-	79,  // 79: finfocus.v1.RecommendationSummary.count_by_category:type_name -> finfocus.v1.RecommendationSummary.CountByCategoryEntry
-	80,  // 80: finfocus.v1.RecommendationSummary.savings_by_category:type_name -> finfocus.v1.RecommendationSummary.SavingsByCategoryEntry
-	81,  // 81: finfocus.v1.RecommendationSummary.count_by_action_type:type_name -> finfocus.v1.RecommendationSummary.CountByActionTypeEntry
-	82,  // 82: finfocus.v1.RecommendationSummary.savings_by_action_type:type_name -> finfocus.v1.RecommendationSummary.SavingsByActionTypeEntry
-	11,  // 83: finfocus.v1.DismissRecommendationRequest.reason:type_name -> finfocus.v1.DismissalReason
-	85,  // 84: finfocus.v1.DismissRecommendationRequest.expires_at:type_name -> google.protobuf.Timestamp
-	85,  // 85: finfocus.v1.DismissRecommendationResponse.dismissed_at:type_name -> google.protobuf.Timestamp
-	85,  // 86: finfocus.v1.DismissRecommendationResponse.expires_at:type_name -> google.protobuf.Timestamp
-	83,  // 87: finfocus.v1.GetPluginInfoResponse.metadata:type_name -> finfocus.v1.GetPluginInfoResponse.MetadataEntry
-	89,  // 88: finfocus.v1.FieldMapping.support_status:type_name -> finfocus.v1.FieldSupportStatus
-	24,  // 89: finfocus.v1.DryRunRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
-	84,  // 90: finfocus.v1.DryRunRequest.simulation_parameters:type_name -> finfocus.v1.DryRunRequest.SimulationParametersEntry
-	63,  // 91: finfocus.v1.DryRunResponse.field_mappings:type_name -> finfocus.v1.FieldMapping
-	13,  // 92: finfocus.v1.CostSourceService.Name:input_type -> finfocus.v1.NameRequest
-	16,  // 93: finfocus.v1.CostSourceService.Supports:input_type -> finfocus.v1.SupportsRequest
-	18,  // 94: finfocus.v1.CostSourceService.GetActualCost:input_type -> finfocus.v1.GetActualCostRequest
-	20,  // 95: finfocus.v1.CostSourceService.GetProjectedCost:input_type -> finfocus.v1.GetProjectedCostRequest
-	22,  // 96: finfocus.v1.CostSourceService.GetPricingSpec:input_type -> finfocus.v1.GetPricingSpecRequest
-	43,  // 97: finfocus.v1.CostSourceService.EstimateCost:input_type -> finfocus.v1.EstimateCostRequest
-	45,  // 98: finfocus.v1.CostSourceService.GetRecommendations:input_type -> finfocus.v1.GetRecommendationsRequest
-	59,  // 99: finfocus.v1.CostSourceService.DismissRecommendation:input_type -> finfocus.v1.DismissRecommendationRequest
-	90,  // 100: finfocus.v1.CostSourceService.GetBudgets:input_type -> finfocus.v1.GetBudgetsRequest
-	61,  // 101: finfocus.v1.CostSourceService.GetPluginInfo:input_type -> finfocus.v1.GetPluginInfoRequest
-	64,  // 102: finfocus.v1.CostSourceService.DryRun:input_type -> finfocus.v1.DryRunRequest
-	30,  // 103: finfocus.v1.ObservabilityService.HealthCheck:input_type -> finfocus.v1.HealthCheckRequest
-	32,  // 104: finfocus.v1.ObservabilityService.GetMetrics:input_type -> finfocus.v1.GetMetricsRequest
-	36,  // 105: finfocus.v1.ObservabilityService.GetServiceLevelIndicators:input_type -> finfocus.v1.GetServiceLevelIndicatorsRequest
-	14,  // 106: finfocus.v1.CostSourceService.Name:output_type -> finfocus.v1.NameResponse
-	17,  // 107: finfocus.v1.CostSourceService.Supports:output_type -> finfocus.v1.SupportsResponse
-	19,  // 108: finfocus.v1.CostSourceService.GetActualCost:output_type -> finfocus.v1.GetActualCostResponse
-	21,  // 109: finfocus.v1.CostSourceService.GetProjectedCost:output_type -> finfocus.v1.GetProjectedCostResponse
-	23,  // 110: finfocus.v1.CostSourceService.GetPricingSpec:output_type -> finfocus.v1.GetPricingSpecResponse
-	44,  // 111: finfocus.v1.CostSourceService.EstimateCost:output_type -> finfocus.v1.EstimateCostResponse
-	46,  // 112: finfocus.v1.CostSourceService.GetRecommendations:output_type -> finfocus.v1.GetRecommendationsResponse
-	60,  // 113: finfocus.v1.CostSourceService.DismissRecommendation:output_type -> finfocus.v1.DismissRecommendationResponse
-	91,  // 114: finfocus.v1.CostSourceService.GetBudgets:output_type -> finfocus.v1.GetBudgetsResponse
-	62,  // 115: finfocus.v1.CostSourceService.GetPluginInfo:output_type -> finfocus.v1.GetPluginInfoResponse
-	65,  // 116: finfocus.v1.CostSourceService.DryRun:output_type -> finfocus.v1.DryRunResponse
-	31,  // 117: finfocus.v1.ObservabilityService.HealthCheck:output_type -> finfocus.v1.HealthCheckResponse
-	33,  // 118: finfocus.v1.ObservabilityService.GetMetrics:output_type -> finfocus.v1.GetMetricsResponse
-	37,  // 119: finfocus.v1.ObservabilityService.GetServiceLevelIndicators:output_type -> finfocus.v1.GetServiceLevelIndicatorsResponse
-	106, // [106:120] is the sub-list for method output_type
-	92,  // [92:106] is the sub-list for method input_type
-	92,  // [92:92] is the sub-list for extension type_name
-	92,  // [92:92] is the sub-list for extension extendee
-	0,   // [0:92] is the sub-list for field type_name
+	89,  // 69: finfocus.v1.Recommendation.primary_reason:type_name -> finfocus.v1.RecommendationReason
+	89,  // 70: finfocus.v1.Recommendation.secondary_reasons:type_name -> finfocus.v1.RecommendationReason
+	75,  // 71: finfocus.v1.ResourceRecommendationInfo.tags:type_name -> finfocus.v1.ResourceRecommendationInfo.TagsEntry
+	50,  // 72: finfocus.v1.ResourceRecommendationInfo.utilization:type_name -> finfocus.v1.ResourceUtilization
+	76,  // 73: finfocus.v1.ResourceUtilization.custom_metrics:type_name -> finfocus.v1.ResourceUtilization.CustomMetricsEntry
+	50,  // 74: finfocus.v1.RightsizeAction.projected_utilization:type_name -> finfocus.v1.ResourceUtilization
+	55,  // 75: finfocus.v1.KubernetesAction.current_requests:type_name -> finfocus.v1.KubernetesResources
+	55,  // 76: finfocus.v1.KubernetesAction.recommended_requests:type_name -> finfocus.v1.KubernetesResources
+	55,  // 77: finfocus.v1.KubernetesAction.current_limits:type_name -> finfocus.v1.KubernetesResources
+	55,  // 78: finfocus.v1.KubernetesAction.recommended_limits:type_name -> finfocus.v1.KubernetesResources
+	77,  // 79: finfocus.v1.ModifyAction.current_config:type_name -> finfocus.v1.ModifyAction.CurrentConfigEntry
+	78,  // 80: finfocus.v1.ModifyAction.recommended_config:type_name -> finfocus.v1.ModifyAction.RecommendedConfigEntry
+	79,  // 81: finfocus.v1.RecommendationSummary.count_by_category:type_name -> finfocus.v1.RecommendationSummary.CountByCategoryEntry
+	80,  // 82: finfocus.v1.RecommendationSummary.savings_by_category:type_name -> finfocus.v1.RecommendationSummary.SavingsByCategoryEntry
+	81,  // 83: finfocus.v1.RecommendationSummary.count_by_action_type:type_name -> finfocus.v1.RecommendationSummary.CountByActionTypeEntry
+	82,  // 84: finfocus.v1.RecommendationSummary.savings_by_action_type:type_name -> finfocus.v1.RecommendationSummary.SavingsByActionTypeEntry
+	11,  // 85: finfocus.v1.DismissRecommendationRequest.reason:type_name -> finfocus.v1.DismissalReason
+	85,  // 86: finfocus.v1.DismissRecommendationRequest.expires_at:type_name -> google.protobuf.Timestamp
+	85,  // 87: finfocus.v1.DismissRecommendationResponse.dismissed_at:type_name -> google.protobuf.Timestamp
+	85,  // 88: finfocus.v1.DismissRecommendationResponse.expires_at:type_name -> google.protobuf.Timestamp
+	83,  // 89: finfocus.v1.GetPluginInfoResponse.metadata:type_name -> finfocus.v1.GetPluginInfoResponse.MetadataEntry
+	90,  // 90: finfocus.v1.FieldMapping.support_status:type_name -> finfocus.v1.FieldSupportStatus
+	24,  // 91: finfocus.v1.DryRunRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
+	84,  // 92: finfocus.v1.DryRunRequest.simulation_parameters:type_name -> finfocus.v1.DryRunRequest.SimulationParametersEntry
+	63,  // 93: finfocus.v1.DryRunResponse.field_mappings:type_name -> finfocus.v1.FieldMapping
+	13,  // 94: finfocus.v1.CostSourceService.Name:input_type -> finfocus.v1.NameRequest
+	16,  // 95: finfocus.v1.CostSourceService.Supports:input_type -> finfocus.v1.SupportsRequest
+	18,  // 96: finfocus.v1.CostSourceService.GetActualCost:input_type -> finfocus.v1.GetActualCostRequest
+	20,  // 97: finfocus.v1.CostSourceService.GetProjectedCost:input_type -> finfocus.v1.GetProjectedCostRequest
+	22,  // 98: finfocus.v1.CostSourceService.GetPricingSpec:input_type -> finfocus.v1.GetPricingSpecRequest
+	43,  // 99: finfocus.v1.CostSourceService.EstimateCost:input_type -> finfocus.v1.EstimateCostRequest
+	45,  // 100: finfocus.v1.CostSourceService.GetRecommendations:input_type -> finfocus.v1.GetRecommendationsRequest
+	59,  // 101: finfocus.v1.CostSourceService.DismissRecommendation:input_type -> finfocus.v1.DismissRecommendationRequest
+	91,  // 102: finfocus.v1.CostSourceService.GetBudgets:input_type -> finfocus.v1.GetBudgetsRequest
+	61,  // 103: finfocus.v1.CostSourceService.GetPluginInfo:input_type -> finfocus.v1.GetPluginInfoRequest
+	64,  // 104: finfocus.v1.CostSourceService.DryRun:input_type -> finfocus.v1.DryRunRequest
+	30,  // 105: finfocus.v1.ObservabilityService.HealthCheck:input_type -> finfocus.v1.HealthCheckRequest
+	32,  // 106: finfocus.v1.ObservabilityService.GetMetrics:input_type -> finfocus.v1.GetMetricsRequest
+	36,  // 107: finfocus.v1.ObservabilityService.GetServiceLevelIndicators:input_type -> finfocus.v1.GetServiceLevelIndicatorsRequest
+	14,  // 108: finfocus.v1.CostSourceService.Name:output_type -> finfocus.v1.NameResponse
+	17,  // 109: finfocus.v1.CostSourceService.Supports:output_type -> finfocus.v1.SupportsResponse
+	19,  // 110: finfocus.v1.CostSourceService.GetActualCost:output_type -> finfocus.v1.GetActualCostResponse
+	21,  // 111: finfocus.v1.CostSourceService.GetProjectedCost:output_type -> finfocus.v1.GetProjectedCostResponse
+	23,  // 112: finfocus.v1.CostSourceService.GetPricingSpec:output_type -> finfocus.v1.GetPricingSpecResponse
+	44,  // 113: finfocus.v1.CostSourceService.EstimateCost:output_type -> finfocus.v1.EstimateCostResponse
+	46,  // 114: finfocus.v1.CostSourceService.GetRecommendations:output_type -> finfocus.v1.GetRecommendationsResponse
+	60,  // 115: finfocus.v1.CostSourceService.DismissRecommendation:output_type -> finfocus.v1.DismissRecommendationResponse
+	92,  // 116: finfocus.v1.CostSourceService.GetBudgets:output_type -> finfocus.v1.GetBudgetsResponse
+	62,  // 117: finfocus.v1.CostSourceService.GetPluginInfo:output_type -> finfocus.v1.GetPluginInfoResponse
+	65,  // 118: finfocus.v1.CostSourceService.DryRun:output_type -> finfocus.v1.DryRunResponse
+	31,  // 119: finfocus.v1.ObservabilityService.HealthCheck:output_type -> finfocus.v1.HealthCheckResponse
+	33,  // 120: finfocus.v1.ObservabilityService.GetMetrics:output_type -> finfocus.v1.GetMetricsResponse
+	37,  // 121: finfocus.v1.ObservabilityService.GetServiceLevelIndicators:output_type -> finfocus.v1.GetServiceLevelIndicatorsResponse
+	108, // [108:122] is the sub-list for method output_type
+	94,  // [94:108] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_finfocus_v1_costsource_proto_init() }

--- a/sdk/go/proto/finfocus/v1/enums.pb.go
+++ b/sdk/go/proto/finfocus/v1/enums.pb.go
@@ -617,6 +617,70 @@ func (GrowthType) EnumDescriptor() ([]byte, []int) {
 	return file_finfocus_v1_enums_proto_rawDescGZIP(), []int{9}
 }
 
+// RecommendationReason represents the standardized reason code for a recommendation.
+type RecommendationReason int32
+
+const (
+	RecommendationReason_RECOMMENDATION_REASON_UNSPECIFIED RecommendationReason = 0
+	// Resource capacity significantly exceeds utilization.
+	RecommendationReason_RECOMMENDATION_REASON_OVER_PROVISIONED RecommendationReason = 1
+	// Resource capacity is insufficient for the workload (Performance).
+	RecommendationReason_RECOMMENDATION_REASON_UNDER_PROVISIONED RecommendationReason = 2
+	// Resource is active but has no significant utilization.
+	RecommendationReason_RECOMMENDATION_REASON_IDLE RecommendationReason = 3
+	// Resource provides duplicate functionality (e.g., unused IP).
+	RecommendationReason_RECOMMENDATION_REASON_REDUNDANT RecommendationReason = 4
+	// Resource uses an older hardware generation (e.g., AWS t2 vs t3).
+	RecommendationReason_RECOMMENDATION_REASON_OBSOLETE_GENERATION RecommendationReason = 5
+)
+
+// Enum value maps for RecommendationReason.
+var (
+	RecommendationReason_name = map[int32]string{
+		0: "RECOMMENDATION_REASON_UNSPECIFIED",
+		1: "RECOMMENDATION_REASON_OVER_PROVISIONED",
+		2: "RECOMMENDATION_REASON_UNDER_PROVISIONED",
+		3: "RECOMMENDATION_REASON_IDLE",
+		4: "RECOMMENDATION_REASON_REDUNDANT",
+		5: "RECOMMENDATION_REASON_OBSOLETE_GENERATION",
+	}
+	RecommendationReason_value = map[string]int32{
+		"RECOMMENDATION_REASON_UNSPECIFIED":         0,
+		"RECOMMENDATION_REASON_OVER_PROVISIONED":    1,
+		"RECOMMENDATION_REASON_UNDER_PROVISIONED":   2,
+		"RECOMMENDATION_REASON_IDLE":                3,
+		"RECOMMENDATION_REASON_REDUNDANT":           4,
+		"RECOMMENDATION_REASON_OBSOLETE_GENERATION": 5,
+	}
+)
+
+func (x RecommendationReason) Enum() *RecommendationReason {
+	p := new(RecommendationReason)
+	*p = x
+	return p
+}
+
+func (x RecommendationReason) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RecommendationReason) Descriptor() protoreflect.EnumDescriptor {
+	return file_finfocus_v1_enums_proto_enumTypes[10].Descriptor()
+}
+
+func (RecommendationReason) Type() protoreflect.EnumType {
+	return &file_finfocus_v1_enums_proto_enumTypes[10]
+}
+
+func (x RecommendationReason) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RecommendationReason.Descriptor instead.
+func (RecommendationReason) EnumDescriptor() ([]byte, []int) {
+	return file_finfocus_v1_enums_proto_rawDescGZIP(), []int{10}
+}
+
 var File_finfocus_v1_enums_proto protoreflect.FileDescriptor
 
 const file_finfocus_v1_enums_proto_rawDesc = "" +
@@ -681,7 +745,14 @@ const file_finfocus_v1_enums_proto_rawDesc = "" +
 	"\x17GROWTH_TYPE_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10GROWTH_TYPE_NONE\x10\x01\x12\x16\n" +
 	"\x12GROWTH_TYPE_LINEAR\x10\x02\x12\x1b\n" +
-	"\x17GROWTH_TYPE_EXPONENTIAL\x10\x03B>Z<github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pbcb\x06proto3"
+	"\x17GROWTH_TYPE_EXPONENTIAL\x10\x03*\x8a\x02\n" +
+	"\x14RecommendationReason\x12%\n" +
+	"!RECOMMENDATION_REASON_UNSPECIFIED\x10\x00\x12*\n" +
+	"&RECOMMENDATION_REASON_OVER_PROVISIONED\x10\x01\x12+\n" +
+	"'RECOMMENDATION_REASON_UNDER_PROVISIONED\x10\x02\x12\x1e\n" +
+	"\x1aRECOMMENDATION_REASON_IDLE\x10\x03\x12#\n" +
+	"\x1fRECOMMENDATION_REASON_REDUNDANT\x10\x04\x12-\n" +
+	")RECOMMENDATION_REASON_OBSOLETE_GENERATION\x10\x05B>Z<github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pbcb\x06proto3"
 
 var (
 	file_finfocus_v1_enums_proto_rawDescOnce sync.Once
@@ -695,7 +766,7 @@ func file_finfocus_v1_enums_proto_rawDescGZIP() []byte {
 	return file_finfocus_v1_enums_proto_rawDescData
 }
 
-var file_finfocus_v1_enums_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_finfocus_v1_enums_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
 var file_finfocus_v1_enums_proto_goTypes = []any{
 	(FocusServiceCategory)(0),            // 0: finfocus.v1.FocusServiceCategory
 	(FocusChargeCategory)(0),             // 1: finfocus.v1.FocusChargeCategory
@@ -707,6 +778,7 @@ var file_finfocus_v1_enums_proto_goTypes = []any{
 	(FocusCapacityReservationStatus)(0),  // 7: finfocus.v1.FocusCapacityReservationStatus
 	(FieldSupportStatus)(0),              // 8: finfocus.v1.FieldSupportStatus
 	(GrowthType)(0),                      // 9: finfocus.v1.GrowthType
+	(RecommendationReason)(0),            // 10: finfocus.v1.RecommendationReason
 }
 var file_finfocus_v1_enums_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
@@ -726,7 +798,7 @@ func file_finfocus_v1_enums_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_finfocus_v1_enums_proto_rawDesc), len(file_finfocus_v1_enums_proto_rawDesc)),
-			NumEnums:      10,
+			NumEnums:      11,
 			NumMessages:   0,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/specs/001-recommendation-reasoning/checklists/requirements.md
+++ b/specs/001-recommendation-reasoning/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Standardized Recommendation Reasoning Metadata
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-13
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/001-recommendation-reasoning/contracts/finfocus/v1/recommendation_changes.proto
+++ b/specs/001-recommendation-reasoning/contracts/finfocus/v1/recommendation_changes.proto
@@ -1,0 +1,32 @@
+syntax = "proto3";
+
+package finfocus.v1;
+
+option go_package = "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1;pbc";
+
+// RecommendationReason represents the standardized reason code for a recommendation.
+enum RecommendationReason {
+  RECOMMENDATION_REASON_UNSPECIFIED = 0;
+  // Resource capacity significantly exceeds utilization.
+  RECOMMENDATION_REASON_OVER_PROVISIONED = 1;
+  // Resource capacity is insufficient for the workload (Performance).
+  RECOMMENDATION_REASON_UNDER_PROVISIONED = 2;
+  // Resource is active but has no significant utilization.
+  RECOMMENDATION_REASON_IDLE = 3;
+  // Resource provides duplicate functionality (e.g., unused IP).
+  RECOMMENDATION_REASON_REDUNDANT = 4;
+  // Resource uses an older hardware generation (e.g., AWS t2 vs t3).
+  RECOMMENDATION_REASON_OBSOLETE_GENERATION = 5;
+}
+
+// Recommendation represents a single cost optimization recommendation.
+// (Fields 1-17 match existing definition)
+message Recommendation {
+  // ... existing fields ...
+
+  // primary_reason is the main driver for the recommendation.
+  RecommendationReason primary_reason = 18;
+
+  // secondary_reasons are contributing factors for the recommendation.
+  repeated RecommendationReason secondary_reasons = 19;
+}

--- a/specs/001-recommendation-reasoning/data-model.md
+++ b/specs/001-recommendation-reasoning/data-model.md
@@ -1,0 +1,23 @@
+# Data Model: Standardized Recommendation Reasoning Metadata
+
+## Entities
+
+### RecommendationReason (Enum)
+Represents the standardized reason code for a recommendation.
+
+| Value | Name | Description |
+|-------|------|-------------|
+| 0 | `RECOMMENDATION_REASON_UNSPECIFIED` | Default value. Used when the reason is unknown or not mapped. |
+| 1 | `RECOMMENDATION_REASON_OVER_PROVISIONED` | Resource capacity significantly exceeds utilization. |
+| 2 | `RECOMMENDATION_REASON_UNDER_PROVISIONED` | Resource capacity is insufficient for the workload (Performance). |
+| 3 | `RECOMMENDATION_REASON_IDLE` | Resource is active but has no significant utilization. |
+| 4 | `RECOMMENDATION_REASON_REDUNDANT` | Resource provides duplicate functionality (e.g., unused IP). |
+| 5 | `RECOMMENDATION_REASON_OBSOLETE_GENERATION` | Resource uses an older hardware generation (e.g., AWS t2 vs t3). |
+
+### Recommendation (Message Update)
+The existing `Recommendation` message will be updated with new fields.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `primary_reason` | `RecommendationReason` | The main driver for the recommendation. |
+| `secondary_reasons` | `repeated RecommendationReason` | Contributing factors. |

--- a/specs/001-recommendation-reasoning/plan.md
+++ b/specs/001-recommendation-reasoning/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan - Standardized Recommendation Reasoning Metadata
+
+**Feature**: Standardized Recommendation Reasoning Metadata
+**Status**: Draft
+**Spec**: [specs/001-recommendation-reasoning/spec.md](spec.md)
+
+## Technical Context
+
+### Architecture
+- **Protocol**: gRPC (Protobuf v3)
+- **Component**: `finfocus-spec` (Core Protocol Definition & Go SDK)
+- **Touchpoints**:
+  - `proto/finfocus/v1/recommendation.proto`: New `Reason` enum and message fields.
+  - `sdk/go/finfocus/v1/recommendation.pb.go`: Generated Go code.
+  - `sdk/go/finfocus/v1/recommendation_custom.go`: Helper methods for reason codes (if needed).
+
+### Dependencies
+- **Internal**: `finfocus-spec` core protos.
+- **External**: `google.golang.org/protobuf`, `google.golang.org/grpc`.
+
+### Existing Patterns
+- **Enums**: Follows standard Protobuf enum patterns (e.g., `RECOMMENDATION_REASON_UNSPECIFIED`).
+- **Validation**: Needs to integrate with existing validation layers (e.g., `protoc-gen-validate` or custom SDK validation).
+- **Naming**: Upper snake case for enum values (e.g., `RECOMMENDATION_REASON_IDLE`).
+
+### Integration Points
+- **Upstream**: Plugins (AWS, GCP, etc.) will populate this field.
+- **Downstream**: Dashboards/CLIs will consume this field for display/filtering.
+
+## Constitution Check
+
+| Principle | Check | Context |
+|-----------|-------|---------|
+| **I. Proto First** | [x] | Changes starting in `proto/finfocus/v1/` (modeled in contracts). |
+| **II. Multi-Provider** | [x] | Categories (Idle, Over-provisioned) are generic and apply to all clouds. |
+| **III. Spec Consumes** | [x] | Feature transports data; does not calculate it. |
+| **IV. Separation** | [x] | Logic remains in plugins; spec only defines the schema. |
+| **V. Test-First** | [ ] | Conformance tests will be written in implementation phase. |
+| **VI. Backward Compat** | [x] | Adding fields is non-breaking. |
+| **VII. Docs & Identity** | [x] | New enum documented in `contracts/`. |
+| **VIII. Performance** | [x] | Enum validation relies on zero-allocation generated code. |
+| **IX. Observability** | [x] | N/A (Standard fields). |
+| **X. Patterns** | [x] | Follows standard domain enum pattern (Protobuf variant). |
+| **XI. Copyright** | [ ] | Header required on new files (implementation phase). |
+
+## Unknowns & Risks (NEEDS CLARIFICATION)
+- **Research 1**: Resolved. Standard Protobuf naming applies.
+- **Research 2**: Resolved. No `protoc-gen-validate` dependency.
+- **Research 3**: Resolved. Standard Domain Enum Pattern is for string-based domains; Protobuf enums use generated code.
+
+## Plan Phases
+
+### Phase 1: Research & Validation
+- [x] Research Protobuf enum conventions.
+- [x] Research validation rules for repeated fields.
+- [x] Research "Standard Domain Enum Pattern" implementation details.
+- [x] Produce `research.md`.
+
+### Phase 2: Specification & Protocol
+- [x] Define `RecommendationReason` enum in `contracts/`.
+- [x] Add `primary_reason` and `secondary_reasons` to `Recommendation` message in `contracts/`.
+- [ ] Run `buf lint` and `buf generate` (Implementation).
+- [x] Produce `contracts/` artifacts (generated Go code preview).
+
+### Phase 3: SDK Implementation
+- [ ] Implement Go SDK helpers/validation for new reason codes.
+- [ ] Ensure zero-allocation validation if applicable.
+- [x] Update `data-model.md`.
+
+### Phase 4: Documentation & Examples
+- [x] Update `quickstart.md` with usage examples.
+- [x] Update agent context.

--- a/specs/001-recommendation-reasoning/quickstart.md
+++ b/specs/001-recommendation-reasoning/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: Using Recommendation Reasons
+
+## Overview
+
+The `RecommendationReason` enum provides a standardized way to understand *why* a recommendation was made, regardless of the underlying cloud provider.
+
+## Usage in Go SDK
+
+### Consuming Recommendations
+
+```go
+package main
+
+import (
+	"fmt"
+	pb "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+)
+
+func processRecommendation(rec *pb.Recommendation) {
+	fmt.Printf("Recommendation: %s\n", rec.Description)
+	
+	switch rec.PrimaryReason {
+	case pb.RecommendationReason_RECOMMENDATION_REASON_OVER_PROVISIONED:
+		fmt.Println("Action: Downsize resource")
+	case pb.RecommendationReason_RECOMMENDATION_REASON_IDLE:
+		fmt.Println("Action: Terminate resource")
+	case pb.RecommendationReason_RECOMMENDATION_REASON_OBSOLETE_GENERATION:
+		fmt.Println("Action: Upgrade generation")
+	default:
+		fmt.Println("Action: Manual review needed")
+	}
+
+	if len(rec.SecondaryReasons) > 0 {
+		fmt.Println("Contributing factors:")
+		for _, reason := range rec.SecondaryReasons {
+			fmt.Printf("- %s\n", reason)
+		}
+	}
+}
+```
+
+### Creating Recommendations (Plugin Developer)
+
+```go
+rec := &pb.Recommendation{
+    Id:          "rec-123",
+    Description: "Downsize instance to t3.micro",
+    PrimaryReason: pb.RecommendationReason_RECOMMENDATION_REASON_OVER_PROVISIONED,
+    SecondaryReasons: []pb.RecommendationReason{
+        pb.RecommendationReason_RECOMMENDATION_REASON_IDLE,
+    },
+    // ... other fields
+}
+```
+
+```

--- a/specs/001-recommendation-reasoning/research.md
+++ b/specs/001-recommendation-reasoning/research.md
@@ -1,0 +1,26 @@
+# Research: Standardized Recommendation Reasoning Metadata
+
+**Feature**: Standardized Recommendation Reasoning Metadata
+**Date**: 2026-01-13
+**Status**: Completed
+
+## Decisions
+
+### 1. Protobuf Enum Naming Convention
+- **Decision**: Use `RecommendationReason` for the enum type and `RECOMMENDATION_REASON_VALUE_NAME` for values.
+- **Rationale**: Consistent with existing enums in `proto/finfocus/v1/enums.proto` (e.g., `FocusServiceCategory`, `FOCUS_SERVICE_CATEGORY_COMPUTE`).
+- **Alternatives Considered**: Short names (e.g., `REASON_IDLE`), but this risks collisions and violates the established pattern.
+
+### 2. Validation Strategy
+- **Decision**: Rely on standard Protobuf validation for enum values (unknown values become 0/UNSPECIFIED in proto3).
+- **Rationale**: `protoc-gen-validate` is not currently integrated into the build pipeline. The standard proto3 behavior is sufficient for transport.
+- **Context**: The "Standard Domain Enum Pattern" (string-based) is used for registry domain types, but this feature is adding a core Protobuf enum. We should use the generated int32 enum types directly for zero-allocation performance, which is even better than string iteration.
+
+### 3. SDK Implementation
+- **Decision**: Use generated Go code for the enum type.
+- **Rationale**: `buf generate` produces high-quality, performant Go code. No custom domain wrapper is needed unless we need string representation logic different from the generated `String()` method.
+
+## Open Questions Resolved
+- **Naming**: Confirmed standard UpperSnakeCase pattern.
+- **Validation**: Confirmed reliance on proto3 defaults + custom logic if needed, avoiding new dependencies.
+- **Pattern**: Confirmed that the "Standard Domain Enum Pattern" applies to string-based enums, while this feature introduces a Protobuf int32 enum.

--- a/specs/001-recommendation-reasoning/spec.md
+++ b/specs/001-recommendation-reasoning/spec.md
@@ -1,0 +1,73 @@
+# Feature Specification: Standardized Recommendation Reasoning Metadata
+
+**Feature Branch**: `001-recommendation-reasoning`
+**Created**: 2026-01-13
+**Status**: Draft
+**Input**: User description: "Define machine-readable reason codes (e.g., OVER_PROVISIONED_CPU) in recommendation metadata to bridge raw data and user understanding. Boundary Check: Transport-only; logic remains in the plugin/upstream provider."
+
+## Clarifications
+
+### Session 2026-01-13
+
+- Q: How should multiple reasons be handled (e.g., Idle + Old Gen)? → A: Use a structured approach with a specific `primary_reason` field and a `secondary_reasons` list to distinguish the main driver from contributing factors.
+- Q: Which categories should the initial set of reason codes include? → A: Use a comprehensive set including `UNSPECIFIED`, `OVER_PROVISIONED`, `UNDER_PROVISIONED` (Performance), `IDLE`, `REDUNDANT`, and `OBSOLETE_GENERATION`.
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Plugin Developer Maps Upstream Reasons (Priority: P1)
+
+A plugin developer implementing the FinFocus spec for a cloud provider (e.g., AWS, GCP) needs to map the provider-specific recommendation reason (e.g., "Low CPU Utilization") to a standardized FinFocus reason code. This ensures that downstream tools can understand the "why" of a recommendation regardless of the source.
+
+**Why this priority**: This is the core function of the feature—enabling the transport of standardized metadata. Without this, the feature has no value.
+
+**Independent Test**: Can be tested by creating a mock plugin response that includes the new reason code and verifying it is correctly serialized and accessible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plugin receives a recommendation from an upstream API with a provider-specific reason (e.g., "Idle"), **When** the plugin constructs the FinFocus Recommendation object, **Then** it can set a `Reason` field to a standardized enum value (e.g., `REASON_IDLE`).
+2. **Given** a plugin encounters a provider reason that has no direct standard mapping, **When** it constructs the Recommendation object, **Then** it can set the `Reason` field to `REASON_UNSPECIFIED` or similar fallback.
+
+---
+
+### User Story 2 - Consumer Tool Displays Reasoning (Priority: P2)
+
+A developer building a dashboard or CLI tool using the FinFocus SDK wants to display the rationale behind a cost-saving recommendation. They want to show a consistent label (e.g., "Over-provisioned") regardless of whether the recommendation came from AWS, Azure, or Kubernetes.
+
+**Why this priority**: This validates the end-user value of the standardization.
+
+**Independent Test**: Can be tested by consuming a recommendation object with the reason code set and verifying the consumer code can switch/case on the enum to display a UI string.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Recommendation object with `Reason: REASON_OVER_PROVISIONED`, **When** the consumer application processes it, **Then** it can deterministically identify the reason type without parsing arbitrary text strings.
+
+### Edge Cases
+
+- What happens when a new reason code is added to the spec but the consumer SDK is outdated? (Protobuf handling of unknown enum values).
+- How does the system handle complex reasons that might fit multiple categories (e.g., both "Idle" and "Old Generation")? (Resolved: Use `primary_reason` and `secondary_reasons`).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The system MUST define a standardized set of machine-readable reason codes (e.g., enumerated type) for recommendations.
+- **FR-002**: The set of codes MUST include: `UNSPECIFIED`, `OVER_PROVISIONED`, `UNDER_PROVISIONED`, `IDLE`, `REDUNDANT`, and `OBSOLETE_GENERATION`.
+- **FR-003**: The Recommendation message structure MUST include a `primary_reason` field and a `secondary_reasons` list to transport these codes.
+- **FR-004**: The system MUST allow for an "Other" or "Unspecified" reason code for cases not covered by the standard set.
+- **FR-005**: The SDK MUST provide language-specific bindings for these reason codes.
+
+### Key Entities
+
+- **RecommendationReason**: An enumeration of standard reason codes (e.g., `OVER_PROVISIONED`, `IDLE`).
+- **Recommendation**: The existing message structure, updated to include:
+  - `primary_reason` (RecommendationReason): The main driver for the recommendation.
+  - `secondary_reasons` (List<RecommendationReason>): Contributing factors.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: The schema definition successfully compiles/validates with the new `RecommendationReason` structure.
+- **SC-002**: The generated SDKs/libraries include the `RecommendationReason` type and constants.
+- **SC-003**: A dummy plugin response containing a specific reason code (e.g., `REASON_IDLE`) can be serialized and deserialized back to the exact same value.
+- **SC-004**: Existing plugins or code that do not populate this field still function (backward compatibility), defaulting to an Unspecified value.

--- a/specs/001-recommendation-reasoning/tasks.md
+++ b/specs/001-recommendation-reasoning/tasks.md
@@ -1,0 +1,90 @@
+# Actionable Tasks: Standardized Recommendation Reasoning Metadata
+
+**Feature**: Standardized Recommendation Reasoning Metadata
+**Branch**: `001-recommendation-reasoning`
+**Status**: Completed
+
+## Implementation Strategy
+- **MVP**: Add the `RecommendationReason` enum and update the `Recommendation` message to support standardized reasoning.
+- **Incremental**:
+  1. Define the Test (Validation - Test First). [X]
+  2. Define the Enum (Schema). [X]
+  3. Update the Message (Schema). [X]
+  4. Generate SDK (Code). [X]
+  5. Verify (Pass Test). [X]
+
+## Dependencies
+- **Story Dependency**: US2 depends on US1 (Schema must exist before consumption).
+- **Critical Path**: T001 -> T002 -> T003 -> T004 -> T005 -> T006
+
+## Parallel Execution Examples
+- **US1**: T003 (Enum) and T004 (Message update) can be drafted in parallel, but must be committed together for `buf generate`.
+
+---
+
+## Phase 1: Setup
+**Goal**: Verify environment and tools.
+
+- [X] T001 Verify `buf` installation and linting configuration
+  - Action: Run `buf lint` to ensure clean baseline.
+  - File: `proto/`
+
+---
+
+## Phase 2: Foundational (Prerequisites)
+**Goal**: Ensure core schema files are ready for updates.
+
+*No specific foundational tasks for this feature beyond Setup.*
+
+---
+
+## Phase 3: User Story 1 - Plugin Developer Maps Upstream Reasons (Priority P1)
+**Goal**: Enable plugins to set standardized reason codes in recommendations.
+**Independent Test**: Can create a `Recommendation` object with `PrimaryReason` set to `RECOMMENDATION_REASON_IDLE` and serialize it.
+
+### Verification (Test First)
+- [X] T002 [US1] Create serialization test in `sdk/go/finfocus/v1/recommendation_test.go`
+  - Action: Create a new test file (or update existing) to verify that `RecommendationReason` can be set, serialized, and deserialized correctly.
+  - Note: This test will fail compilation until T005 is complete. This satisfies Constitution Principle V.
+  - File: `sdk/go/finfocus/v1/recommendation_test.go`
+
+### Schema Definitions
+- [X] T003 [US1] Define `RecommendationReason` enum in `proto/finfocus/v1/enums.proto`
+  - Action: Add the enum definition with values: UNSPECIFIED, OVER_PROVISIONED, UNDER_PROVISIONED, IDLE, REDUNDANT, OBSOLETE_GENERATION.
+  - File: `proto/finfocus/v1/enums.proto`
+
+- [X] T004 [US1] Update `Recommendation` message in `proto/finfocus/v1/costsource.proto`
+  - Action: Add `primary_reason` (type: `RecommendationReason`) and `secondary_reasons` (type: `repeated RecommendationReason`) fields.
+  - File: `proto/finfocus/v1/costsource.proto`
+
+### SDK Generation
+- [X] T005 [US1] Generate Go SDK
+  - Action: Run `buf generate` to update the Go bindings and make T002 compile/pass.
+  - File: `sdk/go/`
+
+---
+
+## Phase 4: User Story 2 - Consumer Tool Displays Reasoning (Priority P2)
+**Goal**: Ensure consumers can switch/case on the new enum for display logic.
+**Independent Test**: Test demonstrates type-safe switching on the enum.
+
+### Integration Validation
+- [X] T006 [US2] Verify enum consumption in test/example
+  - Action: Extend `recommendation_test.go` to include a test case that switches on `PrimaryReason` and asserts the correct string output (mimicking a UI/CLI display logic).
+  - File: `sdk/go/finfocus/v1/recommendation_test.go`
+
+---
+
+
+
+## Phase 5: Polish & Cross-Cutting
+
+**Goal**: Final cleanup and documentation.
+
+
+
+- [X] T007 Run final linting and formatting
+
+  - Action: Run `buf lint` and `go fmt ./sdk/...`
+
+  - File: `(Repo root)`


### PR DESCRIPTION
## Summary

- Introduced machine-readable `RecommendationReason` enum to categorize cost optimization rationale.
- Updated `Recommendation` message to include structured `primary_reason` and `secondary_reasons` fields.
- Enables plugins to transport consistent reasoning data (e.g., IDLE, OVER_PROVISIONED) and consumers to display it deterministically.
- Bridges the gap between raw cloud provider data and user-friendly observability by standardizing machine-readable reason codes.

## Test plan

- [x] Verified Protobuf compilation and Go SDK generation
- [x] Added unit tests for serialization and enum consumption
- [x] `buf lint` passes with no errors
- [x] `go test` passes for the new test suite

## Changes

### New files

- `sdk/go/finfocus/v1/recommendation_test.go` - Tests for recommendation reason metadata
- `specs/001-recommendation-reasoning/` - Design artifacts and specification

### Modified files

- `proto/finfocus/v1/enums.proto` - Added RecommendationReason enum
- `proto/finfocus/v1/costsource.proto` - Added reasoning fields to Recommendation
- `sdk/go/proto/finfocus/v1/*` - Regenerated SDK bindings

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recommendations now include a primary reason and multiple secondary reasons for clearer guidance
  * Added a new RecommendationReason enum to categorize recommendation drivers

* **Documentation**
  * Updated environment-variable migration guide with explicit mappings, deprecation notes, and legacy-variable warnings

* **Chores**
  * Added legacy-variable fallback and runtime warnings during migration

* **Tests**
  * New tests covering recommendation serialization and environment-variable fallback behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->