### PR TITLE
feat(jsonld): add StreamResult validation helper methods

### DIFF
--- a/sdk/go/jsonld/README.md
+++ b/sdk/go/jsonld/README.md
@@ -25,8 +25,10 @@ The examples below assume the following imports:
 ```go
 import (
     "bytes"
+    "context"
     "fmt"
     "log"
+    "time"
 
     "google.golang.org/protobuf/types/known/timestamppb"
     pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
@@ -63,7 +65,7 @@ serializer := jsonld.NewSerializer()
 records := []*pbc.FocusCostRecord{...} // 10,000+ records
 
 var buf bytes.Buffer
-result, err := serializer.SerializeSlice(records, &buf)
+result, err := serializer.SerializeSlice(context.Background(), records, &buf)
 if err != nil {
     log.Fatal(err)
 }
@@ -192,13 +194,58 @@ if err != nil {
 ### Streaming Errors
 
 ```go
-result, err := serializer.SerializeSlice(records, &buf)
+result, err := serializer.SerializeSlice(context.Background(), records, &buf)
 if result.HasErrors() {
     for _, e := range result.Errors {
         fmt.Printf("Index %d: %v\n", e.Index, e.Err)
     }
 }
 ```
+
+### Context Cancellation and Output Validation
+
+When using context cancellation with streaming operations, the output may be corrupted if
+cancellation occurs mid-stream. Use the helper methods to validate output safety:
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+var buf bytes.Buffer
+result, err := serializer.SerializeStream(ctx, recordsChan, &buf)
+
+// Always check the error first
+if err != nil {
+    // For non-cancel errors (e.g., write failures), the output is unusable
+    if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+        return fmt.Errorf("serialization failed: %w", err)
+    }
+    // Context was cancelled — check if the partial output is still valid
+    if !result.IsOutputValid() {
+        // ValidateOutputJSON checks if the buffer contains parseable JSON.
+        // This only proves syntactic validity, not that serialization completed.
+        if valErr := result.ValidateOutputJSON(buf.Bytes()); valErr != nil {
+            // Output is corrupted - must retry from scratch
+            return retry()
+        }
+        // Output is parseable JSON despite cancellation - safe to use
+    }
+}
+// err == nil && result.IsOutputValid(): serialization completed successfully
+```
+
+**Helper Methods**:
+
+- `IsOutputValid()` - Returns `false` if context cancellation may have corrupted the output
+- `ValidateOutputJSON(data []byte) error` - Checks if the buffer contains parseable JSON
+  when `CorruptedOnCancel` is true; does **not** guarantee serialization completed successfully
+
+**Best Practices**:
+
+1. Always check the `err` return value before using the output buffer
+2. Check `IsOutputValid()` when context cancellation is possible
+3. Use `ValidateOutputJSON()` to verify JSON parseability for partial output
+4. Consider transactional writes (write to temp file, rename on success) for critical operations
 
 ## Testing
 

--- a/sdk/go/jsonld/streaming.go
+++ b/sdk/go/jsonld/streaming.go
@@ -67,11 +67,41 @@ var (
 	ErrMaxRecordsExceeded = errors.New("max records limit exceeded")
 	// ErrRecordTooLarge is returned when a single record exceeds the size limit.
 	ErrRecordTooLarge = errors.New("record size exceeds limit")
+	// ErrOutputCorrupted is returned when context cancellation corrupted the output JSON.
+	ErrOutputCorrupted = errors.New("output corrupted during cancellation: JSON is invalid")
 )
 
 // HasErrors returns true if any errors occurred during streaming.
 func (r *StreamResult) HasErrors() bool {
 	return len(r.Errors) > 0
+}
+
+// IsOutputValid returns true if the output can be safely used.
+// Returns false if context cancellation may have corrupted the output.
+func (r *StreamResult) IsOutputValid() bool {
+	return !r.CorruptedOnCancel
+}
+
+// ValidateOutputJSON validates the output if corruption may have occurred.
+// Returns nil if output is valid, error if corrupted and invalid JSON.
+//
+// Usage pattern after context cancellation:
+//
+//	result, err := serializer.SerializeStream(ctx, ch, &buf)
+//	if err != nil && result.CorruptedOnCancel {
+//	    if valErr := result.ValidateOutputJSON(buf.Bytes()); valErr != nil {
+//	        // Must retry from scratch
+//	        return retry()
+//	    }
+//	    // Output is valid despite cancellation
+//	}
+func (r *StreamResult) ValidateOutputJSON(data []byte) error {
+	if r.CorruptedOnCancel {
+		if !json.Valid(data) {
+			return ErrOutputCorrupted
+		}
+	}
+	return nil
 }
 
 // Buffer pool configuration constants.

--- a/sdk/go/jsonld/streaming_test.go
+++ b/sdk/go/jsonld/streaming_test.go
@@ -761,3 +761,188 @@ func TestSerializeStream_MaxRecordSizeLimit(t *testing.T) {
 		t.Errorf("Expected ErrRecordTooLarge, got %v", result.Errors[0].Err)
 	}
 }
+
+func TestStreamResult_IsOutputValid(t *testing.T) {
+	tests := []struct {
+		name              string
+		corruptedOnCancel bool
+		expected          bool
+	}{
+		{
+			name:              "valid output - not corrupted",
+			corruptedOnCancel: false,
+			expected:          true,
+		},
+		{
+			name:              "invalid output - corrupted on cancel",
+			corruptedOnCancel: true,
+			expected:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &jsonld.StreamResult{CorruptedOnCancel: tt.corruptedOnCancel}
+			if got := result.IsOutputValid(); got != tt.expected {
+				t.Errorf("IsOutputValid() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStreamResult_ValidateOutputJSON(t *testing.T) {
+	tests := []struct {
+		name              string
+		corruptedOnCancel bool
+		data              []byte
+		wantErr           bool
+	}{
+		{
+			name:              "not corrupted - valid JSON",
+			corruptedOnCancel: false,
+			data:              []byte(`[{"key": "value"}]`),
+			wantErr:           false,
+		},
+		{
+			name:              "not corrupted - invalid JSON",
+			corruptedOnCancel: false,
+			data:              []byte(`[{"key": "value"`),
+			wantErr:           false, // Should not validate if not corrupted
+		},
+		{
+			name:              "corrupted - valid JSON",
+			corruptedOnCancel: true,
+			data:              []byte(`[{"key": "value"}]`),
+			wantErr:           false, // Valid JSON passes validation
+		},
+		{
+			name:              "corrupted - invalid JSON",
+			corruptedOnCancel: true,
+			data:              []byte(`[{"key": "value"`),
+			wantErr:           true,
+		},
+		{
+			name:              "corrupted - empty data",
+			corruptedOnCancel: true,
+			data:              []byte(``),
+			wantErr:           true,
+		},
+		{
+			name:              "corrupted - partial record",
+			corruptedOnCancel: true,
+			data:              []byte(`[{"key": "val`),
+			wantErr:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &jsonld.StreamResult{CorruptedOnCancel: tt.corruptedOnCancel}
+			err := result.ValidateOutputJSON(tt.data)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateOutputJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil {
+				if !errors.Is(err, jsonld.ErrOutputCorrupted) {
+					t.Errorf("ValidateOutputJSON() error = %v, want %v", err, jsonld.ErrOutputCorrupted)
+				}
+			}
+		})
+	}
+}
+
+func TestStreamResult_ValidateOutputJSON_Integration(t *testing.T) {
+	// Integration test: test the usage pattern from the issue description.
+	// Uses an unbuffered channel + signal writer to ensure deterministic ordering:
+	// 1. SerializeStream reads the record from the unbuffered channel
+	// 2. The record is written to output (signalWriter notifies)
+	// 3. Only THEN is context cancelled
+	// This eliminates the race between ctx.Done() and channel reads in the select.
+	serializer := jsonld.NewSerializer()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *pbc.FocusCostRecord) // unbuffered: send blocks until received
+	recordWritten := make(chan struct{})
+	sw := &signalWriter{signal: recordWritten}
+
+	type streamResult struct {
+		result *jsonld.StreamResult
+		err    error
+	}
+	done := make(chan streamResult, 1)
+
+	// Start serialization first so it's ready to receive from the channel
+	go func() {
+		result, err := serializer.SerializeStream(ctx, ch, sw)
+		done <- streamResult{result, err}
+	}()
+
+	// Send one record — blocks until SerializeStream reads it (unbuffered channel)
+	ch <- &pbc.FocusCostRecord{
+		BillingAccountId:  "123456789012",
+		ChargePeriodStart: &timestamppb.Timestamp{Seconds: 1735689600},
+		ServiceName:       "Amazon EC2",
+		BilledCost:        100.0,
+		BillingCurrency:   "USD",
+	}
+
+	// Wait until the record data has been written to output (RecordsWritten > 0 guaranteed)
+	<-recordWritten
+
+	// Cancel context after record is written — CorruptedOnCancel will be true
+	cancel()
+
+	// Wait for SerializeStream to return, then close the channel
+	sr := <-done
+	close(ch)
+
+	// Should return context.Canceled error
+	if !errors.Is(sr.err, context.Canceled) {
+		t.Fatalf("Expected context.Canceled error, got %v", sr.err)
+	}
+
+	// CorruptedOnCancel must be true since records were written before cancel
+	if !sr.result.CorruptedOnCancel {
+		t.Fatal("Expected CorruptedOnCancel to be true when records were written before cancel")
+	}
+
+	// Validate usage pattern from issue description
+	if valErr := sr.result.ValidateOutputJSON(sw.Bytes()); valErr != nil {
+		if !errors.Is(valErr, jsonld.ErrOutputCorrupted) {
+			t.Errorf("Expected ErrOutputCorrupted, got %v", valErr)
+		}
+		t.Logf("Output corrupted and invalid - would retry: %v", valErr)
+	} else {
+		t.Log("Output is valid despite cancellation")
+	}
+
+	// Assert that IsOutputValid() reports false for cancelled stream
+	if sr.result.IsOutputValid() {
+		t.Fatal("Expected IsOutputValid() to return false for cancelled stream, got true")
+	}
+}
+
+// signalWriter wraps bytes.Buffer and signals after the first record data is written.
+// The first Write is the opening bracket "[\n"; subsequent writes contain record data.
+type signalWriter struct {
+	bytes.Buffer
+
+	writes int
+	signal chan struct{}
+	once   sync.Once
+}
+
+func (w *signalWriter) Write(p []byte) (int, error) {
+	n, err := w.Buffer.Write(p)
+	w.writes++
+	// Signal after the first record data write (write #1 is "[\n", write #2+ is record data)
+	if w.writes > 1 {
+		w.once.Do(func() { close(w.signal) })
+	}
+	return n, err
+}


### PR DESCRIPTION
Add IsOutputValid() and ValidateOutputJSON() helper methods to StreamResult to simplify validation of potentially corrupted output after context cancellation.

- IsOutputValid() returns false if context cancellation may have corrupted the output
- ValidateOutputJSON(data []byte) validates JSON when CorruptedOnCancel is true
- Added comprehensive test coverage for both methods
- Updated README with usage examples and best practices

Fixes #344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added output validation and a corruption indicator to detect and handle potentially invalid streaming output after cancellation.

* **Documentation**
  * Expanded guidance on context cancellation, validation steps, and updated example usage to show the context-aware pattern.

* **Tests**
  * Added comprehensive tests covering cancellation, output validation, and streaming behavior.

* **Breaking Changes**
  * Public serialization API now requires a context parameter as the first argument.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->