### PR TITLE
docs(proto): improve ResourceError.code comment with gRPC code reference

### DIFF
--- a/proto/finfocus/v1/costsource.proto
+++ b/proto/finfocus/v1/costsource.proto
@@ -1782,7 +1782,10 @@ message ActualCostData {
 // ResourceError contains structured error information for a single resource failure.
 // Per-resource errors do not cause the entire batch RPC to fail.
 message ResourceError {
-  // gRPC-compatible status code (e.g., NOT_FOUND=5, INTERNAL=13).
+  // gRPC-compatible status code from google.rpc.Code.
+  // Common values: INVALID_ARGUMENT(3), NOT_FOUND(5), UNIMPLEMENTED(12), INTERNAL(13).
+  // Must not be OK(0) — the presence of ResourceError implies a non-OK status.
+  // See: https://grpc.io/docs/guides/status-codes/
   int32 code = 1;
 
   // human-readable error description.

--- a/sdk/go/proto/finfocus/v1/costsource.pb.go
+++ b/sdk/go/proto/finfocus/v1/costsource.pb.go
@@ -6229,7 +6229,10 @@ func (x *ActualCostData) GetTotalCount() int32 {
 // Per-resource errors do not cause the entire batch RPC to fail.
 type ResourceError struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// gRPC-compatible status code (e.g., NOT_FOUND=5, INTERNAL=13).
+	// gRPC-compatible status code from google.rpc.Code.
+	// Common values: INVALID_ARGUMENT(3), NOT_FOUND(5), UNIMPLEMENTED(12), INTERNAL(13).
+	// Must not be OK(0) — the presence of ResourceError implies a non-OK status.
+	// See: https://grpc.io/docs/guides/status-codes/
 	Code int32 `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
 	// human-readable error description.
 	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`

--- a/sdk/typescript/packages/client/src/generated/finfocus/v1/costsource_pb.ts
+++ b/sdk/typescript/packages/client/src/generated/finfocus/v1/costsource_pb.ts
@@ -3411,7 +3411,10 @@ export const ActualCostDataSchema: GenMessage<ActualCostData> = /*@__PURE__*/
  */
 export type ResourceError = Message<"finfocus.v1.ResourceError"> & {
   /**
-   * gRPC-compatible status code (e.g., NOT_FOUND=5, INTERNAL=13).
+   * gRPC-compatible status code from google.rpc.Code.
+   * Common values: INVALID_ARGUMENT(3), NOT_FOUND(5), UNIMPLEMENTED(12), INTERNAL(13).
+   * Must not be OK(0) — the presence of ResourceError implies a non-OK status.
+   * See: https://grpc.io/docs/guides/status-codes/
    *
    * @generated from field: int32 code = 1;
    */


### PR DESCRIPTION
## Summary

Improved the proto comment for `ResourceError.code` to include:

1. Reference to `google.rpc.Code` and full gRPC status codes documentation
2. Documentation that `0` (OK) should never appear in a `ResourceError`
3. List of common codes used in batch context (INVALID_ARGUMENT, NOT_FOUND, UNIMPLEMENTED, INTERNAL)

## Changes

- Updated proto comment at `proto/finfocus/v1/costsource.proto:1785`
- Regenerated Go and TypeScript code from proto definitions

Closes #406

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced error code documentation for ResourceError, clarifying valid code values and common usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->