### PR TITLE
docs(proto): add batch cost pagination continuation docs

### DIFF
--- a/proto/finfocus/v1/costsource.proto
+++ b/proto/finfocus/v1/costsource.proto
@@ -1765,9 +1765,14 @@ message ActualCostData {
   //     1. Call BatchCost with resources and query_type=ACTUAL.
   //     2. For each ResourceCostResult whose ActualCostData has a non-empty
   //        next_page_token:
-  //        a. Call GetActualCost with the resource's ResourceDescriptor.id
-  //           (or .arn) as resource_id, and the next_page_token as page_token.
-  //        b. Continue calling GetActualCost until next_page_token is empty.
+  //        a. Call GetActualCost with the exact same lookup identifier used in
+  //           the initial request (the plugin/billing-system resource_id).
+  //           ResourceDescriptor.id is a correlation identifier unless your
+  //           integration explicitly uses it for lookup. When applicable, use
+  //           ResourceDescriptor.arn (or another stable provider identifier) as
+  //           resource_id.
+  //        b. Continue calling GetActualCost with each returned next_page_token
+  //           passed unchanged as page_token until next_page_token is empty.
   string next_page_token = 3;
 
   // total number of cost data points available for this resource.

--- a/sdk/go/pluginsdk/README.md
+++ b/sdk/go/pluginsdk/README.md
@@ -718,9 +718,14 @@ back to the per-resource `GetActualCost` RPC:
 
 1. Call `BatchCost` with the desired resources and `query_type = COST_QUERY_TYPE_ACTUAL`.
 2. For each `ResourceCostResult` whose `ActualCostData.next_page_token` is non-empty:
-   a. Call `GetActualCost` with the resource's `ResourceDescriptor.id` (or `.arn`)
-      as `resource_id`, and the `next_page_token` as `page_token`.
-   b. Continue calling `GetActualCost` until `next_page_token` is empty.
+   a. Call `GetActualCost` with the plugin-specific lookup identifier in
+      `GetActualCostRequest.ResourceId` (the same value used for the initial
+      lookup). `ResourceDescriptor.id` is often correlation-only; if the plugin
+      expects ARN-based lookup, forward `ResourceDescriptor.arn` and use it as
+      the lookup identifier.
+   b. Continue calling `GetActualCost`, passing each returned
+      `next_page_token` unchanged as `page_token`, until `next_page_token` is
+      empty.
 
 The `next_page_token` from `ActualCostData` is guaranteed to be a valid
 `page_token` for the corresponding `GetActualCost` call. Pass it
@@ -753,16 +758,20 @@ for _, res := range batchResp.GetResults() {
     // Process the first page returned by BatchCost.
     processResults(data.GetResults())
 
+    // Resolve the plugin-specific lookup identifier used for this resource.
+    // ResourceDescriptor.id may be correlation-only; use ARN if lookup is ARN-based.
+    lookupID := pluginLookupIDForResource(res.GetResource())
+
     // Fetch remaining pages via GetActualCost.
     pageToken := data.GetNextPageToken()
     for pageToken != "" {
         resp, err := client.GetActualCost(ctx, &pbc.GetActualCostRequest{
-            ResourceId: res.GetResource().GetId(),
-            Arn:        res.GetResource().GetArn(),  // forward for exact matching
+            ResourceId: lookupID,
+            Arn:        res.GetResource().GetArn(),  // forward when plugin expects ARN lookup
             Tags:       res.GetResource().GetTags(), // forward for consistent filtering
             Start:      batchReq.GetStart(),
             End:        batchReq.GetEnd(),
-            PageToken:  pageToken,
+            PageToken:  pageToken, // pass through unchanged from the previous response
             PageSize:   100, // server default is 50 (DefaultPageSize); omit to use it
         })
         if err != nil {

--- a/sdk/go/proto/finfocus/v1/costsource.pb.go
+++ b/sdk/go/proto/finfocus/v1/costsource.pb.go
@@ -6152,9 +6152,14 @@ type ActualCostData struct {
 	//	  1. Call BatchCost with resources and query_type=ACTUAL.
 	//	  2. For each ResourceCostResult whose ActualCostData has a non-empty
 	//	     next_page_token:
-	//	     a. Call GetActualCost with the resource's ResourceDescriptor.id
-	//	        (or .arn) as resource_id, and the next_page_token as page_token.
-	//	     b. Continue calling GetActualCost until next_page_token is empty.
+	//	     a. Call GetActualCost with the exact same lookup identifier used in
+	//	        the initial request (the plugin/billing-system resource_id).
+	//	        ResourceDescriptor.id is a correlation identifier unless your
+	//	        integration explicitly uses it for lookup. When applicable, use
+	//	        ResourceDescriptor.arn (or another stable provider identifier) as
+	//	        resource_id.
+	//	     b. Continue calling GetActualCost with each returned next_page_token
+	//	        passed unchanged as page_token until next_page_token is empty.
 	NextPageToken string `protobuf:"bytes,3,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	// total number of cost data points available for this resource.
 	TotalCount    int32 `protobuf:"varint,4,opt,name=total_count,json=totalCount,proto3" json:"total_count,omitempty"`

--- a/sdk/typescript/packages/client/src/generated/finfocus/v1/costsource_pb.ts
+++ b/sdk/typescript/packages/client/src/generated/finfocus/v1/costsource_pb.ts
@@ -3375,9 +3375,14 @@ export type ActualCostData = Message<"finfocus.v1.ActualCostData"> & {
    *     1. Call BatchCost with resources and query_type=ACTUAL.
    *     2. For each ResourceCostResult whose ActualCostData has a non-empty
    *        next_page_token:
-   *        a. Call GetActualCost with the resource's ResourceDescriptor.id
-   *           (or .arn) as resource_id, and the next_page_token as page_token.
-   *        b. Continue calling GetActualCost until next_page_token is empty.
+   *        a. Call GetActualCost with the exact same lookup identifier used in
+   *           the initial request (the plugin/billing-system resource_id).
+   *           ResourceDescriptor.id is a correlation identifier unless your
+   *           integration explicitly uses it for lookup. When applicable, use
+   *           ResourceDescriptor.arn (or another stable provider identifier) as
+   *           resource_id.
+   *        b. Continue calling GetActualCost with each returned next_page_token
+   *           passed unchanged as page_token until next_page_token is empty.
    *
    * @generated from field: string next_page_token = 3;
    */


### PR DESCRIPTION
## Summary

- BatchCost returns per-resource `next_page_token` values but has no way to accept page tokens in the request, requiring callers to fall back to GetActualCost for pagination continuation
- Added step-by-step workflow comments on `ActualCostData.next_page_token` in the proto definition so the pattern is discoverable from generated code documentation
- Added a new "Pagination Continuation" subsection under the BatchCost RPC section in the SDK README with a complete Go code example and a cross-reference to the existing `ActualCostIterator` helper

## Test plan

- [x] `make generate` regenerates proto Go and TypeScript bindings
- [x] `make test` passes with zero failures
- [x] `make lint` passes (Go, buf, markdown, YAML)

## Changes

### Modified files

- `proto/finfocus/v1/costsource.proto` - Expanded `next_page_token` comment on `ActualCostData` with continuation workflow steps
- `sdk/go/pluginsdk/README.md` - Added "Pagination Continuation for Batch Actual Cost Results" subsection with workflow and code example
- `sdk/go/proto/finfocus/v1/costsource.pb.go` - Regenerated from updated proto
- `sdk/typescript/.../costsource_pb.ts` - Regenerated from updated proto

Closes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified pagination continuation for batch actual cost results and when per-resource results include a continuation token.
  * Added step-by-step guidance on retrieving remaining pages by repeating per-resource calls with the returned token.
  * Included practical examples (including an iterator option) and a note to pass tokens unchanged to ensure complete result retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->