### PR TITLE
docs(sdk): add plugin contract for GetProjectedCost 

### DIFF
--- a/PLUGIN_DEVELOPER_GUIDE.md
+++ b/PLUGIN_DEVELOPER_GUIDE.md
@@ -398,6 +398,196 @@ These two RPCs serve different use cases. Understanding when to use each is impo
 - You need deterministic, cacheable results for cost comparisons
 - You're building Pulumi preview cost estimation features
 
+### Cost Diff Pattern: Handling Sparse Properties
+
+The **cost diff feature** introduces a critical calling pattern where `GetProjectedCost` is called **twice per updated resource**:
+
+1. **Baseline call**: Using `OldState.Inputs` (resource properties before the change)
+2. **Modified call**: Using `NewState.Inputs` (resource properties after the change)
+
+This pattern enables accurate cost impact analysis by comparing the two projections. However,
+`OldState.Inputs` often contains **sparse property sets** because Pulumi stores only the
+explicitly declared inputs, not computed or defaulted values.
+
+#### Why Properties Are Sparse
+
+When Pulumi stores old resource state, it captures the **user-declared inputs** rather than
+the full computed state. This means:
+
+- **Optional properties** that were computed by the provider are missing
+- **Default values** that were applied during previous deployments are not present
+- **Nested structures** may be incomplete or flattened differently
+- **Tags and metadata** may be partially populated
+
+#### Plugin Contract Requirements
+
+Plugins **MUST** handle sparse property scenarios correctly to avoid producing misleading cost
+comparisons:
+
+##### Contract 1: Signal Missing Critical Properties
+
+Do NOT silently return `$0` or apply arbitrary defaults when critical properties are missing. Instead, signal the gap explicitly:
+
+```go
+func (p *Plugin) GetProjectedCost(ctx context.Context, req *pbc.GetProjectedCostRequest) (*pbc.GetProjectedCostResponse, error) {
+    tags := req.Resource.Tags
+
+    instanceType := tags["instanceType"]
+    if instanceType == "" {
+        // Critical property missing - signal inability to estimate
+        return &pbc.GetProjectedCostResponse{
+            CostPerMonth:  0,
+            Currency:      "USD",
+            BillingDetail: "SPARSE_PROPERTIES:instanceType|Cannot estimate without instance type",
+        }, nil
+    }
+
+    // Process valid properties...
+}
+```
+
+##### Contract 2: Document Applied Defaults
+
+When defaulting optional properties, track and communicate which defaults were applied:
+
+```go
+func (p *Plugin) GetProjectedCost(ctx context.Context, req *pbc.GetProjectedCostRequest) (*pbc.GetProjectedCostResponse, error) {
+    tags := req.Resource.Tags
+    var defaultsApplied []string
+
+    // Required property
+    instanceType := tags["instanceType"]
+    if instanceType == "" {
+        return &pbc.GetProjectedCostResponse{
+            CostPerMonth:  0,
+            Currency:      "USD",
+            BillingDetail: "SPARSE_PROPERTIES:instanceType|Cannot estimate",
+        }, nil
+    }
+
+    // Optional property with documented default
+    storageGB := 20 // default
+    if s, ok := tags["allocatedStorage"]; ok {
+        storageGB = parseSize(s)
+    } else {
+        defaultsApplied = append(defaultsApplied, "allocatedStorage=20GB")
+    }
+
+    // Include defaults in billing detail for transparency
+    var billingDetail strings.Builder
+    billingDetail.WriteString(fmt.Sprintf("Instance: %s, Storage: %dGB", instanceType, storageGB))
+    if len(defaultsApplied) > 0 {
+        billingDetail.WriteString(fmt.Sprintf("; defaults applied: %s", strings.Join(defaultsApplied, ", ")))
+    }
+
+    cost := calculateCost(instanceType, storageGB)
+    return &pbc.GetProjectedCostResponse{
+        CostPerMonth:  cost,
+        Currency:      "USD",
+        BillingDetail: billingDetail.String(),
+    }, nil
+}
+```
+
+##### Contract 3: Distinguish Explicit Zero from Missing
+
+Use the presence/absence of map keys to differentiate between "property explicitly set to zero"
+and "property not provided":
+
+```go
+// CORRECT: Check for key presence
+if requestCount, ok := tags["requestCount"]; ok {
+    // User explicitly set requestCount (even if "0")
+    count = parseCount(requestCount)
+} else {
+    // Property missing - this is old state
+    return signalSparseProperties("requestCount")
+}
+
+// WRONG: Treats explicit zero same as missing
+requestCount := tags["requestCount"]
+if requestCount == "" {
+    // Can't distinguish "" from missing!
+}
+```
+
+#### Validation Strategy
+
+For sparse property scenarios, use **lenient validation** that allows missing SKU and region:
+
+```go
+// Use lenient validation for old-state baseline lookups
+err := pluginsdk.ValidateProjectedCostRequestLenient(req)
+if err != nil {
+    return nil, status.Error(codes.InvalidArgument, err.Error())
+}
+
+// Extract properties, checking for empty results
+sku := mapping.ExtractAWSSKU(req.Resource.Tags)
+if sku == "" {
+    // SKU missing - signal sparse properties
+    return &pbc.GetProjectedCostResponse{
+        CostPerMonth:  0,
+        Currency:      "USD",
+        BillingDetail: "SPARSE_PROPERTIES:sku|Cannot estimate without SKU",
+    }, nil
+}
+```
+
+#### Note on FallbackHint
+
+`FallbackHint` is a field on `GetActualCostResponse` and `ActualCostData` only — it is **not part of
+`GetProjectedCostResponse`**. For `GetProjectedCost`, signal missing or sparse properties via the
+`billing_detail` field (e.g., `"SPARSE_PROPERTIES:sku|Cannot estimate without SKU"`) or return a
+structured gRPC error with an appropriate status code. See the examples above for recommended patterns.
+
+#### Testing Your Implementation
+
+Test your plugin with realistic sparse property scenarios:
+
+```go
+func TestCostDiff_SparseOldState(t *testing.T) {
+    plugin := &MyPlugin{}
+
+    // Old state: Only instanceType present (common scenario)
+    oldStateReq := &pbc.GetProjectedCostRequest{
+        Resource: &pbc.ResourceDescriptor{
+            Provider:     "aws",
+            ResourceType: "ec2",
+            Tags: map[string]string{
+                "instanceType": "t3.medium",
+                // allocatedStorage missing (was computed)
+            },
+        },
+    }
+
+    // New state: All properties present
+    newStateReq := &pbc.GetProjectedCostRequest{
+        Resource: &pbc.ResourceDescriptor{
+            Provider:     "aws",
+            ResourceType: "ec2",
+            Tags: map[string]string{
+                "instanceType":     "t3.large",
+                "allocatedStorage": "100",
+            },
+        },
+    }
+
+    oldResp, err := plugin.GetProjectedCost(ctx, oldStateReq)
+    require.NoError(t, err)
+
+    newResp, err := plugin.GetProjectedCost(ctx, newStateReq)
+    require.NoError(t, err)
+
+    // Verify defaults are documented
+    assert.Contains(t, oldResp.BillingDetail, "defaults applied")
+
+    // Cost diff should reflect actual change
+    costDiff := newResp.CostPerMonth - oldResp.CostPerMonth
+    assert.Greater(t, costDiff, 0.0) // Larger instance + explicit storage
+}
+```
+
 ### Implementation Requirements
 
 #### Error Handling

--- a/docs/ADVANCED_PATTERNS.md
+++ b/docs/ADVANCED_PATTERNS.md
@@ -612,6 +612,415 @@ func (c *PluginChain) GetActualCost(
 }
 ```
 
+## Cost Diff Patterns: Comparing Resource States
+
+The **cost diff** feature enables showing cost impact before applying infrastructure changes by
+calling `GetProjectedCost` twice - once with old state properties and once with new state
+properties. This section covers advanced patterns for handling this use case.
+
+### Understanding the Two-Call Pattern
+
+```go
+// Baseline cost: Properties before the change (OldState.Inputs)
+baselineReq := &pbc.GetProjectedCostRequest{
+    Resource: &pbc.ResourceDescriptor{
+        Provider:     "aws",
+        ResourceType: "ec2",
+        Tags: map[string]string{
+            "instanceType": "t3.medium", // From old state
+            // availabilityZone missing (was computed)
+            // monitoring missing (was defaulted)
+        },
+    },
+}
+baselineResp, err := plugin.GetProjectedCost(ctx, baselineReq)
+if err != nil {
+    return fmt.Errorf("baseline cost lookup failed: %w", err)
+}
+
+// Modified cost: Properties after the change (NewState.Inputs)
+modifiedReq := &pbc.GetProjectedCostRequest{
+    Resource: &pbc.ResourceDescriptor{
+        Provider:     "aws",
+        ResourceType: "ec2",
+        Tags: map[string]string{
+            "instanceType":     "t3.large",  // Updated
+            "availabilityZone": "us-east-1a", // Now present
+            "monitoring":       "detailed",   // Explicitly set
+        },
+    },
+}
+modifiedResp, err := plugin.GetProjectedCost(ctx, modifiedReq)
+if err != nil {
+    return fmt.Errorf("modified cost lookup failed: %w", err)
+}
+
+// Validate responses before use
+if baselineResp == nil || modifiedResp == nil {
+    return fmt.Errorf("received nil response from GetProjectedCost")
+}
+
+// Cost impact
+costDiff := modifiedResp.CostPerMonth - baselineResp.CostPerMonth
+```
+
+### Pattern 1: Graceful Degradation with Partial Properties
+
+When critical properties are missing, signal the limitation rather than returning misleading results:
+
+```go
+func (p *Plugin) GetProjectedCost(
+    ctx context.Context,
+    req *pbc.GetProjectedCostRequest,
+) (*pbc.GetProjectedCostResponse, error) {
+    // Extract using mapping helpers
+    sku := mapping.ExtractAWSSKU(req.Resource.Tags)
+    region := mapping.ExtractAWSRegion(req.Resource.Tags)
+
+    // Check for sparse property scenario
+    if sku == "" {
+        // Cannot estimate without SKU - signal explicitly
+        return pluginsdk.NewProjectedCostResponse(
+            pluginsdk.WithCostPerMonth(0),
+            pluginsdk.WithCurrency("USD"),
+            pluginsdk.WithBillingDetail("SPARSE_PROPERTIES:instanceType|Cannot estimate without instance type"),
+        ), nil
+    }
+
+    // If region is missing, we can try a default but should document it
+    regionDefaulted := false
+    if region == "" {
+        region = "us-east-1"
+        regionDefaulted = true
+    }
+
+    // Proceed with available properties
+    cost, err := p.pricingAPI.GetCost(ctx, sku, region)
+    if err != nil {
+        return nil, status.Errorf(codes.Unavailable, "pricing lookup failed: %v", err)
+    }
+
+    var billingDetail strings.Builder
+    billingDetail.WriteString(fmt.Sprintf("SKU: %s, Region: %s", sku, region))
+    if regionDefaulted {
+        billingDetail.WriteString("; region defaulted to us-east-1")
+    }
+
+    return pluginsdk.NewProjectedCostResponse(
+        pluginsdk.WithCostPerMonth(cost),
+        pluginsdk.WithCurrency("USD"),
+        pluginsdk.WithBillingDetail(billingDetail.String()),
+    ), nil
+}
+```
+
+### Pattern 2: Using Most-Specific Available Properties
+
+Prefer more-specific properties when available, with graceful fallback:
+
+```go
+func extractStorageSize(tags map[string]string) (int, bool, []string) {
+    var defaults []string
+
+    // Try explicit storage specification
+    if size, ok := tags["allocatedStorage"]; ok {
+        return parseSize(size), true, defaults
+    }
+
+    // Try volume configuration
+    if size, ok := tags["volumeSize"]; ok {
+        return parseSize(size), true, defaults
+    }
+
+    // No explicit storage - check if this is a sparse property scenario
+    // by verifying expected keys are present alongside instanceType
+    if _, hasInstanceType := tags["instanceType"]; hasInstanceType {
+        _, hasAMI := tags["ami"]
+        _, hasRegion := tags["region"]
+        if !hasAMI && !hasRegion {
+            // Missing expected keys indicates sparse old state - return 0 with flag
+            return 0, false, defaults
+        }
+    }
+
+    // Use provider default
+    defaultSize := 20 // GB
+    defaults = append(defaults, fmt.Sprintf("allocatedStorage=%dGB", defaultSize))
+    return defaultSize, true, defaults
+}
+
+func (p *Plugin) GetProjectedCost(
+    ctx context.Context,
+    req *pbc.GetProjectedCostRequest,
+) (*pbc.GetProjectedCostResponse, error) {
+    tags := req.Resource.Tags
+
+    sku := mapping.ExtractAWSSKU(tags)
+    if sku == "" {
+        return signalSparseProperties("instanceType")
+    }
+
+    storageGB, hasStorage, defaults := extractStorageSize(tags)
+    if !hasStorage {
+        // Storage property missing and cannot default safely
+        return signalSparseProperties("allocatedStorage")
+    }
+
+    // Include defaults in response
+    var billingDetail strings.Builder
+    billingDetail.WriteString(fmt.Sprintf("Instance: %s, Storage: %dGB", sku, storageGB))
+    if len(defaults) > 0 {
+        billingDetail.WriteString(fmt.Sprintf("; defaults: %s", strings.Join(defaults, ", ")))
+    }
+
+    cost := calculateCost(sku, storageGB)
+    return pluginsdk.NewProjectedCostResponse(
+        pluginsdk.WithCostPerMonth(cost),
+        pluginsdk.WithCurrency("USD"),
+        pluginsdk.WithBillingDetail(billingDetail.String()),
+    ), nil
+}
+```
+
+### Pattern 3: Differentiating Usage Properties from Configuration Properties
+
+Handle missing **usage properties** (requests, data transfer) differently from **configuration
+properties** (instance type, region):
+
+```go
+func (p *Plugin) GetProjectedCost(
+    ctx context.Context,
+    req *pbc.GetProjectedCostRequest,
+) (*pbc.GetProjectedCostResponse, error) {
+    tags := req.Resource.Tags
+
+    // Configuration properties - MUST be present
+    functionMemory := tags["memory"]
+    if functionMemory == "" {
+        return signalSparseProperties("memory")
+    }
+
+    // Usage properties - can estimate with reasonable defaults
+    monthlyRequests := 1000000 // Default 1M requests
+    var defaults []string
+
+    if r, ok := tags["monthlyRequests"]; ok {
+        monthlyRequests = parseInt(r)
+    } else {
+        defaults = append(defaults, "monthlyRequests=1000000")
+    }
+
+    avgDuration := 100.0 // Default 100ms
+    if d, ok := tags["averageDuration"]; ok {
+        avgDuration = parseFloat(d)
+    } else {
+        defaults = append(defaults, "averageDuration=100ms")
+    }
+
+    // Calculate with documented assumptions
+    cost := calculateLambdaCost(functionMemory, monthlyRequests, avgDuration)
+
+    var billingDetail strings.Builder
+    billingDetail.WriteString(fmt.Sprintf(
+        "Memory: %sMB, Requests: %d/mo, Duration: %.0fms",
+        functionMemory, monthlyRequests, avgDuration,
+    ))
+    if len(defaults) > 0 {
+        billingDetail.WriteString(fmt.Sprintf("; assumed: %s", strings.Join(defaults, ", ")))
+    }
+
+    return pluginsdk.NewProjectedCostResponse(
+        pluginsdk.WithCostPerMonth(cost),
+        pluginsdk.WithCurrency("USD"),
+        pluginsdk.WithBillingDetail(billingDetail.String()),
+    ), nil
+}
+```
+
+### Anti-Pattern: Silent Defaulting
+
+**DO NOT** silently apply defaults that produce misleading cost comparisons:
+
+```go
+// WRONG: Silent defaults make cost diffs meaningless
+func (p *Plugin) GetProjectedCost(
+    ctx context.Context,
+    req *pbc.GetProjectedCostRequest,
+) (*pbc.GetProjectedCostResponse, error) {
+    tags := req.Resource.Tags
+
+    // Silently default everything
+    sku := tags["instanceType"]
+    if sku == "" {
+        sku = "t3.micro" // USER DOESN'T KNOW THIS HAPPENED
+    }
+
+    region := tags["region"]
+    if region == "" {
+        region = "us-east-1" // USER DOESN'T KNOW THIS HAPPENED
+    }
+
+    storageGB := parseInt(tags["storage"])
+    if storageGB == 0 {
+        storageGB = 20 // USER DOESN'T KNOW THIS HAPPENED
+    }
+
+    // This cost may be completely wrong but user sees a number
+    cost := calculateCost(sku, region, storageGB)
+    return pluginsdk.NewProjectedCostResponse(
+        pluginsdk.WithCostPerMonth(cost),
+        pluginsdk.WithCurrency("USD"),
+    ), nil
+}
+
+// CORRECT: Document defaults or signal missing properties
+func (p *Plugin) GetProjectedCost(
+    ctx context.Context,
+    req *pbc.GetProjectedCostRequest,
+) (*pbc.GetProjectedCostResponse, error) {
+    tags := req.Resource.Tags
+    var defaults []string
+
+    // Critical property missing - cannot estimate
+    sku := tags["instanceType"]
+    if sku == "" {
+        return signalSparseProperties("instanceType")
+    }
+
+    // Optional property - use default but document it
+    region := tags["region"]
+    if region == "" {
+        region = "us-east-1"
+        defaults = append(defaults, "region=us-east-1")
+    }
+
+    storageGB := parseInt(tags["storage"])
+    if storageGB == 0 {
+        storageGB = 20
+        defaults = append(defaults, "storage=20GB")
+    }
+
+    cost := calculateCost(sku, region, storageGB)
+
+    var billingDetail strings.Builder
+    billingDetail.WriteString(fmt.Sprintf("SKU: %s, Region: %s, Storage: %dGB", sku, region, storageGB))
+    if len(defaults) > 0 {
+        billingDetail.WriteString(fmt.Sprintf("; defaults: %s", strings.Join(defaults, ", ")))
+    }
+
+    return pluginsdk.NewProjectedCostResponse(
+        pluginsdk.WithCostPerMonth(cost),
+        pluginsdk.WithCurrency("USD"),
+        pluginsdk.WithBillingDetail(billingDetail.String()),
+    ), nil
+}
+```
+
+### When NOT to Use FallbackHint for Sparse Properties
+
+`FallbackHint` signals **"resource type not supported"** or **"no data available"**, not **"properties incomplete"**:
+
+| Scenario | Correct Approach | Wrong Approach |
+|---|---|---|
+| SKU missing from old state | Return response with `SPARSE_PROPERTIES` billing detail | `FALLBACK_HINT_REQUIRED` |
+| Region missing from old state | Use default region, document in billing detail | `FALLBACK_HINT_RECOMMENDED` |
+| Usage property missing | Use reasonable default, document in billing detail | `FALLBACK_HINT_RECOMMENDED` |
+| Unsupported resource type | `FALLBACK_HINT_REQUIRED` | Error or $0 response |
+| No billing data available | `FALLBACK_HINT_RECOMMENDED` | Error or $0 response |
+
+**Correct pattern for sparse properties:**
+
+```go
+if sku == "" {
+    // NOT fallback - just incomplete properties
+    return &pbc.GetProjectedCostResponse{
+        CostPerMonth:  0,
+        Currency:      "USD",
+        BillingDetail: "SPARSE_PROPERTIES:instanceType|Cannot estimate without SKU",
+        // FallbackHint is UNSPECIFIED - this is the right response
+    }, nil
+}
+```
+
+### Testing Cost Diff Scenarios
+
+Comprehensive tests should cover realistic old/new state combinations:
+
+```go
+func TestCostDiff_RealWorldScenarios(t *testing.T) {
+    tests := []struct {
+        name         string
+        oldTags      map[string]string
+        newTags      map[string]string
+        wantBaseline float64
+        wantModified float64
+        wantDiff     float64
+    }{
+        {
+            name: "instance type change with sparse old state",
+            oldTags: map[string]string{
+                "instanceType": "t3.medium",
+                // monitoring was defaulted (missing)
+                // availabilityZone was computed (missing)
+            },
+            newTags: map[string]string{
+                "instanceType": "t3.large",
+                "monitoring":   "detailed", // Now explicit
+            },
+            wantBaseline: 30.37,  // t3.medium with basic monitoring (default)
+            wantModified: 80.65,  // t3.large with detailed monitoring
+            wantDiff:     50.28,
+        },
+        {
+            name: "storage increase with complete state",
+            oldTags: map[string]string{
+                "instanceType": "t3.medium",
+                "storage":      "20",
+            },
+            newTags: map[string]string{
+                "instanceType": "t3.medium",
+                "storage":      "100",
+            },
+            wantBaseline: 38.37,  // t3.medium + 20GB
+            wantModified: 46.37,  // t3.medium + 100GB
+            wantDiff:     8.00,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // Test baseline
+            baselineReq := &pbc.GetProjectedCostRequest{
+                Resource: &pbc.ResourceDescriptor{
+                    Provider:     "aws",
+                    ResourceType: "ec2",
+                    Tags:         tt.oldTags,
+                },
+            }
+            baselineResp, err := plugin.GetProjectedCost(ctx, baselineReq)
+            require.NoError(t, err)
+            assert.InDelta(t, tt.wantBaseline, baselineResp.CostPerMonth, 0.01)
+
+            // Test modified
+            modifiedReq := &pbc.GetProjectedCostRequest{
+                Resource: &pbc.ResourceDescriptor{
+                    Provider:     "aws",
+                    ResourceType: "ec2",
+                    Tags:         tt.newTags,
+                },
+            }
+            modifiedResp, err := plugin.GetProjectedCost(ctx, modifiedReq)
+            require.NoError(t, err)
+            assert.InDelta(t, tt.wantModified, modifiedResp.CostPerMonth, 0.01)
+
+            // Verify cost diff
+            diff := modifiedResp.CostPerMonth - baselineResp.CostPerMonth
+            assert.InDelta(t, tt.wantDiff, diff, 0.01)
+        })
+    }
+}
+```
+
 ## Cost Aggregation Strategies
 
 ### Time-Based Aggregation

--- a/docs/PROPERTY_MAPPING.md
+++ b/docs/PROPERTY_MAPPING.md
@@ -289,6 +289,191 @@ props := map[string]string{"location": "eastus"}
 region := mapping.ExtractRegion(props)  // "eastus"
 ```
 
+## Sparse Property Scenarios: Old vs New State
+
+When `GetProjectedCost` is called as part of a **cost diff operation**, the plugin receives
+property maps that may be incomplete. Understanding the difference between old state and new state
+properties is critical for accurate cost projections.
+
+### Property Availability by Source
+
+| Property Source | Typical Contents | Completeness |
+|---|---|---|
+| **OldState.Inputs** | User-declared inputs from previous deployment | **Sparse** - Only explicit declarations |
+| **NewState.Inputs** | Current user-declared inputs | **Partial** - Richer than OldState.Inputs but can omit provider-computed/defaulted values |
+| **Computed Values** | Provider-calculated values (e.g., auto-generated IDs) | **Never in OldState.Inputs** |
+
+### Per-Provider Property Patterns
+
+#### AWS Properties
+
+| Property | OldState.Inputs | NewState.Inputs | Notes |
+|---|---|---|---|
+| `instanceType` | ✅ Usually present | ✅ Always present | User-specified |
+| `availabilityZone` | ⚠️ Often missing | ✅ Usually present | May be provider-assigned |
+| `ebsOptimized` | ❌ Rarely present | ✅ Often present | Defaults to false if omitted |
+| `monitoring` | ❌ Rarely present | ⚠️ Sometimes present | Defaults to basic if omitted |
+| `volumeSize` | ⚠️ Depends on declaration | ✅ Usually present | May have provider default |
+
+**Extraction Pattern for AWS:**
+
+```go
+sku := mapping.ExtractAWSSKU(props)
+if sku == "" {
+    // Old state likely missing instanceType - cannot estimate
+    return signalSparseProperties("instanceType")
+}
+
+region := mapping.ExtractAWSRegion(props)
+if region == "" {
+    // availabilityZone missing - may need to use default region
+    region = "us-east-1" // Or signal error
+}
+```
+
+#### Azure Properties
+
+| Property | OldState.Inputs | NewState.Inputs | Notes |
+|---|---|---|---|
+| `vmSize` | ✅ Usually present | ✅ Always present | User-specified |
+| `location` | ✅ Usually present | ✅ Always present | Required at creation |
+| `osDisk.diskSizeGB` | ❌ Often missing | ⚠️ Sometimes present | Provider default varies by SKU |
+| `networkInterfaces` | ❌ Rarely present | ⚠️ Sometimes present | Often computed |
+
+**Extraction Pattern for Azure:**
+
+```go
+sku := mapping.ExtractAzureSKU(props)
+if sku == "" {
+    return signalSparseProperties("vmSize")
+}
+
+// Location is usually stable across old and new state
+region := mapping.ExtractAzureRegion(props)
+```
+
+#### GCP Properties
+
+| Property | OldState.Inputs | NewState.Inputs | Notes |
+|---|---|---|---|
+| `machineType` | ✅ Usually present | ✅ Always present | User-specified |
+| `zone` | ⚠️ Sometimes missing | ✅ Usually present | May be project default |
+| `diskSizeGb` | ❌ Often missing | ⚠️ Sometimes present | Provider default 10GB |
+| `serviceAccount` | ❌ Rarely present | ⚠️ Sometimes present | May use default SA |
+
+**Extraction Pattern for GCP:**
+
+```go
+sku := mapping.ExtractGCPSKU(props)
+if sku == "" {
+    return signalSparseProperties("machineType")
+}
+
+region := mapping.ExtractGCPRegion(props)
+if region == "" {
+    // Zone missing - try project default or signal error
+    return signalSparseProperties("zone")
+}
+```
+
+### Extraction Function Behavior with Sparse Maps
+
+All mapping extraction functions return **empty string** when properties are missing:
+
+```go
+// Empty map
+props := map[string]string{}
+sku := mapping.ExtractAWSSKU(props) // Returns: ""
+
+// Nil map
+var props map[string]string
+sku = mapping.ExtractAWSSKU(props)  // Returns: ""
+
+// Property present but empty
+props = map[string]string{"instanceType": ""}
+sku = mapping.ExtractAWSSKU(props)  // Returns: ""
+```
+
+**Critical Pattern**: Always check extraction results before proceeding:
+
+```go
+// CORRECT: Check before use
+sku := mapping.ExtractAWSSKU(req.Resource.Tags)
+if sku == "" {
+    // Handle sparse property scenario
+    return &pbc.GetProjectedCostResponse{
+        CostPerMonth:  0,
+        Currency:      "USD",
+        BillingDetail: "SPARSE_PROPERTIES:instanceType|Cannot estimate without SKU",
+    }, nil
+}
+
+// WRONG: Assume extraction succeeded
+sku := mapping.ExtractAWSSKU(req.Resource.Tags)
+price := pricingAPI.GetPrice(sku) // May fail or return wrong result
+```
+
+### Testing with Sparse Properties
+
+Plugins should test realistic sparse property scenarios:
+
+```go
+func TestSparseOldStateProperties(t *testing.T) {
+    tests := []struct {
+        name     string
+        props    map[string]string
+        wantErr  bool
+        wantCost float64
+    }{
+        {
+            name: "old state - only instanceType",
+            props: map[string]string{
+                "instanceType": "t3.medium",
+                // No availabilityZone (was provider-assigned)
+                // No ebsOptimized (was defaulted)
+            },
+            wantErr:  false,
+            wantCost: 30.37, // Should use default values
+        },
+        {
+            name: "old state - completely sparse",
+            props: map[string]string{},
+            wantErr:  false,
+            wantCost: 0, // Should signal sparse properties
+        },
+        {
+            name: "new state - complete properties",
+            props: map[string]string{
+                "instanceType":     "t3.large",
+                "availabilityZone": "us-east-1a",
+                "ebsOptimized":     "true",
+            },
+            wantErr:  false,
+            wantCost: 75.65,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            req := &pbc.GetProjectedCostRequest{
+                Resource: &pbc.ResourceDescriptor{
+                    Provider:     "aws",
+                    ResourceType: "ec2",
+                    Tags:         tt.props,
+                },
+            }
+            resp, err := plugin.GetProjectedCost(ctx, req)
+            if tt.wantErr {
+                assert.Error(t, err)
+            } else {
+                assert.NoError(t, err)
+                assert.Equal(t, tt.wantCost, resp.CostPerMonth)
+            }
+        })
+    }
+}
+```
+
 ## Common Pitfalls
 
 ### 1. Nested Struct Properties

--- a/proto/finfocus/v1/costsource.proto
+++ b/proto/finfocus/v1/costsource.proto
@@ -509,6 +509,15 @@ message GetPricingSpecResponse {
 //   - REQUIRED fields must be non-empty for valid requests
 //   - OPTIONAL fields may be omitted or empty depending on context
 //
+// Sparse Property Scenarios:
+//   - When GetProjectedCost is called for cost diff operations, the ResourceDescriptor
+//     may contain sparse property sets from Pulumi's OldState.Inputs
+//   - OldState.Inputs contains only user-declared inputs, not computed or defaulted values
+//   - Plugins MUST handle sparse scenarios by either:
+//     a) Signaling missing critical properties via billing_detail
+//     b) Applying documented defaults and indicating them in billing_detail
+//   - See PLUGIN_DEVELOPER_GUIDE.md section "Cost Diff Pattern: Handling Sparse Properties"
+//
 // Validation Rules:
 //   - provider: Must be one of: "aws", "azure", "gcp", "kubernetes", "custom"
 //   - resource_type: Must match the plugin's supported resource types
@@ -531,6 +540,14 @@ message ResourceDescriptor {
 
   // sku is the provider-specific SKU or instance size.
   // OPTIONAL. Required for compute resources, may be omitted for others.
+  //
+  // Sparse Property Note:
+  //   - May be empty when called with old resource state (OldState.Inputs)
+  //   - Plugins should use pluginsdk.ValidateProjectedCostRequestLenient() for
+  //     cost diff scenarios to allow empty SKU
+  //   - When empty, plugins MUST signal via billing_detail rather than returning
+  //     misleading cost estimates
+  //
   // Examples:
   //   - AWS: "t3.micro", "m5.large"
   //   - Azure: "Standard_B1s", "Standard_D2s_v3"
@@ -540,6 +557,12 @@ message ResourceDescriptor {
 
   // region specifies the deployment region.
   // OPTIONAL. Required for regional resources, omit for global resources.
+  //
+  // Sparse Property Note:
+  //   - May be empty when called with old resource state if region was provider-assigned
+  //   - Plugins may apply default region but MUST document it in billing_detail
+  //   - Consider using ValidateProjectedCostRequestLenient() to allow empty region
+  //
   // Examples:
   //   - AWS: "us-east-1", "eu-west-1"
   //   - Azure: "eastus", "westeurope"
@@ -549,6 +572,13 @@ message ResourceDescriptor {
 
   // tags provide label/tag hints for resource identification and filtering.
   // OPTIONAL. Used for additional resource matching and cost allocation.
+  //
+  // Sparse Property Note:
+  //   - May contain incomplete property sets when called with OldState.Inputs
+  //   - Properties that were computed or defaulted by the provider will be missing
+  //   - Plugins MUST check for empty extraction results from mapping helpers
+  //   - See docs/PROPERTY_MAPPING.md section "Sparse Property Scenarios"
+  //
   // Examples: {"app": "web", "env": "production", "team": "platform"}
   // Both keys and values should be non-empty when provided.
   map<string, string> tags = 5;

--- a/sdk/go/pluginsdk/mapping/README.md
+++ b/sdk/go/pluginsdk/mapping/README.md
@@ -149,6 +149,43 @@ mapping.ExtractAWSRegionFromAZ("")         // ""
 mapping.ExtractGCPRegionFromZone("invalid")// "" (fails validation)
 ```
 
+### Sparse Property Scenarios
+
+When processing cost diff requests, property maps may be incomplete (from Pulumi's
+`OldState.Inputs`). Extraction functions return **empty string** for missing properties:
+
+```go
+// Sparse property map from old resource state
+props := map[string]string{
+    "instanceType": "t3.medium",
+    // availabilityZone missing (was provider-computed)
+    // monitoring missing (was defaulted)
+}
+
+sku := mapping.ExtractAWSSKU(props)       // "t3.medium" - present
+region := mapping.ExtractAWSRegion(props) // "" - MISSING
+
+// CRITICAL: Always check extraction results before use
+if region == "" {
+    // Handle sparse property scenario:
+    // Option 1: Signal inability to estimate
+    return signalSparseProperties("region")
+
+    // Option 2: Apply documented default
+    region = "us-east-1"
+    billingDetail += "; region defaulted to us-east-1"
+}
+```
+
+**Best Practice**: Check all extraction results before proceeding with cost calculations. See
+[docs/PROPERTY_MAPPING.md](../../../../docs/PROPERTY_MAPPING.md) section "Sparse Property
+Scenarios" for comprehensive guidance.
+
+**Related Documentation**:
+
+- [PLUGIN_DEVELOPER_GUIDE.md](../../../../PLUGIN_DEVELOPER_GUIDE.md) - "Cost Diff Pattern: Handling Sparse Properties"
+- [docs/ADVANCED_PATTERNS.md](../../../../docs/ADVANCED_PATTERNS.md) - "Cost Diff Patterns: Comparing Resource States"
+
 ## Performance
 
 All functions are optimized for minimal allocation:

--- a/sdk/go/pluginsdk/validation.go
+++ b/sdk/go/pluginsdk/validation.go
@@ -145,6 +145,92 @@ func ValidateProjectedCostRequest(req *pbc.GetProjectedCostRequest) error {
 	return nil
 }
 
+// ValidateProjectedCostRequestLenient validates a GetProjectedCostRequest for sparse property scenarios.
+// This function is designed for cost diff operations where the request may contain incomplete
+// property sets from Pulumi's OldState.Inputs.
+//
+// Unlike ValidateProjectedCostRequest, this lenient validator:
+//   - Does NOT require resource.sku to be non-empty
+//   - Does NOT require resource.region to be non-empty
+//   - Still validates structural requirements (non-nil request/resource, provider, resource_type)
+//
+// Use this validator when:
+//   - Processing GetProjectedCostRequest for cost diff baseline (old state properties)
+//   - The caller may provide sparse property maps from historical resource state
+//   - Your plugin can handle or signal missing SKU/region appropriately
+//
+// After lenient validation passes, plugins MUST:
+//   - Check extraction results from mapping helpers (they return "" for missing properties)
+//   - Signal missing critical properties via billing_detail rather than returning misleading costs
+//   - Document any applied defaults in billing_detail
+//
+// Validation order (fail-fast):
+//  1. Request nil check
+//  2. Resource nil check
+//  3. Provider empty check
+//  4. ResourceType empty check
+//  5. Global utilization range check (if non-zero)
+//  6. Resource-level utilization range check (if provided)
+//
+// Performance: Zero allocations on the happy path (valid request returns nil).
+// Error paths allocate for the error message.
+//
+// Example usage:
+//
+//	func (p *MyPlugin) GetProjectedCost(ctx context.Context, req *pbc.GetProjectedCostRequest) (*pbc.GetProjectedCostResponse, error) {
+//	    // Use lenient validation for potential old-state scenarios
+//	    if err := pluginsdk.ValidateProjectedCostRequestLenient(req); err != nil {
+//	        return nil, status.Error(codes.InvalidArgument, err.Error())
+//	    }
+//
+//	    // Check extraction results - may be empty for sparse properties
+//	    sku := mapping.ExtractAWSSKU(req.Resource.Tags)
+//	    if sku == "" {
+//	        // Signal sparse properties rather than guessing
+//	        return &pbc.GetProjectedCostResponse{
+//	            CostPerMonth:  0,
+//	            Currency:      "USD",
+//	            BillingDetail: "SPARSE_PROPERTIES:instanceType|Cannot estimate without SKU",
+//	        }, nil
+//	    }
+//	    // Process with available properties...
+//	}
+//
+// Returns nil if the request is valid, or an error describing the first validation failure.
+func ValidateProjectedCostRequestLenient(req *pbc.GetProjectedCostRequest) error {
+	if req == nil {
+		return ErrProjectedCostRequestNil
+	}
+
+	resource := req.GetResource()
+	if resource == nil {
+		return ErrProjectedCostResourceNil
+	}
+
+	if len(resource.GetProvider()) == 0 {
+		return ErrProjectedCostProviderEmpty
+	}
+
+	if len(resource.GetResourceType()) == 0 {
+		return ErrProjectedCostResourceTypeEmpty
+	}
+
+	// SKU and region validation intentionally omitted for lenient mode
+
+	// Validate utilization values using centralized helper
+	// Global utilization: non-zero values must be valid (protobuf3 default is 0.0)
+	if u := req.GetUtilizationPercentage(); u != 0 && !IsUtilizationValid(u) {
+		return ErrUtilizationOutOfRange
+	}
+
+	// Resource-level utilization: if explicitly set, must be valid
+	if resource.UtilizationPercentage != nil && !IsUtilizationValid(resource.GetUtilizationPercentage()) {
+		return ErrUtilizationOutOfRange
+	}
+
+	return nil
+}
+
 // ValidateSupportsResponse validates a SupportsResponse for correctness.
 //
 // Validation order:

--- a/sdk/go/pluginsdk/validation_test.go
+++ b/sdk/go/pluginsdk/validation_test.go
@@ -454,3 +454,288 @@ func BenchmarkIsUtilizationValid_Invalid(b *testing.B) {
 		_ = pluginsdk.IsUtilizationValid(1.5)
 	}
 }
+
+func TestValidateProjectedCostRequestLenient(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *pbc.GetProjectedCostRequest
+		wantErr error
+	}{
+		{
+			name:    "nil request returns error",
+			req:     nil,
+			wantErr: pluginsdk.ErrProjectedCostRequestNil,
+		},
+		{
+			name:    "nil resource returns error",
+			req:     &pbc.GetProjectedCostRequest{Resource: nil},
+			wantErr: pluginsdk.ErrProjectedCostResourceNil,
+		},
+		{
+			name:    "unset resource field returns error",
+			req:     &pbc.GetProjectedCostRequest{},
+			wantErr: pluginsdk.ErrProjectedCostResourceNil,
+		},
+		{
+			name: "empty provider returns error",
+			req: &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "",
+					ResourceType: "ec2",
+				},
+			},
+			wantErr: pluginsdk.ErrProjectedCostProviderEmpty,
+		},
+		{
+			name: "empty resource_type returns error",
+			req: &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "",
+				},
+			},
+			wantErr: pluginsdk.ErrProjectedCostResourceTypeEmpty,
+		},
+		{
+			name: "empty sku is ALLOWED in lenient mode",
+			req: &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "ec2",
+					Sku:          "",
+					Region:       "us-east-1",
+				},
+			},
+			wantErr: nil, // No error - lenient mode allows empty SKU
+		},
+		{
+			name: "empty region is ALLOWED in lenient mode",
+			req: &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "ec2",
+					Sku:          "t3.micro",
+					Region:       "",
+				},
+			},
+			wantErr: nil, // No error - lenient mode allows empty region
+		},
+		{
+			name: "both sku and region empty is ALLOWED in lenient mode",
+			req: &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "ec2",
+					Sku:          "",
+					Region:       "",
+				},
+			},
+			wantErr: nil, // No error - lenient mode allows sparse properties
+		},
+		{
+			name: "valid complete request returns nil",
+			req: &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "ec2",
+					Sku:          "t3.micro",
+					Region:       "us-east-1",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "sparse old state properties passes validation",
+			req: &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "ec2",
+					Tags: map[string]string{
+						"instanceType": "t3.medium",
+						// availabilityZone missing
+						// monitoring missing
+					},
+					// SKU and region extracted from tags - may be empty
+					Sku:    "",
+					Region: "",
+				},
+			},
+			wantErr: nil, // Lenient mode allows this
+		},
+		{
+			name: "utilization too high still returns error",
+			req: &pbc.GetProjectedCostRequest{
+				UtilizationPercentage: 1.1,
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "ec2",
+					Sku:          "",
+					Region:       "",
+				},
+			},
+			wantErr: pluginsdk.ErrUtilizationOutOfRange,
+		},
+		{
+			name: "utilization too low still returns error",
+			req: &pbc.GetProjectedCostRequest{
+				UtilizationPercentage: -0.1,
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "ec2",
+					Sku:          "",
+					Region:       "",
+				},
+			},
+			wantErr: pluginsdk.ErrUtilizationOutOfRange,
+		},
+		{
+			name: "resource utilization override too high still returns error",
+			req: &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:              "aws",
+					ResourceType:          "ec2",
+					Sku:                   "",
+					Region:                "",
+					UtilizationPercentage: proto.Float64(1.1),
+				},
+			},
+			wantErr: pluginsdk.ErrUtilizationOutOfRange,
+		},
+		{
+			name: "valid utilization with sparse properties passes",
+			req: &pbc.GetProjectedCostRequest{
+				UtilizationPercentage: 0.75,
+				Resource: &pbc.ResourceDescriptor{
+					Provider:              "aws",
+					ResourceType:          "ec2",
+					Sku:                   "",
+					Region:                "",
+					UtilizationPercentage: proto.Float64(0.5),
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := pluginsdk.ValidateProjectedCostRequestLenient(tt.req)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("ValidateProjectedCostRequestLenient() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateProjectedCostRequestLenient_DifferenceFromStrictValidation(t *testing.T) {
+	t.Run("strict validation rejects empty sku", func(t *testing.T) {
+		req := &pbc.GetProjectedCostRequest{
+			Resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Sku:          "",
+				Region:       "us-east-1",
+			},
+		}
+
+		// Strict validation should fail
+		err := pluginsdk.ValidateProjectedCostRequest(req)
+		if err == nil {
+			t.Error("ValidateProjectedCostRequest() expected error for empty sku, got nil")
+		}
+		if !errors.Is(err, pluginsdk.ErrProjectedCostSkuEmpty) {
+			t.Errorf("ValidateProjectedCostRequest() expected ErrProjectedCostSkuEmpty, got %v", err)
+		}
+
+		// Lenient validation should pass
+		err = pluginsdk.ValidateProjectedCostRequestLenient(req)
+		if err != nil {
+			t.Errorf("ValidateProjectedCostRequestLenient() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("strict validation rejects empty region", func(t *testing.T) {
+		req := &pbc.GetProjectedCostRequest{
+			Resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Sku:          "t3.micro",
+				Region:       "",
+			},
+		}
+
+		// Strict validation should fail
+		err := pluginsdk.ValidateProjectedCostRequest(req)
+		if err == nil {
+			t.Error("ValidateProjectedCostRequest() expected error for empty region, got nil")
+		}
+		if !errors.Is(err, pluginsdk.ErrProjectedCostRegionEmpty) {
+			t.Errorf("ValidateProjectedCostRequest() expected ErrProjectedCostRegionEmpty, got %v", err)
+		}
+
+		// Lenient validation should pass
+		err = pluginsdk.ValidateProjectedCostRequestLenient(req)
+		if err != nil {
+			t.Errorf("ValidateProjectedCostRequestLenient() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("both validations accept complete requests", func(t *testing.T) {
+		req := &pbc.GetProjectedCostRequest{
+			Resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Sku:          "t3.micro",
+				Region:       "us-east-1",
+			},
+		}
+
+		// Both should pass
+		if err := pluginsdk.ValidateProjectedCostRequest(req); err != nil {
+			t.Errorf("ValidateProjectedCostRequest() unexpected error: %v", err)
+		}
+		if err := pluginsdk.ValidateProjectedCostRequestLenient(req); err != nil {
+			t.Errorf("ValidateProjectedCostRequestLenient() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("both validations reject structural errors", func(t *testing.T) {
+		req := &pbc.GetProjectedCostRequest{
+			Resource: &pbc.ResourceDescriptor{
+				Provider:     "",
+				ResourceType: "ec2",
+				Sku:          "t3.micro",
+				Region:       "us-east-1",
+			},
+		}
+
+		// Both should fail with same error
+		strictErr := pluginsdk.ValidateProjectedCostRequest(req)
+		lenientErr := pluginsdk.ValidateProjectedCostRequestLenient(req)
+
+		if !errors.Is(strictErr, pluginsdk.ErrProjectedCostProviderEmpty) {
+			t.Errorf("ValidateProjectedCostRequest() expected ErrProjectedCostProviderEmpty, got %v", strictErr)
+		}
+		if !errors.Is(lenientErr, pluginsdk.ErrProjectedCostProviderEmpty) {
+			t.Errorf("ValidateProjectedCostRequestLenient() expected ErrProjectedCostProviderEmpty, got %v", lenientErr)
+		}
+	})
+}
+
+// BenchmarkValidateProjectedCostRequestLenient validates the zero-allocation claim.
+func BenchmarkValidateProjectedCostRequestLenient(b *testing.B) {
+	req := &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "ec2",
+			Sku:          "",
+			Region:       "",
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = pluginsdk.ValidateProjectedCostRequestLenient(req)
+	}
+}

--- a/sdk/go/proto/finfocus/v1/costsource.pb.go
+++ b/sdk/go/proto/finfocus/v1/costsource.pb.go
@@ -1836,6 +1836,15 @@ func (x *GetPricingSpecResponse) GetSpec() *PricingSpec {
 //   - REQUIRED fields must be non-empty for valid requests
 //   - OPTIONAL fields may be omitted or empty depending on context
 //
+// Sparse Property Scenarios:
+//   - When GetProjectedCost is called for cost diff operations, the ResourceDescriptor
+//     may contain sparse property sets from Pulumi's OldState.Inputs
+//   - OldState.Inputs contains only user-declared inputs, not computed or defaulted values
+//   - Plugins MUST handle sparse scenarios by either:
+//     a) Signaling missing critical properties via billing_detail
+//     b) Applying documented defaults and indicating them in billing_detail
+//   - See PLUGIN_DEVELOPER_GUIDE.md section "Cost Diff Pattern: Handling Sparse Properties"
+//
 // Validation Rules:
 //   - provider: Must be one of: "aws", "azure", "gcp", "kubernetes", "custom"
 //   - resource_type: Must match the plugin's supported resource types
@@ -1857,6 +1866,14 @@ type ResourceDescriptor struct {
 	ResourceType string `protobuf:"bytes,2,opt,name=resource_type,json=resourceType,proto3" json:"resource_type,omitempty"`
 	// sku is the provider-specific SKU or instance size.
 	// OPTIONAL. Required for compute resources, may be omitted for others.
+	//
+	// Sparse Property Note:
+	//   - May be empty when called with old resource state (OldState.Inputs)
+	//   - Plugins should use pluginsdk.ValidateProjectedCostRequestLenient() for
+	//     cost diff scenarios to allow empty SKU
+	//   - When empty, plugins MUST signal via billing_detail rather than returning
+	//     misleading cost estimates
+	//
 	// Examples:
 	//   - AWS: "t3.micro", "m5.large"
 	//   - Azure: "Standard_B1s", "Standard_D2s_v3"
@@ -1865,6 +1882,12 @@ type ResourceDescriptor struct {
 	Sku string `protobuf:"bytes,3,opt,name=sku,proto3" json:"sku,omitempty"`
 	// region specifies the deployment region.
 	// OPTIONAL. Required for regional resources, omit for global resources.
+	//
+	// Sparse Property Note:
+	//   - May be empty when called with old resource state if region was provider-assigned
+	//   - Plugins may apply default region but MUST document it in billing_detail
+	//   - Consider using ValidateProjectedCostRequestLenient() to allow empty region
+	//
 	// Examples:
 	//   - AWS: "us-east-1", "eu-west-1"
 	//   - Azure: "eastus", "westeurope"
@@ -1873,6 +1896,13 @@ type ResourceDescriptor struct {
 	Region string `protobuf:"bytes,4,opt,name=region,proto3" json:"region,omitempty"`
 	// tags provide label/tag hints for resource identification and filtering.
 	// OPTIONAL. Used for additional resource matching and cost allocation.
+	//
+	// Sparse Property Note:
+	//   - May contain incomplete property sets when called with OldState.Inputs
+	//   - Properties that were computed or defaulted by the provider will be missing
+	//   - Plugins MUST check for empty extraction results from mapping helpers
+	//   - See docs/PROPERTY_MAPPING.md section "Sparse Property Scenarios"
+	//
 	// Examples: {"app": "web", "env": "production", "team": "platform"}
 	// Both keys and values should be non-empty when provided.
 	Tags map[string]string `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`

--- a/sdk/typescript/packages/client/src/generated/finfocus/v1/costsource_pb.ts
+++ b/sdk/typescript/packages/client/src/generated/finfocus/v1/costsource_pb.ts
@@ -667,6 +667,15 @@ export const GetPricingSpecResponseSchema: GenMessage<GetPricingSpecResponse> = 
  *   - REQUIRED fields must be non-empty for valid requests
  *   - OPTIONAL fields may be omitted or empty depending on context
  *
+ * Sparse Property Scenarios:
+ *   - When GetProjectedCost is called for cost diff operations, the ResourceDescriptor
+ *     may contain sparse property sets from Pulumi's OldState.Inputs
+ *   - OldState.Inputs contains only user-declared inputs, not computed or defaulted values
+ *   - Plugins MUST handle sparse scenarios by either:
+ *     a) Signaling missing critical properties via billing_detail
+ *     b) Applying documented defaults and indicating them in billing_detail
+ *   - See PLUGIN_DEVELOPER_GUIDE.md section "Cost Diff Pattern: Handling Sparse Properties"
+ *
  * Validation Rules:
  *   - provider: Must be one of: "aws", "azure", "gcp", "kubernetes", "custom"
  *   - resource_type: Must match the plugin's supported resource types
@@ -701,6 +710,14 @@ export type ResourceDescriptor = Message<"finfocus.v1.ResourceDescriptor"> & {
   /**
    * sku is the provider-specific SKU or instance size.
    * OPTIONAL. Required for compute resources, may be omitted for others.
+   *
+   * Sparse Property Note:
+   *   - May be empty when called with old resource state (OldState.Inputs)
+   *   - Plugins should use pluginsdk.ValidateProjectedCostRequestLenient() for
+   *     cost diff scenarios to allow empty SKU
+   *   - When empty, plugins MUST signal via billing_detail rather than returning
+   *     misleading cost estimates
+   *
    * Examples:
    *   - AWS: "t3.micro", "m5.large"
    *   - Azure: "Standard_B1s", "Standard_D2s_v3"
@@ -714,6 +731,12 @@ export type ResourceDescriptor = Message<"finfocus.v1.ResourceDescriptor"> & {
   /**
    * region specifies the deployment region.
    * OPTIONAL. Required for regional resources, omit for global resources.
+   *
+   * Sparse Property Note:
+   *   - May be empty when called with old resource state if region was provider-assigned
+   *   - Plugins may apply default region but MUST document it in billing_detail
+   *   - Consider using ValidateProjectedCostRequestLenient() to allow empty region
+   *
    * Examples:
    *   - AWS: "us-east-1", "eu-west-1"
    *   - Azure: "eastus", "westeurope"
@@ -727,6 +750,13 @@ export type ResourceDescriptor = Message<"finfocus.v1.ResourceDescriptor"> & {
   /**
    * tags provide label/tag hints for resource identification and filtering.
    * OPTIONAL. Used for additional resource matching and cost allocation.
+   *
+   * Sparse Property Note:
+   *   - May contain incomplete property sets when called with OldState.Inputs
+   *   - Properties that were computed or defaulted by the provider will be missing
+   *   - Plugins MUST check for empty extraction results from mapping helpers
+   *   - See docs/PROPERTY_MAPPING.md section "Sparse Property Scenarios"
+   *
    * Examples: {"app": "web", "env": "production", "team": "platform"}
    * Both keys and values should be non-empty when provided.
    *


### PR DESCRIPTION

## Summary

Add comprehensive documentation and SDK support for handling sparse property sets when GetProjectedCost is called with old resource state from Pulumi's OldState.Inputs.

Documentation Changes:
- PLUGIN_DEVELOPER_GUIDE.md: Added "Cost Diff Pattern: Handling Sparse Properties" section with three contract requirements and examples
- docs/PROPERTY_MAPPING.md: Added "Sparse Property Scenarios" section with per-provider property availability tables and extraction patterns
- docs/ADVANCED_PATTERNS.md: Added "Cost Diff Patterns" section with graceful degradation patterns and anti-patterns
- proto/finfocus/v1/costsource.proto: Enhanced ResourceDescriptor comments to explain sparse property scenarios

SDK Changes:
- sdk/go/pluginsdk/validation.go: Added ValidateProjectedCostRequestLenient() function for cost diff scenarios that allows empty SKU and region fields
- sdk/go/pluginsdk/mapping/README.md: Added sparse property scenario documentation and best practices for checking extraction results

Tests:
- sdk/go/pluginsdk/validation_test.go: Added comprehensive tests for lenient validation including comparison with strict validation

Resolves: #377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced lenient cost request validation enabling sparse property scenarios with incomplete property maps.

* **Documentation**
  * Comprehensive cost difference patterns documenting baseline and modified resource state comparisons.
  * Detailed sparse property handling guidance covering extraction, signaling missing values, and explicit defaults.
  * Testing examples and implementation patterns for cost differentiation across cloud providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->