### PR TITLE
feat(sdk): implement granular capability discovery in supports rpc

### DIFF
--- a/proto/finfocus/v1/costsource.proto
+++ b/proto/finfocus/v1/costsource.proto
@@ -209,6 +209,9 @@ message SupportsResponse {
   map<string, bool> capabilities = 3;
   // supported_metrics declares optional sustainability metrics the plugin supports
   repeated MetricKind supported_metrics = 4;
+  // capabilities_enum declares optional capabilities using strongly-typed enums.
+  // This field is automatically populated by the SDK based on implemented interfaces.
+  repeated PluginCapability capabilities_enum = 5;
 }
 
 // GetActualCostRequest contains parameters for retrieving historical cost data.

--- a/sdk/go/proto/finfocus/v1/costsource.pb.go
+++ b/sdk/go/proto/finfocus/v1/costsource.pb.go
@@ -1042,6 +1042,9 @@ type SupportsResponse struct {
 	Capabilities map[string]bool `protobuf:"bytes,3,rep,name=capabilities,proto3" json:"capabilities,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	// supported_metrics declares optional sustainability metrics the plugin supports
 	SupportedMetrics []MetricKind `protobuf:"varint,4,rep,packed,name=supported_metrics,json=supportedMetrics,proto3,enum=finfocus.v1.MetricKind" json:"supported_metrics,omitempty"`
+	// capabilities_enum declares optional capabilities using strongly-typed enums.
+	// This field is automatically populated by the SDK based on implemented interfaces.
+	CapabilitiesEnum []PluginCapability `protobuf:"varint,5,rep,packed,name=capabilities_enum,json=capabilitiesEnum,proto3,enum=finfocus.v1.PluginCapability" json:"capabilities_enum,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -1100,6 +1103,13 @@ func (x *SupportsResponse) GetCapabilities() map[string]bool {
 func (x *SupportsResponse) GetSupportedMetrics() []MetricKind {
 	if x != nil {
 		return x.SupportedMetrics
+	}
+	return nil
+}
+
+func (x *SupportsResponse) GetCapabilitiesEnum() []PluginCapability {
+	if x != nil {
+		return x.CapabilitiesEnum
 	}
 	return nil
 }
@@ -5446,12 +5456,13 @@ const file_finfocus_v1_costsource_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x01R\x05value\x12\x12\n" +
 	"\x04unit\x18\x03 \x01(\tR\x04unit\"N\n" +
 	"\x0fSupportsRequest\x12;\n" +
-	"\bresource\x18\x01 \x01(\v2\x1f.finfocus.v1.ResourceDescriptorR\bresource\"\xa4\x02\n" +
+	"\bresource\x18\x01 \x01(\v2\x1f.finfocus.v1.ResourceDescriptorR\bresource\"\xf0\x02\n" +
 	"\x10SupportsResponse\x12\x1c\n" +
 	"\tsupported\x18\x01 \x01(\bR\tsupported\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12S\n" +
 	"\fcapabilities\x18\x03 \x03(\v2/.finfocus.v1.SupportsResponse.CapabilitiesEntryR\fcapabilities\x12D\n" +
-	"\x11supported_metrics\x18\x04 \x03(\x0e2\x17.finfocus.v1.MetricKindR\x10supportedMetrics\x1a?\n" +
+	"\x11supported_metrics\x18\x04 \x03(\x0e2\x17.finfocus.v1.MetricKindR\x10supportedMetrics\x12J\n" +
+	"\x11capabilities_enum\x18\x05 \x03(\x0e2\x1d.finfocus.v1.PluginCapabilityR\x10capabilitiesEnum\x1a?\n" +
 	"\x11CapabilitiesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\bR\x05value:\x028\x01\"\xbc\x02\n" +
@@ -6067,12 +6078,12 @@ var file_finfocus_v1_costsource_proto_goTypes = []any{
 	nil,                                       // 82: finfocus.v1.RecommendationSummary.SavingsByActionTypeEntry
 	nil,                                       // 83: finfocus.v1.GetPluginInfoResponse.MetadataEntry
 	nil,                                       // 84: finfocus.v1.DryRunRequest.SimulationParametersEntry
-	(*timestamppb.Timestamp)(nil),             // 85: google.protobuf.Timestamp
-	(GrowthType)(0),                           // 86: finfocus.v1.GrowthType
-	(*FocusCostRecord)(nil),                   // 87: finfocus.v1.FocusCostRecord
-	(*structpb.Struct)(nil),                   // 88: google.protobuf.Struct
-	(RecommendationReason)(0),                 // 89: finfocus.v1.RecommendationReason
-	(PluginCapability)(0),                     // 90: finfocus.v1.PluginCapability
+	(PluginCapability)(0),                     // 85: finfocus.v1.PluginCapability
+	(*timestamppb.Timestamp)(nil),             // 86: google.protobuf.Timestamp
+	(GrowthType)(0),                           // 87: finfocus.v1.GrowthType
+	(*FocusCostRecord)(nil),                   // 88: finfocus.v1.FocusCostRecord
+	(*structpb.Struct)(nil),                   // 89: google.protobuf.Struct
+	(RecommendationReason)(0),                 // 90: finfocus.v1.RecommendationReason
 	(FieldSupportStatus)(0),                   // 91: finfocus.v1.FieldSupportStatus
 	(*GetBudgetsRequest)(nil),                 // 92: finfocus.v1.GetBudgetsRequest
 	(*GetBudgetsResponse)(nil),                // 93: finfocus.v1.GetBudgetsResponse
@@ -6082,130 +6093,131 @@ var file_finfocus_v1_costsource_proto_depIdxs = []int32{
 	24,  // 1: finfocus.v1.SupportsRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
 	66,  // 2: finfocus.v1.SupportsResponse.capabilities:type_name -> finfocus.v1.SupportsResponse.CapabilitiesEntry
 	0,   // 3: finfocus.v1.SupportsResponse.supported_metrics:type_name -> finfocus.v1.MetricKind
-	85,  // 4: finfocus.v1.GetActualCostRequest.start:type_name -> google.protobuf.Timestamp
-	85,  // 5: finfocus.v1.GetActualCostRequest.end:type_name -> google.protobuf.Timestamp
-	67,  // 6: finfocus.v1.GetActualCostRequest.tags:type_name -> finfocus.v1.GetActualCostRequest.TagsEntry
-	25,  // 7: finfocus.v1.GetActualCostResponse.results:type_name -> finfocus.v1.ActualCostResult
-	1,   // 8: finfocus.v1.GetActualCostResponse.fallback_hint:type_name -> finfocus.v1.FallbackHint
-	65,  // 9: finfocus.v1.GetActualCostResponse.dry_run_result:type_name -> finfocus.v1.DryRunResponse
-	24,  // 10: finfocus.v1.GetProjectedCostRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
-	86,  // 11: finfocus.v1.GetProjectedCostRequest.growth_type:type_name -> finfocus.v1.GrowthType
-	15,  // 12: finfocus.v1.GetProjectedCostResponse.impact_metrics:type_name -> finfocus.v1.ImpactMetric
-	86,  // 13: finfocus.v1.GetProjectedCostResponse.growth_type:type_name -> finfocus.v1.GrowthType
-	65,  // 14: finfocus.v1.GetProjectedCostResponse.dry_run_result:type_name -> finfocus.v1.DryRunResponse
-	24,  // 15: finfocus.v1.GetPricingSpecRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
-	27,  // 16: finfocus.v1.GetPricingSpecResponse.spec:type_name -> finfocus.v1.PricingSpec
-	68,  // 17: finfocus.v1.ResourceDescriptor.tags:type_name -> finfocus.v1.ResourceDescriptor.TagsEntry
-	86,  // 18: finfocus.v1.ResourceDescriptor.growth_type:type_name -> finfocus.v1.GrowthType
-	85,  // 19: finfocus.v1.ActualCostResult.timestamp:type_name -> google.protobuf.Timestamp
-	87,  // 20: finfocus.v1.ActualCostResult.focus_record:type_name -> finfocus.v1.FocusCostRecord
-	15,  // 21: finfocus.v1.ActualCostResult.impact_metrics:type_name -> finfocus.v1.ImpactMetric
-	26,  // 22: finfocus.v1.PricingSpec.metric_hints:type_name -> finfocus.v1.UsageMetricHint
-	69,  // 23: finfocus.v1.PricingSpec.plugin_metadata:type_name -> finfocus.v1.PricingSpec.PluginMetadataEntry
-	28,  // 24: finfocus.v1.PricingSpec.pricing_tiers:type_name -> finfocus.v1.PricingTier
-	3,   // 25: finfocus.v1.ErrorDetail.code:type_name -> finfocus.v1.ErrorCode
-	2,   // 26: finfocus.v1.ErrorDetail.category:type_name -> finfocus.v1.ErrorCategory
-	70,  // 27: finfocus.v1.ErrorDetail.details:type_name -> finfocus.v1.ErrorDetail.DetailsEntry
-	85,  // 28: finfocus.v1.ErrorDetail.timestamp:type_name -> google.protobuf.Timestamp
-	12,  // 29: finfocus.v1.HealthCheckResponse.status:type_name -> finfocus.v1.HealthCheckResponse.Status
-	85,  // 30: finfocus.v1.HealthCheckResponse.last_check_time:type_name -> google.protobuf.Timestamp
-	34,  // 31: finfocus.v1.GetMetricsResponse.metrics:type_name -> finfocus.v1.Metric
-	85,  // 32: finfocus.v1.GetMetricsResponse.timestamp:type_name -> google.protobuf.Timestamp
-	4,   // 33: finfocus.v1.Metric.type:type_name -> finfocus.v1.MetricType
-	35,  // 34: finfocus.v1.Metric.samples:type_name -> finfocus.v1.MetricSample
-	71,  // 35: finfocus.v1.MetricSample.labels:type_name -> finfocus.v1.MetricSample.LabelsEntry
-	85,  // 36: finfocus.v1.MetricSample.timestamp:type_name -> google.protobuf.Timestamp
-	39,  // 37: finfocus.v1.GetServiceLevelIndicatorsRequest.time_range:type_name -> finfocus.v1.TimeRange
-	38,  // 38: finfocus.v1.GetServiceLevelIndicatorsResponse.slis:type_name -> finfocus.v1.ServiceLevelIndicator
-	85,  // 39: finfocus.v1.GetServiceLevelIndicatorsResponse.measurement_time:type_name -> google.protobuf.Timestamp
-	5,   // 40: finfocus.v1.ServiceLevelIndicator.status:type_name -> finfocus.v1.SLIStatus
-	85,  // 41: finfocus.v1.TimeRange.start:type_name -> google.protobuf.Timestamp
-	85,  // 42: finfocus.v1.TimeRange.end:type_name -> google.protobuf.Timestamp
-	85,  // 43: finfocus.v1.LogEntry.timestamp:type_name -> google.protobuf.Timestamp
-	72,  // 44: finfocus.v1.LogEntry.fields:type_name -> finfocus.v1.LogEntry.FieldsEntry
-	42,  // 45: finfocus.v1.LogEntry.error_details:type_name -> finfocus.v1.ErrorDetails
-	88,  // 46: finfocus.v1.EstimateCostRequest.attributes:type_name -> google.protobuf.Struct
-	47,  // 47: finfocus.v1.GetRecommendationsRequest.filter:type_name -> finfocus.v1.RecommendationFilter
-	24,  // 48: finfocus.v1.GetRecommendationsRequest.target_resources:type_name -> finfocus.v1.ResourceDescriptor
-	48,  // 49: finfocus.v1.GetRecommendationsResponse.recommendations:type_name -> finfocus.v1.Recommendation
-	58,  // 50: finfocus.v1.GetRecommendationsResponse.summary:type_name -> finfocus.v1.RecommendationSummary
-	6,   // 51: finfocus.v1.RecommendationFilter.category:type_name -> finfocus.v1.RecommendationCategory
-	7,   // 52: finfocus.v1.RecommendationFilter.action_type:type_name -> finfocus.v1.RecommendationActionType
-	73,  // 53: finfocus.v1.RecommendationFilter.tags:type_name -> finfocus.v1.RecommendationFilter.TagsEntry
-	8,   // 54: finfocus.v1.RecommendationFilter.priority:type_name -> finfocus.v1.RecommendationPriority
-	9,   // 55: finfocus.v1.RecommendationFilter.sort_by:type_name -> finfocus.v1.RecommendationSortBy
-	10,  // 56: finfocus.v1.RecommendationFilter.sort_order:type_name -> finfocus.v1.SortOrder
-	6,   // 57: finfocus.v1.Recommendation.category:type_name -> finfocus.v1.RecommendationCategory
-	7,   // 58: finfocus.v1.Recommendation.action_type:type_name -> finfocus.v1.RecommendationActionType
-	49,  // 59: finfocus.v1.Recommendation.resource:type_name -> finfocus.v1.ResourceRecommendationInfo
-	51,  // 60: finfocus.v1.Recommendation.rightsize:type_name -> finfocus.v1.RightsizeAction
-	52,  // 61: finfocus.v1.Recommendation.terminate:type_name -> finfocus.v1.TerminateAction
-	53,  // 62: finfocus.v1.Recommendation.commitment:type_name -> finfocus.v1.CommitmentAction
-	54,  // 63: finfocus.v1.Recommendation.kubernetes:type_name -> finfocus.v1.KubernetesAction
-	56,  // 64: finfocus.v1.Recommendation.modify:type_name -> finfocus.v1.ModifyAction
-	57,  // 65: finfocus.v1.Recommendation.impact:type_name -> finfocus.v1.RecommendationImpact
-	8,   // 66: finfocus.v1.Recommendation.priority:type_name -> finfocus.v1.RecommendationPriority
-	85,  // 67: finfocus.v1.Recommendation.created_at:type_name -> google.protobuf.Timestamp
-	74,  // 68: finfocus.v1.Recommendation.metadata:type_name -> finfocus.v1.Recommendation.MetadataEntry
-	89,  // 69: finfocus.v1.Recommendation.primary_reason:type_name -> finfocus.v1.RecommendationReason
-	89,  // 70: finfocus.v1.Recommendation.secondary_reasons:type_name -> finfocus.v1.RecommendationReason
-	75,  // 71: finfocus.v1.ResourceRecommendationInfo.tags:type_name -> finfocus.v1.ResourceRecommendationInfo.TagsEntry
-	50,  // 72: finfocus.v1.ResourceRecommendationInfo.utilization:type_name -> finfocus.v1.ResourceUtilization
-	76,  // 73: finfocus.v1.ResourceUtilization.custom_metrics:type_name -> finfocus.v1.ResourceUtilization.CustomMetricsEntry
-	50,  // 74: finfocus.v1.RightsizeAction.projected_utilization:type_name -> finfocus.v1.ResourceUtilization
-	55,  // 75: finfocus.v1.KubernetesAction.current_requests:type_name -> finfocus.v1.KubernetesResources
-	55,  // 76: finfocus.v1.KubernetesAction.recommended_requests:type_name -> finfocus.v1.KubernetesResources
-	55,  // 77: finfocus.v1.KubernetesAction.current_limits:type_name -> finfocus.v1.KubernetesResources
-	55,  // 78: finfocus.v1.KubernetesAction.recommended_limits:type_name -> finfocus.v1.KubernetesResources
-	77,  // 79: finfocus.v1.ModifyAction.current_config:type_name -> finfocus.v1.ModifyAction.CurrentConfigEntry
-	78,  // 80: finfocus.v1.ModifyAction.recommended_config:type_name -> finfocus.v1.ModifyAction.RecommendedConfigEntry
-	79,  // 81: finfocus.v1.RecommendationSummary.count_by_category:type_name -> finfocus.v1.RecommendationSummary.CountByCategoryEntry
-	80,  // 82: finfocus.v1.RecommendationSummary.savings_by_category:type_name -> finfocus.v1.RecommendationSummary.SavingsByCategoryEntry
-	81,  // 83: finfocus.v1.RecommendationSummary.count_by_action_type:type_name -> finfocus.v1.RecommendationSummary.CountByActionTypeEntry
-	82,  // 84: finfocus.v1.RecommendationSummary.savings_by_action_type:type_name -> finfocus.v1.RecommendationSummary.SavingsByActionTypeEntry
-	11,  // 85: finfocus.v1.DismissRecommendationRequest.reason:type_name -> finfocus.v1.DismissalReason
-	85,  // 86: finfocus.v1.DismissRecommendationRequest.expires_at:type_name -> google.protobuf.Timestamp
-	85,  // 87: finfocus.v1.DismissRecommendationResponse.dismissed_at:type_name -> google.protobuf.Timestamp
-	85,  // 88: finfocus.v1.DismissRecommendationResponse.expires_at:type_name -> google.protobuf.Timestamp
-	83,  // 89: finfocus.v1.GetPluginInfoResponse.metadata:type_name -> finfocus.v1.GetPluginInfoResponse.MetadataEntry
-	90,  // 90: finfocus.v1.GetPluginInfoResponse.capabilities:type_name -> finfocus.v1.PluginCapability
-	91,  // 91: finfocus.v1.FieldMapping.support_status:type_name -> finfocus.v1.FieldSupportStatus
-	24,  // 92: finfocus.v1.DryRunRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
-	84,  // 93: finfocus.v1.DryRunRequest.simulation_parameters:type_name -> finfocus.v1.DryRunRequest.SimulationParametersEntry
-	63,  // 94: finfocus.v1.DryRunResponse.field_mappings:type_name -> finfocus.v1.FieldMapping
-	13,  // 95: finfocus.v1.CostSourceService.Name:input_type -> finfocus.v1.NameRequest
-	16,  // 96: finfocus.v1.CostSourceService.Supports:input_type -> finfocus.v1.SupportsRequest
-	18,  // 97: finfocus.v1.CostSourceService.GetActualCost:input_type -> finfocus.v1.GetActualCostRequest
-	20,  // 98: finfocus.v1.CostSourceService.GetProjectedCost:input_type -> finfocus.v1.GetProjectedCostRequest
-	22,  // 99: finfocus.v1.CostSourceService.GetPricingSpec:input_type -> finfocus.v1.GetPricingSpecRequest
-	43,  // 100: finfocus.v1.CostSourceService.EstimateCost:input_type -> finfocus.v1.EstimateCostRequest
-	45,  // 101: finfocus.v1.CostSourceService.GetRecommendations:input_type -> finfocus.v1.GetRecommendationsRequest
-	59,  // 102: finfocus.v1.CostSourceService.DismissRecommendation:input_type -> finfocus.v1.DismissRecommendationRequest
-	92,  // 103: finfocus.v1.CostSourceService.GetBudgets:input_type -> finfocus.v1.GetBudgetsRequest
-	61,  // 104: finfocus.v1.CostSourceService.GetPluginInfo:input_type -> finfocus.v1.GetPluginInfoRequest
-	64,  // 105: finfocus.v1.CostSourceService.DryRun:input_type -> finfocus.v1.DryRunRequest
-	30,  // 106: finfocus.v1.ObservabilityService.HealthCheck:input_type -> finfocus.v1.HealthCheckRequest
-	32,  // 107: finfocus.v1.ObservabilityService.GetMetrics:input_type -> finfocus.v1.GetMetricsRequest
-	36,  // 108: finfocus.v1.ObservabilityService.GetServiceLevelIndicators:input_type -> finfocus.v1.GetServiceLevelIndicatorsRequest
-	14,  // 109: finfocus.v1.CostSourceService.Name:output_type -> finfocus.v1.NameResponse
-	17,  // 110: finfocus.v1.CostSourceService.Supports:output_type -> finfocus.v1.SupportsResponse
-	19,  // 111: finfocus.v1.CostSourceService.GetActualCost:output_type -> finfocus.v1.GetActualCostResponse
-	21,  // 112: finfocus.v1.CostSourceService.GetProjectedCost:output_type -> finfocus.v1.GetProjectedCostResponse
-	23,  // 113: finfocus.v1.CostSourceService.GetPricingSpec:output_type -> finfocus.v1.GetPricingSpecResponse
-	44,  // 114: finfocus.v1.CostSourceService.EstimateCost:output_type -> finfocus.v1.EstimateCostResponse
-	46,  // 115: finfocus.v1.CostSourceService.GetRecommendations:output_type -> finfocus.v1.GetRecommendationsResponse
-	60,  // 116: finfocus.v1.CostSourceService.DismissRecommendation:output_type -> finfocus.v1.DismissRecommendationResponse
-	93,  // 117: finfocus.v1.CostSourceService.GetBudgets:output_type -> finfocus.v1.GetBudgetsResponse
-	62,  // 118: finfocus.v1.CostSourceService.GetPluginInfo:output_type -> finfocus.v1.GetPluginInfoResponse
-	65,  // 119: finfocus.v1.CostSourceService.DryRun:output_type -> finfocus.v1.DryRunResponse
-	31,  // 120: finfocus.v1.ObservabilityService.HealthCheck:output_type -> finfocus.v1.HealthCheckResponse
-	33,  // 121: finfocus.v1.ObservabilityService.GetMetrics:output_type -> finfocus.v1.GetMetricsResponse
-	37,  // 122: finfocus.v1.ObservabilityService.GetServiceLevelIndicators:output_type -> finfocus.v1.GetServiceLevelIndicatorsResponse
-	109, // [109:123] is the sub-list for method output_type
-	95,  // [95:109] is the sub-list for method input_type
-	95,  // [95:95] is the sub-list for extension type_name
-	95,  // [95:95] is the sub-list for extension extendee
-	0,   // [0:95] is the sub-list for field type_name
+	85,  // 4: finfocus.v1.SupportsResponse.capabilities_enum:type_name -> finfocus.v1.PluginCapability
+	86,  // 5: finfocus.v1.GetActualCostRequest.start:type_name -> google.protobuf.Timestamp
+	86,  // 6: finfocus.v1.GetActualCostRequest.end:type_name -> google.protobuf.Timestamp
+	67,  // 7: finfocus.v1.GetActualCostRequest.tags:type_name -> finfocus.v1.GetActualCostRequest.TagsEntry
+	25,  // 8: finfocus.v1.GetActualCostResponse.results:type_name -> finfocus.v1.ActualCostResult
+	1,   // 9: finfocus.v1.GetActualCostResponse.fallback_hint:type_name -> finfocus.v1.FallbackHint
+	65,  // 10: finfocus.v1.GetActualCostResponse.dry_run_result:type_name -> finfocus.v1.DryRunResponse
+	24,  // 11: finfocus.v1.GetProjectedCostRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
+	87,  // 12: finfocus.v1.GetProjectedCostRequest.growth_type:type_name -> finfocus.v1.GrowthType
+	15,  // 13: finfocus.v1.GetProjectedCostResponse.impact_metrics:type_name -> finfocus.v1.ImpactMetric
+	87,  // 14: finfocus.v1.GetProjectedCostResponse.growth_type:type_name -> finfocus.v1.GrowthType
+	65,  // 15: finfocus.v1.GetProjectedCostResponse.dry_run_result:type_name -> finfocus.v1.DryRunResponse
+	24,  // 16: finfocus.v1.GetPricingSpecRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
+	27,  // 17: finfocus.v1.GetPricingSpecResponse.spec:type_name -> finfocus.v1.PricingSpec
+	68,  // 18: finfocus.v1.ResourceDescriptor.tags:type_name -> finfocus.v1.ResourceDescriptor.TagsEntry
+	87,  // 19: finfocus.v1.ResourceDescriptor.growth_type:type_name -> finfocus.v1.GrowthType
+	86,  // 20: finfocus.v1.ActualCostResult.timestamp:type_name -> google.protobuf.Timestamp
+	88,  // 21: finfocus.v1.ActualCostResult.focus_record:type_name -> finfocus.v1.FocusCostRecord
+	15,  // 22: finfocus.v1.ActualCostResult.impact_metrics:type_name -> finfocus.v1.ImpactMetric
+	26,  // 23: finfocus.v1.PricingSpec.metric_hints:type_name -> finfocus.v1.UsageMetricHint
+	69,  // 24: finfocus.v1.PricingSpec.plugin_metadata:type_name -> finfocus.v1.PricingSpec.PluginMetadataEntry
+	28,  // 25: finfocus.v1.PricingSpec.pricing_tiers:type_name -> finfocus.v1.PricingTier
+	3,   // 26: finfocus.v1.ErrorDetail.code:type_name -> finfocus.v1.ErrorCode
+	2,   // 27: finfocus.v1.ErrorDetail.category:type_name -> finfocus.v1.ErrorCategory
+	70,  // 28: finfocus.v1.ErrorDetail.details:type_name -> finfocus.v1.ErrorDetail.DetailsEntry
+	86,  // 29: finfocus.v1.ErrorDetail.timestamp:type_name -> google.protobuf.Timestamp
+	12,  // 30: finfocus.v1.HealthCheckResponse.status:type_name -> finfocus.v1.HealthCheckResponse.Status
+	86,  // 31: finfocus.v1.HealthCheckResponse.last_check_time:type_name -> google.protobuf.Timestamp
+	34,  // 32: finfocus.v1.GetMetricsResponse.metrics:type_name -> finfocus.v1.Metric
+	86,  // 33: finfocus.v1.GetMetricsResponse.timestamp:type_name -> google.protobuf.Timestamp
+	4,   // 34: finfocus.v1.Metric.type:type_name -> finfocus.v1.MetricType
+	35,  // 35: finfocus.v1.Metric.samples:type_name -> finfocus.v1.MetricSample
+	71,  // 36: finfocus.v1.MetricSample.labels:type_name -> finfocus.v1.MetricSample.LabelsEntry
+	86,  // 37: finfocus.v1.MetricSample.timestamp:type_name -> google.protobuf.Timestamp
+	39,  // 38: finfocus.v1.GetServiceLevelIndicatorsRequest.time_range:type_name -> finfocus.v1.TimeRange
+	38,  // 39: finfocus.v1.GetServiceLevelIndicatorsResponse.slis:type_name -> finfocus.v1.ServiceLevelIndicator
+	86,  // 40: finfocus.v1.GetServiceLevelIndicatorsResponse.measurement_time:type_name -> google.protobuf.Timestamp
+	5,   // 41: finfocus.v1.ServiceLevelIndicator.status:type_name -> finfocus.v1.SLIStatus
+	86,  // 42: finfocus.v1.TimeRange.start:type_name -> google.protobuf.Timestamp
+	86,  // 43: finfocus.v1.TimeRange.end:type_name -> google.protobuf.Timestamp
+	86,  // 44: finfocus.v1.LogEntry.timestamp:type_name -> google.protobuf.Timestamp
+	72,  // 45: finfocus.v1.LogEntry.fields:type_name -> finfocus.v1.LogEntry.FieldsEntry
+	42,  // 46: finfocus.v1.LogEntry.error_details:type_name -> finfocus.v1.ErrorDetails
+	89,  // 47: finfocus.v1.EstimateCostRequest.attributes:type_name -> google.protobuf.Struct
+	47,  // 48: finfocus.v1.GetRecommendationsRequest.filter:type_name -> finfocus.v1.RecommendationFilter
+	24,  // 49: finfocus.v1.GetRecommendationsRequest.target_resources:type_name -> finfocus.v1.ResourceDescriptor
+	48,  // 50: finfocus.v1.GetRecommendationsResponse.recommendations:type_name -> finfocus.v1.Recommendation
+	58,  // 51: finfocus.v1.GetRecommendationsResponse.summary:type_name -> finfocus.v1.RecommendationSummary
+	6,   // 52: finfocus.v1.RecommendationFilter.category:type_name -> finfocus.v1.RecommendationCategory
+	7,   // 53: finfocus.v1.RecommendationFilter.action_type:type_name -> finfocus.v1.RecommendationActionType
+	73,  // 54: finfocus.v1.RecommendationFilter.tags:type_name -> finfocus.v1.RecommendationFilter.TagsEntry
+	8,   // 55: finfocus.v1.RecommendationFilter.priority:type_name -> finfocus.v1.RecommendationPriority
+	9,   // 56: finfocus.v1.RecommendationFilter.sort_by:type_name -> finfocus.v1.RecommendationSortBy
+	10,  // 57: finfocus.v1.RecommendationFilter.sort_order:type_name -> finfocus.v1.SortOrder
+	6,   // 58: finfocus.v1.Recommendation.category:type_name -> finfocus.v1.RecommendationCategory
+	7,   // 59: finfocus.v1.Recommendation.action_type:type_name -> finfocus.v1.RecommendationActionType
+	49,  // 60: finfocus.v1.Recommendation.resource:type_name -> finfocus.v1.ResourceRecommendationInfo
+	51,  // 61: finfocus.v1.Recommendation.rightsize:type_name -> finfocus.v1.RightsizeAction
+	52,  // 62: finfocus.v1.Recommendation.terminate:type_name -> finfocus.v1.TerminateAction
+	53,  // 63: finfocus.v1.Recommendation.commitment:type_name -> finfocus.v1.CommitmentAction
+	54,  // 64: finfocus.v1.Recommendation.kubernetes:type_name -> finfocus.v1.KubernetesAction
+	56,  // 65: finfocus.v1.Recommendation.modify:type_name -> finfocus.v1.ModifyAction
+	57,  // 66: finfocus.v1.Recommendation.impact:type_name -> finfocus.v1.RecommendationImpact
+	8,   // 67: finfocus.v1.Recommendation.priority:type_name -> finfocus.v1.RecommendationPriority
+	86,  // 68: finfocus.v1.Recommendation.created_at:type_name -> google.protobuf.Timestamp
+	74,  // 69: finfocus.v1.Recommendation.metadata:type_name -> finfocus.v1.Recommendation.MetadataEntry
+	90,  // 70: finfocus.v1.Recommendation.primary_reason:type_name -> finfocus.v1.RecommendationReason
+	90,  // 71: finfocus.v1.Recommendation.secondary_reasons:type_name -> finfocus.v1.RecommendationReason
+	75,  // 72: finfocus.v1.ResourceRecommendationInfo.tags:type_name -> finfocus.v1.ResourceRecommendationInfo.TagsEntry
+	50,  // 73: finfocus.v1.ResourceRecommendationInfo.utilization:type_name -> finfocus.v1.ResourceUtilization
+	76,  // 74: finfocus.v1.ResourceUtilization.custom_metrics:type_name -> finfocus.v1.ResourceUtilization.CustomMetricsEntry
+	50,  // 75: finfocus.v1.RightsizeAction.projected_utilization:type_name -> finfocus.v1.ResourceUtilization
+	55,  // 76: finfocus.v1.KubernetesAction.current_requests:type_name -> finfocus.v1.KubernetesResources
+	55,  // 77: finfocus.v1.KubernetesAction.recommended_requests:type_name -> finfocus.v1.KubernetesResources
+	55,  // 78: finfocus.v1.KubernetesAction.current_limits:type_name -> finfocus.v1.KubernetesResources
+	55,  // 79: finfocus.v1.KubernetesAction.recommended_limits:type_name -> finfocus.v1.KubernetesResources
+	77,  // 80: finfocus.v1.ModifyAction.current_config:type_name -> finfocus.v1.ModifyAction.CurrentConfigEntry
+	78,  // 81: finfocus.v1.ModifyAction.recommended_config:type_name -> finfocus.v1.ModifyAction.RecommendedConfigEntry
+	79,  // 82: finfocus.v1.RecommendationSummary.count_by_category:type_name -> finfocus.v1.RecommendationSummary.CountByCategoryEntry
+	80,  // 83: finfocus.v1.RecommendationSummary.savings_by_category:type_name -> finfocus.v1.RecommendationSummary.SavingsByCategoryEntry
+	81,  // 84: finfocus.v1.RecommendationSummary.count_by_action_type:type_name -> finfocus.v1.RecommendationSummary.CountByActionTypeEntry
+	82,  // 85: finfocus.v1.RecommendationSummary.savings_by_action_type:type_name -> finfocus.v1.RecommendationSummary.SavingsByActionTypeEntry
+	11,  // 86: finfocus.v1.DismissRecommendationRequest.reason:type_name -> finfocus.v1.DismissalReason
+	86,  // 87: finfocus.v1.DismissRecommendationRequest.expires_at:type_name -> google.protobuf.Timestamp
+	86,  // 88: finfocus.v1.DismissRecommendationResponse.dismissed_at:type_name -> google.protobuf.Timestamp
+	86,  // 89: finfocus.v1.DismissRecommendationResponse.expires_at:type_name -> google.protobuf.Timestamp
+	83,  // 90: finfocus.v1.GetPluginInfoResponse.metadata:type_name -> finfocus.v1.GetPluginInfoResponse.MetadataEntry
+	85,  // 91: finfocus.v1.GetPluginInfoResponse.capabilities:type_name -> finfocus.v1.PluginCapability
+	91,  // 92: finfocus.v1.FieldMapping.support_status:type_name -> finfocus.v1.FieldSupportStatus
+	24,  // 93: finfocus.v1.DryRunRequest.resource:type_name -> finfocus.v1.ResourceDescriptor
+	84,  // 94: finfocus.v1.DryRunRequest.simulation_parameters:type_name -> finfocus.v1.DryRunRequest.SimulationParametersEntry
+	63,  // 95: finfocus.v1.DryRunResponse.field_mappings:type_name -> finfocus.v1.FieldMapping
+	13,  // 96: finfocus.v1.CostSourceService.Name:input_type -> finfocus.v1.NameRequest
+	16,  // 97: finfocus.v1.CostSourceService.Supports:input_type -> finfocus.v1.SupportsRequest
+	18,  // 98: finfocus.v1.CostSourceService.GetActualCost:input_type -> finfocus.v1.GetActualCostRequest
+	20,  // 99: finfocus.v1.CostSourceService.GetProjectedCost:input_type -> finfocus.v1.GetProjectedCostRequest
+	22,  // 100: finfocus.v1.CostSourceService.GetPricingSpec:input_type -> finfocus.v1.GetPricingSpecRequest
+	43,  // 101: finfocus.v1.CostSourceService.EstimateCost:input_type -> finfocus.v1.EstimateCostRequest
+	45,  // 102: finfocus.v1.CostSourceService.GetRecommendations:input_type -> finfocus.v1.GetRecommendationsRequest
+	59,  // 103: finfocus.v1.CostSourceService.DismissRecommendation:input_type -> finfocus.v1.DismissRecommendationRequest
+	92,  // 104: finfocus.v1.CostSourceService.GetBudgets:input_type -> finfocus.v1.GetBudgetsRequest
+	61,  // 105: finfocus.v1.CostSourceService.GetPluginInfo:input_type -> finfocus.v1.GetPluginInfoRequest
+	64,  // 106: finfocus.v1.CostSourceService.DryRun:input_type -> finfocus.v1.DryRunRequest
+	30,  // 107: finfocus.v1.ObservabilityService.HealthCheck:input_type -> finfocus.v1.HealthCheckRequest
+	32,  // 108: finfocus.v1.ObservabilityService.GetMetrics:input_type -> finfocus.v1.GetMetricsRequest
+	36,  // 109: finfocus.v1.ObservabilityService.GetServiceLevelIndicators:input_type -> finfocus.v1.GetServiceLevelIndicatorsRequest
+	14,  // 110: finfocus.v1.CostSourceService.Name:output_type -> finfocus.v1.NameResponse
+	17,  // 111: finfocus.v1.CostSourceService.Supports:output_type -> finfocus.v1.SupportsResponse
+	19,  // 112: finfocus.v1.CostSourceService.GetActualCost:output_type -> finfocus.v1.GetActualCostResponse
+	21,  // 113: finfocus.v1.CostSourceService.GetProjectedCost:output_type -> finfocus.v1.GetProjectedCostResponse
+	23,  // 114: finfocus.v1.CostSourceService.GetPricingSpec:output_type -> finfocus.v1.GetPricingSpecResponse
+	44,  // 115: finfocus.v1.CostSourceService.EstimateCost:output_type -> finfocus.v1.EstimateCostResponse
+	46,  // 116: finfocus.v1.CostSourceService.GetRecommendations:output_type -> finfocus.v1.GetRecommendationsResponse
+	60,  // 117: finfocus.v1.CostSourceService.DismissRecommendation:output_type -> finfocus.v1.DismissRecommendationResponse
+	93,  // 118: finfocus.v1.CostSourceService.GetBudgets:output_type -> finfocus.v1.GetBudgetsResponse
+	62,  // 119: finfocus.v1.CostSourceService.GetPluginInfo:output_type -> finfocus.v1.GetPluginInfoResponse
+	65,  // 120: finfocus.v1.CostSourceService.DryRun:output_type -> finfocus.v1.DryRunResponse
+	31,  // 121: finfocus.v1.ObservabilityService.HealthCheck:output_type -> finfocus.v1.HealthCheckResponse
+	33,  // 122: finfocus.v1.ObservabilityService.GetMetrics:output_type -> finfocus.v1.GetMetricsResponse
+	37,  // 123: finfocus.v1.ObservabilityService.GetServiceLevelIndicators:output_type -> finfocus.v1.GetServiceLevelIndicatorsResponse
+	110, // [110:124] is the sub-list for method output_type
+	96,  // [96:110] is the sub-list for method input_type
+	96,  // [96:96] is the sub-list for extension type_name
+	96,  // [96:96] is the sub-list for extension extendee
+	0,   // [0:96] is the sub-list for field type_name
 }
 
 func init() { file_finfocus_v1_costsource_proto_init() }

--- a/specs/037-dual-layer-capability-discovery/spec.md
+++ b/specs/037-dual-layer-capability-discovery/spec.md
@@ -1,0 +1,65 @@
+# Feature Specification: Dual-Layer Capability Discovery
+
+**Feature Branch**: `feat/plugin-capability-discovery`
+**Created**: 2026-01-15
+**Status**: Draft
+**Input**: Issue #194, PR #290
+
+## Objective
+
+Formalize a dual-layer capability discovery protocol that enables both high-level service registration (Global) and granular, resource-specific feature negotiation (Granular). This ensures the Host only calls RPCs that a plugin explicitly supports for a given context.
+
+## Discovery Layers
+
+### 1. Global Discovery (`GetPluginInfo`)
+
+*   **When**: Called once during plugin initialization.
+*   **Purpose**: To determine which major feature sets (Budgets, Recommendations, etc.) the plugin supports across its entire lifecycle.
+*   **Host Action**: The Host uses this to register internal service handlers. If a plugin does not advertise `PLUGIN_CAPABILITY_BUDGETS`, the Host should never attempt to call `GetBudgets`.
+
+### 2. Granular Discovery (`Supports`)
+
+*   **When**: Called per resource or resource type during execution.
+*   **Purpose**: To determine if a globally supported feature is applicable to a specific `ResourceDescriptor` (Provider, Region, Resource Type).
+*   **Host Action**: The Host uses this to decide whether to execute specific logic for a resource. For example, a plugin might support Recommendations globally, but return `false` for `PLUGIN_CAPABILITY_RECOMMENDATIONS` in the `Supports` response for a specific legacy SKU.
+
+## Technical Implementation
+
+### Protobuf Changes
+
+`SupportsResponse` is enhanced with a `capabilities_enum` field:
+
+```protobuf
+message SupportsResponse {
+  bool supported = 1;
+  string reason = 2;
+  map<string, bool> capabilities = 3; // Legacy string map
+  repeated MetricKind supported_metrics = 4;
+  repeated PluginCapability capabilities_enum = 5; // New strongly-typed list
+}
+```
+
+### SDK Auto-Discovery
+
+The Go SDK automatically populates these fields by introspecting implemented interfaces:
+
+*   `RecommendationsProvider` -> `PLUGIN_CAPABILITY_RECOMMENDATIONS`
+*   `BudgetsProvider` -> `PLUGIN_CAPABILITY_BUDGETS`
+*   `DryRunProvider` -> `PLUGIN_CAPABILITY_DRY_RUN` (Future)
+
+## Host Integration Requirements (FinFocus Core)
+
+Consuming applications (like `finfocus-core`) SHOULD follow this logic:
+
+1.  **Init Phase**: Call `GetPluginInfo`. Store global capabilities.
+2.  **Registration**: Only enable feature-specific UI/API components if the capability is present globally.
+3.  **Execution Phase**:
+    *   Call `Supports(resource)`.
+    *   Check `capabilities_enum` in the response.
+    *   If a capability (e.g., `CARBON`) is present globally but **absent** in the granular `Supports` response, the Host MUST NOT call the related RPC for that resource.
+
+## Success Criteria
+
+1.  Plugins can advertise granular support without extra code (auto-discovery).
+2.  Hosts can avoid unnecessary RPC failures by checking support before calling.
+3.  100% backward compatibility with string-based `capabilities` map.


### PR DESCRIPTION
## Summary

- Enhanced the `Supports` RPC to return a strongly-typed list of capabilities supported for specific resources.
- Implemented automatic capability population in the Go SDK using interface introspection, complementing the global discovery.
- Formalized the dual-layer discovery protocol (Global vs Granular) to enable more precise feature negotiation between Hosts and Plugins.
- Maintained backward compatibility with the legacy string-based capability map in `SupportsResponse`.

## Test plan

- [x] Added `TestSupports_AutoDiscovery` to verify SDK population.
- [x] Verified `GetPluginInfo` still works as expected.
- [x] `make lint` passes with zero issues.
- [x] `make test` passes for all SDK components.

## Changes

### New files

- `specs/037-dual-layer-capability-discovery/spec.md` - Protocol spec.

### Modified files

- `proto/finfocus/v1/costsource.proto` - Added `capabilities_enum`.
- `sdk/go/pluginsdk/sdk.go` - Implemented auto-discovery in `Supports`.
- `sdk/go/pluginsdk/sdk_test.go` - Added integration tests.
- `PLUGIN_DEVELOPER_GUIDE.md` - Added dual-layer discovery docs.

Closes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic capability discovery for plugins with global and per-resource detection layers.
  * Capabilities now automatically populate across both modern and legacy formats for backward compatibility.

* **Documentation**
  * Updated developer guide to explain the two-layer capability discovery model and automatic capability population.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->