### PR TITLE
refactor(pluginsdk): improve ValidateBatchCostRequest return type

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,9 +53,9 @@ centered around the FinOps Foundation's FOCUS standard.
 - [ ] **Deduplicate grpcCodeToInt32**
   ([#399](https://github.com/rshade/finfocus-spec/issues/399)) [S] -
   Deduplicate grpcCodeToInt32 between pluginsdk and testing packages.
-- [ ] **Improve ValidateBatchCostRequest Return Type**
+- [x] **Improve ValidateBatchCostRequest Return Type**
   ([#400](https://github.com/rshade/finfocus-spec/issues/400)) [M] -
-  Improve return type to avoid (nil, nil) sentinel pattern.
+  Improve return type to avoid (nil, nil) sentinel pattern. Resolved Mar 2026.
 - [ ] **Add ResourceDescriptor Field Validation Limits**
   ([#401](https://github.com/rshade/finfocus-spec/issues/401)) [M] -
   Add field validation limits to batch request validation.

--- a/sdk/go/pluginsdk/batch.go
+++ b/sdk/go/pluginsdk/batch.go
@@ -232,26 +232,34 @@ func ValidateResourceDescriptor(resource *pbc.ResourceDescriptor) error {
 	return nil
 }
 
-// ValidateBatchCostRequest validates a BatchCostRequest and either returns an eager empty
-// BatchCostResponse for an empty resource list, an error for invalid requests, or (nil, nil)
-// to indicate a valid non-empty request that should be processed further.
+// BatchCostValidationResult represents the outcome of validating a BatchCostRequest.
+// If EarlyResponse is non-nil, the caller should return it immediately without further processing.
+// If EarlyResponse is nil and no error occurred, the caller should proceed with normal processing.
+type BatchCostValidationResult struct {
+	// EarlyResponse is set when validation determines an empty response should be
+	// returned immediately (e.g., for empty resource lists).
+	EarlyResponse *pbc.BatchCostResponse
+}
+
+// ValidateBatchCostRequest validates a BatchCostRequest and returns a BatchCostValidationResult
+// indicating whether the request is valid and if an early response should be returned.
 //
 // Validation rules:
 // - req must be non-nil.
 // - If maxBatchSize <= 0, DefaultMaxBatchSize is applied.
-// - If the resource list is empty, returns a BatchCostResponse with Results=[] and MaxBatchSize set.
+// - If the resource list is empty, returns a ValidationResult with EarlyResponse set.
 // - The number of resources must not exceed maxBatchSize.
 // - Each ResourceDescriptor is validated via ValidateResourceDescriptor (field lengths, tag constraints).
 // - query_type must be a valid CostQueryType.
-// - If the normalized query type is not ACTUAL, returns (nil, nil) to signal no further eager validation here.
 // - For ACTUAL queries, both start and end must be present and start must be strictly before end.
 //
 // Return values:
-// - (*pbc.BatchCostResponse, nil): when an eager empty response is produced for an empty resource list.
-// - (nil, error): when the request is invalid.
-func ValidateBatchCostRequest(req *pbc.BatchCostRequest, maxBatchSize int32) (*pbc.BatchCostResponse, error) {
+// - BatchCostValidationResult with EarlyResponse set: when an eager empty response should be returned.
+// - BatchCostValidationResult with EarlyResponse nil: when the request is valid and should be processed normally.
+// - error: when the request is invalid.
+func ValidateBatchCostRequest(req *pbc.BatchCostRequest, maxBatchSize int32) (BatchCostValidationResult, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "request is required")
+		return BatchCostValidationResult{}, status.Error(codes.InvalidArgument, "request is required")
 	}
 
 	if maxBatchSize <= 0 {
@@ -260,14 +268,16 @@ func ValidateBatchCostRequest(req *pbc.BatchCostRequest, maxBatchSize int32) (*p
 
 	resourceCount := len(req.GetResources())
 	if resourceCount == 0 {
-		return NewBatchCostResponse(
-			WithBatchResults([]*pbc.ResourceCostResult{}),
-			WithMaxBatchSize(maxBatchSize),
-		), nil
+		return BatchCostValidationResult{
+			EarlyResponse: NewBatchCostResponse(
+				WithBatchResults([]*pbc.ResourceCostResult{}),
+				WithMaxBatchSize(maxBatchSize),
+			),
+		}, nil
 	}
 
 	if int64(resourceCount) > int64(maxBatchSize) {
-		return nil, status.Errorf(
+		return BatchCostValidationResult{}, status.Errorf(
 			codes.InvalidArgument,
 			"batch size %d exceeds max_batch_size %d",
 			resourceCount,
@@ -281,7 +291,7 @@ func ValidateBatchCostRequest(req *pbc.BatchCostRequest, maxBatchSize int32) (*p
 			// ValidateResourceDescriptor always returns gRPC status errors,
 			// so status.FromError is guaranteed to succeed here.
 			s, _ := status.FromError(err)
-			return nil, status.Errorf(
+			return BatchCostValidationResult{}, status.Errorf(
 				codes.InvalidArgument,
 				"resource at index %d: %s",
 				i,
@@ -292,26 +302,30 @@ func ValidateBatchCostRequest(req *pbc.BatchCostRequest, maxBatchSize int32) (*p
 
 	queryType := req.GetQueryType()
 	if !IsValidCostQueryType(queryType) {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid query_type: %d", queryType)
+		return BatchCostValidationResult{}, status.Errorf(codes.InvalidArgument, "invalid query_type: %d", queryType)
 	}
 
 	if NormalizeCostQueryType(queryType) != pbc.CostQueryType_COST_QUERY_TYPE_ACTUAL {
-		//nolint:nilnil // Non-empty valid requests intentionally return (nil, nil)
-		return nil, nil
+		return BatchCostValidationResult{}, nil
 	}
 
 	start := req.GetStart()
 	end := req.GetEnd()
 	if start == nil || end == nil {
-		return nil, status.Error(codes.InvalidArgument, "start and end are required for ACTUAL query type")
+		return BatchCostValidationResult{}, status.Error(
+			codes.InvalidArgument,
+			"start and end are required for ACTUAL query type",
+		)
 	}
 
 	if !start.AsTime().Before(end.AsTime()) {
-		return nil, status.Error(codes.InvalidArgument, "start must be before end for ACTUAL query type")
+		return BatchCostValidationResult{}, status.Error(
+			codes.InvalidArgument,
+			"start must be before end for ACTUAL query type",
+		)
 	}
 
-	//nolint:nilnil // Non-empty valid requests intentionally return (nil, nil)
-	return nil, nil
+	return BatchCostValidationResult{}, nil
 }
 
 // BatchCostResponseOption is a functional option for BatchCostResponse.

--- a/sdk/go/pluginsdk/batch_test.go
+++ b/sdk/go/pluginsdk/batch_test.go
@@ -29,10 +29,11 @@ func TestValidateBatchCostRequestActualRequiresTimeRange(t *testing.T) {
 		},
 	}
 
-	_, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
+	result, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	assert.Contains(t, err.Error(), "start and end are required")
+	assert.Nil(t, result.EarlyResponse, "EarlyResponse must be nil when error is returned")
 }
 
 func TestValidateBatchCostRequestActualStartBeforeEnd(t *testing.T) {
@@ -46,10 +47,23 @@ func TestValidateBatchCostRequestActualStartBeforeEnd(t *testing.T) {
 		},
 	}
 
-	_, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
+	result, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 	assert.Contains(t, err.Error(), "start must be before end")
+	assert.Nil(t, result.EarlyResponse, "EarlyResponse must be nil when error is returned")
+}
+
+func TestValidateBatchCostRequestEmptyResourcesReturnsEarlyResponse(t *testing.T) {
+	req := &pbc.BatchCostRequest{
+		QueryType: pbc.CostQueryType_COST_QUERY_TYPE_ESTIMATE,
+		Resources: []*pbc.ResourceDescriptor{},
+	}
+	result, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
+	require.NoError(t, err)
+	require.NotNil(t, result.EarlyResponse)
+	assert.Empty(t, result.EarlyResponse.GetResults())
+	assert.Equal(t, int32(DefaultMaxBatchSize), result.EarlyResponse.GetMaxBatchSize())
 }
 
 func TestValidateBatchCostRequestNonActualIgnoresTimeRange(t *testing.T) {
@@ -79,9 +93,9 @@ func TestValidateBatchCostRequestNonActualIgnoresTimeRange(t *testing.T) {
 					{Provider: "aws", ResourceType: "ec2"},
 				},
 			}
-			emptyResp, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
+			result, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
 			require.NoError(t, err)
-			assert.Nil(t, emptyResp)
+			assert.Nil(t, result.EarlyResponse)
 		})
 	}
 }
@@ -685,11 +699,12 @@ func TestValidateBatchCostRequestResourceDescriptorValidation(t *testing.T) {
 				QueryType: pbc.CostQueryType_COST_QUERY_TYPE_ESTIMATE,
 				Resources: tc.resources,
 			}
-			_, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
+			result, err := ValidateBatchCostRequest(req, DefaultMaxBatchSize)
 			if tc.expectError {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errorText)
 				assert.Equal(t, codes.InvalidArgument, status.Code(err))
+				assert.Nil(t, result.EarlyResponse, "EarlyResponse must be nil when error is returned")
 				// Verify clean error wrapping: the status message (desc) should not
 				// contain a nested "rpc error: code =" from an inner gRPC status.
 				s, ok := status.FromError(err)

--- a/sdk/go/pluginsdk/sdk.go
+++ b/sdk/go/pluginsdk/sdk.go
@@ -809,14 +809,14 @@ func (s *Server) BatchCost(
 ) (*pbc.BatchCostResponse, error) {
 	startedAt := logBatchCostRequest(s.logger, req)
 
-	emptyResp, err := ValidateBatchCostRequest(req, s.maxBatchSize)
+	result, err := ValidateBatchCostRequest(req, s.maxBatchSize)
 	if err != nil {
 		return nil, err
 	}
-	if emptyResp != nil {
-		errorCount := logBatchCostResourceErrors(s.logger, emptyResp.GetResults())
-		logBatchCostCompletion(s.logger, startedAt, emptyResp, errorCount)
-		return emptyResp, nil
+	if result.EarlyResponse != nil {
+		errorCount := logBatchCostResourceErrors(s.logger, result.EarlyResponse.GetResults())
+		logBatchCostCompletion(s.logger, startedAt, result.EarlyResponse, errorCount)
+		return result.EarlyResponse, nil
 	}
 
 	// Check if we have a custom BatchCostHandler


### PR DESCRIPTION
Replace (nil, nil) sentinel return with ValidationResult type for better Go idioms and self-documenting API.

Changes:
- Add ValidationResult struct to represent validation outcome
- Update ValidateBatchCostRequest to return ValidationResult instead of (*BatchCostResponse, error)
- Remove //nolint:nilnil suppressions (2 instances)
- Update caller in sdk.go to check result.EarlyResponse
- Update tests to assert on result.EarlyResponse

Fixes #400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved batch cost validation logic with clearer handling of edge cases and better signaling of processing flow control.
* **Tests**
  * Enhanced test coverage to verify validation behavior across various input scenarios.
* **Documentation**
  * Updated roadmap to reflect completion of batch validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->