### PR TITLE
refactor: deduplicate grpcCodeToInt32 into shared internal package

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ centered around the FinOps Foundation's FOCUS standard.
 - [ ] **Fix Unbounded Goroutine Creation in batchCostFallback**
   ([#398](https://github.com/rshade/finfocus-spec/issues/398)) [M] -
   Add goroutine pool bounds to prevent unbounded concurrency.
-- [ ] **Deduplicate grpcCodeToInt32**
+- [x] **Deduplicate grpcCodeToInt32**
   ([#399](https://github.com/rshade/finfocus-spec/issues/399)) [S] -
   Deduplicate grpcCodeToInt32 between pluginsdk and testing packages.
 - [x] **Improve ValidateBatchCostRequest Return Type**
@@ -83,7 +83,7 @@ centered around the FinOps Foundation's FOCUS standard.
 - [ ] **Resolve Concurrency TODO in BatchCost Tests**
   ([#403](https://github.com/rshade/finfocus-spec/issues/403)) [M] -
   Resolve TODO in TestBatchCostFallbackWorkerPoolConfig for concurrency assertions.
-- [ ] **Replace Magic Constant defaultInternalErrCode**
+- [x] **Replace Magic Constant defaultInternalErrCode**
   ([#404](https://github.com/rshade/finfocus-spec/issues/404)) [S] -
   Replace magic constant with `codes.Internal` from gRPC.
 - [ ] **Extract Helper from MockPlugin.BatchCost**

--- a/sdk/go/internal/grpcconv/grpcconv.go
+++ b/sdk/go/internal/grpcconv/grpcconv.go
@@ -1,0 +1,30 @@
+// Package grpcconv provides internal utilities for converting gRPC types.
+//
+// This package exists to break circular dependencies between sdk/go/pluginsdk and
+// sdk/go/testing. Both packages need gRPC code-to-int32 conversion logic, but
+// pluginsdk imports testing (via conformance.go), which would create a circular
+// import if testing imported pluginsdk directly.
+//
+// # Usage
+//
+// This is an internal package. External consumers should use:
+//   - [github.com/rshade/finfocus-spec/sdk/go/pluginsdk.NewResourceError]
+//   - [github.com/rshade/finfocus-spec/sdk/go/testing] (batchResourceErrorFromErr)
+package grpcconv
+
+import (
+	"math"
+
+	"google.golang.org/grpc/codes"
+)
+
+// CodeToInt32 converts a gRPC codes.Code to its int32 numeric value for use in protobuf fields.
+// If the code's numeric value is outside the int32 range, it returns the numeric value for codes.Internal.
+func CodeToInt32(code codes.Code) int32 {
+	codeValue := int64(code)
+	if codeValue > math.MaxInt32 {
+		return int32(codes.Internal)
+	}
+	//nolint:gosec // Overflow impossible: codeValue is in [0, math.MaxInt32] after the bounds check above.
+	return int32(codeValue)
+}

--- a/sdk/go/internal/grpcconv/grpcconv_test.go
+++ b/sdk/go/internal/grpcconv/grpcconv_test.go
@@ -1,0 +1,81 @@
+package grpcconv_test
+
+import (
+	"math"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+
+	"github.com/rshade/finfocus-spec/sdk/go/internal/grpcconv"
+)
+
+func TestCodeToInt32(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     codes.Code
+		expected int32
+	}{
+		{
+			name:     "OK code (0)",
+			code:     codes.OK,
+			expected: 0,
+		},
+		{
+			name:     "NotFound code (5)",
+			code:     codes.NotFound,
+			expected: 5,
+		},
+		{
+			name:     "Internal code (13)",
+			code:     codes.Internal,
+			expected: 13,
+		},
+		{
+			name:     "Unauthenticated code (16)",
+			code:     codes.Unauthenticated,
+			expected: 16,
+		},
+		{
+			name:     "Max valid int32 code",
+			code:     codes.Code(math.MaxInt32),
+			expected: math.MaxInt32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := grpcconv.CodeToInt32(tt.code)
+			if result != tt.expected {
+				t.Errorf("CodeToInt32(%v) = %v, want %v", tt.code, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCodeToInt32_Overflow(t *testing.T) {
+	tests := []struct {
+		name string
+		code codes.Code
+	}{
+		{"MaxInt32+1", codes.Code(math.MaxInt32 + 1)},
+		{"MaxUint32", codes.Code(math.MaxUint32)},
+	}
+	expected := int32(codes.Internal)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := grpcconv.CodeToInt32(tt.code)
+			if result != expected {
+				t.Errorf("CodeToInt32(%v) = %v, want %v (codes.Internal)", tt.code, result, expected)
+			}
+		})
+	}
+}
+
+// BenchmarkCodeToInt32 measures the performance of the conversion function.
+func BenchmarkCodeToInt32(b *testing.B) {
+	b.ReportAllocs()
+	code := codes.NotFound
+	for range b.N {
+		_ = grpcconv.CodeToInt32(code)
+	}
+}

--- a/sdk/go/pluginsdk/batch.go
+++ b/sdk/go/pluginsdk/batch.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/rshade/finfocus-spec/sdk/go/internal/grpcconv"
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
@@ -363,21 +363,10 @@ func NewResourceError(code codes.Code, message string, resourceTypeUnsupported b
 		message = code.String()
 	}
 	return &pbc.ResourceError{
-		Code:                    grpcCodeToInt32(code),
+		Code:                    grpcconv.CodeToInt32(code),
 		Message:                 message,
 		ResourceTypeUnsupported: resourceTypeUnsupported,
 	}
-}
-
-// grpcCodeToInt32 converts a gRPC codes.Code to its int32 numeric value for use in protobuf fields.
-// If the code's numeric value is outside the int32 range, it returns the numeric value for codes.Internal.
-func grpcCodeToInt32(code codes.Code) int32 {
-	codeValue := int64(code)
-	if codeValue > math.MaxInt32 {
-		return int32(codes.Internal)
-	}
-	//nolint:gosec // Overflow impossible: codeValue is in [0, math.MaxInt32] after the bounds check above.
-	return int32(codeValue)
 }
 
 // resourceErrorFromGRPCError converts a Go error into a ResourceError.

--- a/sdk/go/testing/mock_plugin.go
+++ b/sdk/go/testing/mock_plugin.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/rshade/finfocus-spec/sdk/go/internal/grpcconv"
 	"github.com/rshade/finfocus-spec/sdk/go/internal/utilization"
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
@@ -66,11 +67,10 @@ const (
 
 	// Mock impact metric base values at 100% utilization.
 	// These are arbitrary values for testing purposes only.
-	mockCarbonPerHour       = 100.0 // gCO2e per hour at 100% utilization
-	mockEnergyPerHour       = 1.0   // kWh per hour at 100% utilization
-	mockWaterPerHour        = 5.0   // L per hour at 100% utilization
-	defaultMockBatchSize    = 100
-	fallbackInternalErrCode = int32(codes.Internal) // Fallback error code for overflow cases
+	mockCarbonPerHour    = 100.0 // gCO2e per hour at 100% utilization
+	mockEnergyPerHour    = 1.0   // kWh per hour at 100% utilization
+	mockWaterPerHour     = 5.0   // L per hour at 100% utilization
+	defaultMockBatchSize = 100
 )
 
 // MockPlugin provides a configurable mock implementation of CostSourceServiceServer.
@@ -532,7 +532,7 @@ func (m *MockPlugin) BatchCost(
 				Resource: nil,
 				Result: &pbc.ResourceCostResult_Error{
 					Error: &pbc.ResourceError{
-						Code:    batchGRPCCodeToInt32(codes.InvalidArgument),
+						Code:    grpcconv.CodeToInt32(codes.InvalidArgument),
 						Message: "resource descriptor is required",
 					},
 				},
@@ -543,7 +543,7 @@ func (m *MockPlugin) BatchCost(
 				Resource: resource,
 				Result: &pbc.ResourceCostResult_Error{
 					Error: &pbc.ResourceError{
-						Code: batchGRPCCodeToInt32(codes.Unimplemented),
+						Code: grpcconv.CodeToInt32(codes.Unimplemented),
 						Message: fmt.Sprintf(
 							"resource type %q is not supported",
 							resource.GetResourceType(),
@@ -696,7 +696,7 @@ func (m *MockPlugin) BatchCost(
 				Resource: resource,
 				Result: &pbc.ResourceCostResult_Error{
 					Error: &pbc.ResourceError{
-						Code:    batchGRPCCodeToInt32(codes.InvalidArgument),
+						Code:    grpcconv.CodeToInt32(codes.InvalidArgument),
 						Message: "invalid query type",
 					},
 				},
@@ -744,31 +744,20 @@ func defaultBatchResourceID(resource *pbc.ResourceDescriptor) string {
 
 // batchResourceErrorFromErr converts an error into a pbc.ResourceError suitable for batch responses.
 // If the error is a gRPC status error its code and message are used; otherwise the error is reported
-// with an Internal code and the error string. The gRPC code is mapped to int32 via batchGRPCCodeToInt32.
+// with an Internal code and the error string. The gRPC code is mapped to int32 via grpcconv.CodeToInt32.
 func batchResourceErrorFromErr(err error) *pbc.ResourceError {
 	st, ok := status.FromError(err)
 	if !ok {
 		return &pbc.ResourceError{
-			Code:    batchGRPCCodeToInt32(codes.Internal),
+			Code:    grpcconv.CodeToInt32(codes.Internal),
 			Message: err.Error(),
 		}
 	}
 
 	return &pbc.ResourceError{
-		Code:    batchGRPCCodeToInt32(st.Code()),
+		Code:    grpcconv.CodeToInt32(st.Code()),
 		Message: st.Message(),
 	}
-}
-
-// batchGRPCCodeToInt32 converts a gRPC `codes.Code` value (uint32) to an `int32` suitable for protobuf fields.
-// If the code exceeds `math.MaxInt32`, `fallbackInternalErrCode` is returned to avoid overflow.
-func batchGRPCCodeToInt32(code codes.Code) int32 {
-	codeValue := int64(code)
-	if codeValue > math.MaxInt32 {
-		return fallbackInternalErrCode
-	}
-	//nolint:gosec // Overflow impossible: codeValue is in [0, math.MaxInt32] after the bounds check above.
-	return int32(codeValue)
 }
 
 // generateDefaultFieldMappings creates default field mappings for all FOCUS fields.


### PR DESCRIPTION
Create sdk/go/internal/grpcconv package to eliminate DRY violation between pluginsdk and testing packages. Both packages now use the shared grpcconv.CodeToInt32() function for overflow-safe gRPC code conversion to int32.

Changes:
- Add sdk/go/internal/grpcconv package with CodeToInt32() function
- Add comprehensive tests for grpcconv package
- Update pluginsdk/batch.go to use grpcconv.CodeToInt32()
- Update testing/mock_plugin.go to use grpcconv.CodeToInt32()
- Remove grpcCodeToInt32() from pluginsdk/batch.go
- Remove batchGRPCCodeToInt32() from testing/mock_plugin.go
- Remove defaultInternalErrCode constant from testing/mock_plugin.go

This resolves the import cycle issue between pluginsdk and testing packages while maintaining consistent behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked roadmap items as completed: "Deduplicate grpcCodeToInt32" and "Replace Magic Constant defaultInternalErrCode."

* **Chores**
  * Internal refactoring to consolidate gRPC code conversion utilities into a centralized module.

* **Tests**
  * Added comprehensive unit tests and benchmarks for gRPC code conversion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->