### PR TITLE
perf(pluginsdk): fix unbounded goroutine creation in batchCostFallback

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -70,8 +70,7 @@ jobs:
               }
             }
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
           # Optional: Customize review based on file types
           # direct_prompt: |
           #   Review this PR focusing on:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,6 +493,15 @@ Configuration: `lefthook.yml`, `commitlint.config.js`
 - Solution: Separate CI jobs for unit tests, integration tests, and benchmarks
 - Pattern: Parallel job execution with artifact collection for benchmarks
 
+## Pre-Commit Requirements
+
+**MANDATORY**: Before committing any code changes, ALWAYS run:
+
+1. `golangci-lint run ./...` — Verify no lint errors (or `make lint` for full linting)
+2. `make test` — Verify all tests pass
+
+Do NOT commit code without running both checks. Fix any issues before committing.
+
 ## Best Practices Discovered
 
 ### Testing Framework Architecture

--- a/sdk/go/pluginsdk/batch.go
+++ b/sdk/go/pluginsdk/batch.go
@@ -417,9 +417,9 @@ func resolveBatchSize(configured int) int32 {
 }
 
 // resolveBatchWorkers returns the number of workers to use for batching.
-// If configured is < MinBatchWorkers it returns DefaultBatchWorkers. Values above
-// MaxBatchWorkers are lowered to MaxBatchWorkers; otherwise the configured value
-// is returned.
+// If configured is < MinBatchWorkers it returns DefaultBatchWorkers (not
+// MinBatchWorkers). Values above MaxBatchWorkers are capped at MaxBatchWorkers;
+// otherwise the configured value is returned as-is.
 func resolveBatchWorkers(configured int) int {
 	switch {
 	case configured < MinBatchWorkers:
@@ -515,9 +515,11 @@ func logBatchCostCompletion(
 
 // batchCostFallback processes each resource in req in parallel (bounded by workers),
 // invoking batchCostForResource for each and collecting per-resource results into a
-// BatchCostResponse. It respects ctx cancellation for individual work items by
-// recording a ResourceError when the context is done and always returns a response
-// populated with the per-resource results and the provided maxBatchSize.
+// BatchCostResponse. If the context is cancelled while launching goroutines, remaining
+// un-launched resources are immediately marked with a cancellation error and goroutine
+// launching stops. Goroutines already launched before cancellation run to completion;
+// their results are included in the response. Always returns a response populated with
+// per-resource results and the provided maxBatchSize.
 //
 // IMPORTANT: req is read-only; the caller skips proto.Clone before passing it here.
 // All downstream functions must not modify req. Query type normalization is performed
@@ -533,24 +535,43 @@ func batchCostFallback(
 	results := make([]*pbc.ResourceCostResult, len(resources))
 	queryType := NormalizeCostQueryType(req.GetQueryType())
 
-	semaphore := make(chan struct{}, workers)
+	sem := make(chan struct{}, workers)
 	var wg sync.WaitGroup
 
+loop:
 	for idx, resource := range resources {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			// Record cancellation for remaining resources.
+			// INVARIANT: goroutines already launched write to results[0..idx-1];
+			// this fill-in covers results[idx..len-1], so there is no overlap.
+			// Sample ctx.Err() once to avoid repeated calls.
+			ctxErr := ctx.Err()
+			for j := idx; j < len(resources); j++ {
+				results[j] = newResourceErrorResult(
+					resources[j],
+					resourceErrorFromGRPCError(ctxErr),
+				)
+			}
+			break loop // wg.Wait() below drains in-flight goroutines
+		}
+
 		wg.Add(1)
 		go func(index int, descriptor *pbc.ResourceDescriptor) {
 			defer wg.Done()
-
-			select {
-			case semaphore <- struct{}{}:
-				defer func() { <-semaphore }()
-			case <-ctx.Done():
-				results[index] = newResourceErrorResult(
-					descriptor,
-					resourceErrorFromGRPCError(ctx.Err()),
-				)
-				return
-			}
+			defer func() { <-sem }()
+			defer func() {
+				if r := recover(); r != nil {
+					results[index] = newResourceErrorResult(
+						descriptor,
+						&pbc.ResourceError{
+							Code:    int32(codes.Internal),
+							Message: fmt.Sprintf("plugin panic: %v", r),
+						},
+					)
+				}
+			}()
 
 			results[index] = batchCostForResource(ctx, plugin, req, descriptor, queryType)
 		}(idx, resource)

--- a/sdk/go/pluginsdk/batch_test.go
+++ b/sdk/go/pluginsdk/batch_test.go
@@ -517,6 +517,188 @@ func (p *benchmarkStaticBatchPlugin) BatchCost(
 	return p.response, nil
 }
 
+func TestBatchCostFallbackCancelledBeforeLaunch(t *testing.T) {
+	plugin := &batchServerTestPlugin{}
+	server := NewServer(plugin)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately before any goroutines launch
+
+	resp, err := server.BatchCost(ctx, &pbc.BatchCostRequest{
+		QueryType: pbc.CostQueryType_COST_QUERY_TYPE_ESTIMATE,
+		Resources: []*pbc.ResourceDescriptor{
+			{Provider: "aws", ResourceType: "ec2"},
+			{Provider: "aws", ResourceType: "s3"},
+			{Provider: "gcp", ResourceType: "compute"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetResults(), 3, "result count must equal resource count")
+
+	// With a pre-cancelled context, Go's select is non-deterministic (both sem
+	// and ctx.Done() are ready), so some resources may be processed while others
+	// get cancellation errors. The key invariant: all results are non-nil, no
+	// panics, and no data races (verified by -race flag).
+	expectedProviders := []string{"aws", "aws", "gcp"}
+	for i, result := range resp.GetResults() {
+		require.NotNil(t, result, "resource %d must have a non-nil result", i)
+		require.NotNil(t, result.GetResource(), "resource %d must echo back the descriptor", i)
+
+		// Verify result-to-resource index correspondence.
+		assert.Equal(t, expectedProviders[i], result.GetResource().GetProvider(),
+			"resource %d provider must match input ordering", i)
+
+		// Each result must be valid: either cost data or a cancellation error.
+		hasData := result.GetCostData() != nil
+		isCancelled := result.GetError() != nil &&
+			result.GetError().GetCode() == int32(codes.Canceled)
+		assert.True(t, hasData || isCancelled,
+			"resource %d must have cost data or cancellation error, got neither", i)
+	}
+}
+
+func TestBatchCostFallbackCancelledMidBatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var callCount atomic.Int64
+	plugin := &cancellingBatchPlugin{
+		cancelAfter: 2,
+		cancel:      cancel,
+		callCount:   &callCount,
+	}
+	server := NewServer(plugin)
+	server.batchWorkers = 1 // sequential to control cancellation point
+
+	resp, err := server.BatchCost(ctx, &pbc.BatchCostRequest{
+		QueryType: pbc.CostQueryType_COST_QUERY_TYPE_ESTIMATE,
+		Resources: []*pbc.ResourceDescriptor{
+			{Provider: "aws", ResourceType: "ec2"},
+			{Provider: "aws", ResourceType: "s3"},
+			{Provider: "aws", ResourceType: "rds"},
+			{Provider: "aws", ResourceType: "lambda"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetResults(), 4, "result count must always equal resource count")
+
+	// First resources were processed; remaining should have cancellation errors.
+	// With workers=1, cancellation after 2 calls means resources 2+ get errors.
+	cancelledCount := 0
+	for _, result := range resp.GetResults() {
+		if result.GetError() != nil && result.GetError().GetCode() == int32(codes.Canceled) {
+			cancelledCount++
+		}
+	}
+	assert.Positive(t, cancelledCount, "at least one resource must have cancellation error")
+	assert.LessOrEqual(t, callCount.Load(), int64(3),
+		"no goroutines should launch for remaining resources after cancellation")
+}
+
+func TestBatchCostFallbackCancelledMidBatchConcurrent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var callCount atomic.Int64
+	plugin := &cancellingBatchPlugin{
+		cancelAfter: 5,
+		cancel:      cancel,
+		callCount:   &callCount,
+	}
+	server := NewServer(plugin)
+	// Use default workers (10) so multiple goroutines are in flight at cancellation.
+
+	const numResources = 25
+	resources := make([]*pbc.ResourceDescriptor, numResources)
+	for i := range resources {
+		resources[i] = &pbc.ResourceDescriptor{
+			Provider: "aws", ResourceType: fmt.Sprintf("type-%d", i),
+		}
+	}
+
+	resp, err := server.BatchCost(ctx, &pbc.BatchCostRequest{
+		QueryType: pbc.CostQueryType_COST_QUERY_TYPE_ESTIMATE,
+		Resources: resources,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetResults(), numResources, "result count must always equal resource count")
+
+	cancelledCount := 0
+	for i, result := range resp.GetResults() {
+		require.NotNil(t, result, "resource %d must have a non-nil result", i)
+		if result.GetError() != nil && result.GetError().GetCode() == int32(codes.Canceled) {
+			cancelledCount++
+		}
+	}
+	assert.Positive(t, cancelledCount, "at least one resource must have cancellation error with concurrent workers")
+}
+
+func TestBatchCostFallbackPluginPanic(t *testing.T) {
+	plugin := &panickingBatchPlugin{}
+	server := NewServer(plugin)
+
+	resp, err := server.BatchCost(context.Background(), &pbc.BatchCostRequest{
+		QueryType: pbc.CostQueryType_COST_QUERY_TYPE_ESTIMATE,
+		Resources: []*pbc.ResourceDescriptor{
+			{Provider: "aws", ResourceType: "ec2"},
+			{Provider: "aws", ResourceType: "panic-trigger"},
+			{Provider: "aws", ResourceType: "s3"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetResults(), 3, "result count must equal resource count")
+
+	// The panicking resource should get an Internal error, not crash the process.
+	for i, result := range resp.GetResults() {
+		require.NotNil(t, result, "resource %d must have a non-nil result", i)
+		if result.GetResource().GetResourceType() == "panic-trigger" {
+			require.NotNil(t, result.GetError(), "panicking resource must have an error")
+			assert.Equal(t, int32(codes.Internal), result.GetError().GetCode())
+			assert.Contains(t, result.GetError().GetMessage(), "plugin panic")
+		} else {
+			assert.NotNil(t, result.GetCostData(), "non-panicking resource %d must have cost data", i)
+		}
+	}
+}
+
+// panickingBatchPlugin panics when processing "panic-trigger" resource type.
+type panickingBatchPlugin struct {
+	batchServerTestPlugin
+}
+
+func (p *panickingBatchPlugin) EstimateCost(
+	_ context.Context,
+	req *pbc.EstimateCostRequest,
+) (*pbc.EstimateCostResponse, error) {
+	if req.GetResourceType() == "panic-trigger" {
+		panic("simulated plugin crash")
+	}
+	return &pbc.EstimateCostResponse{
+		Currency:    "USD",
+		CostMonthly: 10,
+	}, nil
+}
+
+// cancellingBatchPlugin cancels the context after a specified number of EstimateCost calls.
+type cancellingBatchPlugin struct {
+	batchServerTestPlugin
+
+	cancelAfter int64
+	cancel      context.CancelFunc
+	callCount   *atomic.Int64
+}
+
+func (p *cancellingBatchPlugin) EstimateCost(
+	ctx context.Context,
+	req *pbc.EstimateCostRequest,
+) (*pbc.EstimateCostResponse, error) {
+	count := p.callCount.Add(1)
+	// Use >= defensively: if multiple goroutines increment past the threshold
+	// concurrently, all of them should still trigger cancellation.
+	if count >= p.cancelAfter {
+		p.cancel()
+	}
+	return p.batchServerTestPlugin.EstimateCost(ctx, req)
+}
+
 // TestValidateResourceDescriptor tests field-level validation for ResourceDescriptor.
 func TestValidateResourceDescriptor(t *testing.T) {
 	tests := []struct {
@@ -864,6 +1046,95 @@ func BenchmarkServerBatchCost_CustomHandler_NoClone(b *testing.B) {
 		}
 		if resp == nil {
 			b.Fatal("BatchCost returned nil response")
+		}
+	}
+}
+
+func TestResolveBatchWorkers(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		expected   int
+	}{
+		{"zero returns default", 0, DefaultBatchWorkers},
+		{"negative returns default", -1, DefaultBatchWorkers},
+		{"minimum boundary", MinBatchWorkers, MinBatchWorkers},
+		{"mid-range passthrough", 25, 25},
+		{"maximum boundary", MaxBatchWorkers, MaxBatchWorkers},
+		{"above maximum is capped", MaxBatchWorkers + 1, MaxBatchWorkers},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveBatchWorkers(tt.configured)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// BenchmarkServerBatchCost_CancelledContext measures the overhead of the
+// cancellation fast-path where no goroutines are launched.
+func BenchmarkServerBatchCost_CancelledContext(b *testing.B) {
+	plugin := &batchServerTestPlugin{}
+	server := NewServer(plugin)
+
+	resources := make([]*pbc.ResourceDescriptor, 100)
+	for i := range resources {
+		resources[i] = &pbc.ResourceDescriptor{
+			Provider: "aws", ResourceType: "ec2", Region: "us-east-1",
+		}
+	}
+
+	req := &pbc.BatchCostRequest{
+		QueryType: pbc.CostQueryType_COST_QUERY_TYPE_ESTIMATE,
+		Resources: resources,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		resp, err := server.BatchCost(ctx, req)
+		if err != nil {
+			b.Fatalf("BatchCost returned error: %v", err)
+		}
+		if len(resp.GetResults()) != 100 {
+			b.Fatalf("expected 100 results, got %d", len(resp.GetResults()))
+		}
+	}
+}
+
+// BenchmarkServerBatchCost_Fallback_1000Resources measures memory and throughput
+// at MaxBatchSize (1000 resources) to validate the bounded-goroutine approach.
+func BenchmarkServerBatchCost_Fallback_1000Resources(b *testing.B) {
+	plugin := &batchServerTestPlugin{}
+	server := NewServer(plugin)
+	server.maxBatchSize = int32(MaxBatchSize)
+
+	resources := make([]*pbc.ResourceDescriptor, MaxBatchSize)
+	for i := range resources {
+		resources[i] = &pbc.ResourceDescriptor{
+			Provider: "aws", ResourceType: "ec2", Region: "us-east-1",
+		}
+	}
+
+	req := &pbc.BatchCostRequest{
+		QueryType: pbc.CostQueryType_COST_QUERY_TYPE_ESTIMATE,
+		Resources: resources,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		resp, err := server.BatchCost(context.Background(), req)
+		if err != nil {
+			b.Fatalf("BatchCost returned error: %v", err)
+		}
+		if len(resp.GetResults()) != MaxBatchSize {
+			b.Fatalf("expected %d results, got %d", MaxBatchSize, len(resp.GetResults()))
 		}
 	}
 }


### PR DESCRIPTION
Acquire semaphore before launching goroutines to limit concurrent goroutines to worker count (default 10, max 50) instead of resource count (up to 1000).

This reduces peak memory usage from ~8MB to ~400KB for large batch requests by limiting the number of live goroutines.

Fixes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling in batch operations. When a context is cancelled, remaining resources are now properly marked with cancellation errors without launching additional processing tasks.

* **Tests**
  * Added comprehensive test coverage for batch operation cancellation scenarios, including pre-cancelled contexts and mid-batch cancellations, plus performance benchmarks for cancelled-context operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->