### PR TITLE
docs(proto): enforce page_token opacity with explicit warnings

### DIFF
--- a/proto/finfocus/v1/costsource.proto
+++ b/proto/finfocus/v1/costsource.proto
@@ -256,6 +256,11 @@ message GetActualCostRequest {
   // page_token is the continuation token from a previous GetActualCost response.
   // Empty string requests the first page of results.
   // Ignored when dry_run is true.
+  //
+  // IMPORTANT: page_token is an OPAQUE value. Clients MUST NOT parse, validate,
+  // or construct page tokens manually. The token format is an implementation
+  // detail subject to change without notice. Always pass tokens back verbatim
+  // as received from next_page_token in the response.
   string page_token = 8;
 }
 
@@ -272,6 +277,11 @@ message GetActualCostResponse {
   // next_page_token is the token for retrieving the next page of results.
   // Non-empty when additional pages are available. Empty when this is the
   // last page or when all results fit in a single response.
+  //
+  // IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+  // validate, or construct page tokens manually. The token format is an
+  // implementation detail subject to change without notice. Always pass this
+  // token back verbatim as page_token in the next GetActualCost request.
   string next_page_token = 4;
   // total_count is the total number of matching cost records across all pages.
   // Optional: may be 0 if the total is expensive to compute.
@@ -1169,7 +1179,12 @@ message GetRecommendationsRequest {
   string projection_period = 2;
   // page_size is the maximum number of recommendations to return (default: 50, max: 1000)
   int32 page_size = 3;
-  // page_token is the continuation token from a previous response
+  // page_token is the continuation token from a previous response.
+  //
+  // IMPORTANT: page_token is an OPAQUE value. Clients MUST NOT parse, validate,
+  // or construct page tokens manually. The token format is an implementation
+  // detail subject to change without notice. Always pass tokens back verbatim
+  // as received from next_page_token in the response.
   string page_token = 4;
   // excluded_recommendation_ids contains IDs of recommendations to exclude from results.
   // Use this to filter out recommendations that have been dismissed by users.
@@ -1221,7 +1236,12 @@ message GetRecommendationsResponse {
   // in this response page (not across all pages). Clients should aggregate
   // summaries across pages if global totals are needed.
   RecommendationSummary summary = 2;
-  // next_page_token is the token for retrieving the next page (empty if last)
+  // next_page_token is the token for retrieving the next page (empty if last).
+  //
+  // IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+  // validate, or construct page tokens manually. The token format is an
+  // implementation detail subject to change without notice. Always pass this
+  // token back verbatim as page_token in the next GetRecommendations request.
   string next_page_token = 3;
 }
 
@@ -1757,6 +1777,10 @@ message ActualCostData {
 
   // pagination token for retrieving additional results for this resource.
   // If empty, all results for this resource have been returned.
+  //
+  // IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+  // validate, or construct page tokens manually. The token format is an
+  // implementation detail subject to change without notice.
   //
   // Pagination continuation workflow:
   //   BatchCostRequest does not accept page tokens, so when this field is

--- a/sdk/go/proto/finfocus/v1/costsource.pb.go
+++ b/sdk/go/proto/finfocus/v1/costsource.pb.go
@@ -1158,6 +1158,11 @@ type GetActualCostRequest struct {
 	// page_token is the continuation token from a previous GetActualCost response.
 	// Empty string requests the first page of results.
 	// Ignored when dry_run is true.
+	//
+	// IMPORTANT: page_token is an OPAQUE value. Clients MUST NOT parse, validate,
+	// or construct page tokens manually. The token format is an implementation
+	// detail subject to change without notice. Always pass tokens back verbatim
+	// as received from next_page_token in the response.
 	PageToken     string `protobuf:"bytes,8,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1263,6 +1268,11 @@ type GetActualCostResponse struct {
 	// next_page_token is the token for retrieving the next page of results.
 	// Non-empty when additional pages are available. Empty when this is the
 	// last page or when all results fit in a single response.
+	//
+	// IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+	// validate, or construct page tokens manually. The token format is an
+	// implementation detail subject to change without notice. Always pass this
+	// token back verbatim as page_token in the next GetActualCost request.
 	NextPageToken string `protobuf:"bytes,4,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	// total_count is the total number of matching cost records across all pages.
 	// Optional: may be 0 if the total is expensive to compute.
@@ -3692,7 +3702,12 @@ type GetRecommendationsRequest struct {
 	ProjectionPeriod string `protobuf:"bytes,2,opt,name=projection_period,json=projectionPeriod,proto3" json:"projection_period,omitempty"`
 	// page_size is the maximum number of recommendations to return (default: 50, max: 1000)
 	PageSize int32 `protobuf:"varint,3,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
-	// page_token is the continuation token from a previous response
+	// page_token is the continuation token from a previous response.
+	//
+	// IMPORTANT: page_token is an OPAQUE value. Clients MUST NOT parse, validate,
+	// or construct page tokens manually. The token format is an implementation
+	// detail subject to change without notice. Always pass tokens back verbatim
+	// as received from next_page_token in the response.
 	PageToken string `protobuf:"bytes,4,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	// excluded_recommendation_ids contains IDs of recommendations to exclude from results.
 	// Use this to filter out recommendations that have been dismissed by users.
@@ -3824,7 +3839,12 @@ type GetRecommendationsResponse struct {
 	// in this response page (not across all pages). Clients should aggregate
 	// summaries across pages if global totals are needed.
 	Summary *RecommendationSummary `protobuf:"bytes,2,opt,name=summary,proto3" json:"summary,omitempty"`
-	// next_page_token is the token for retrieving the next page (empty if last)
+	// next_page_token is the token for retrieving the next page (empty if last).
+	//
+	// IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+	// validate, or construct page tokens manually. The token format is an
+	// implementation detail subject to change without notice. Always pass this
+	// token back verbatim as page_token in the next GetRecommendations request.
 	NextPageToken string `protobuf:"bytes,3,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -6143,6 +6163,10 @@ type ActualCostData struct {
 	FallbackHint FallbackHint `protobuf:"varint,2,opt,name=fallback_hint,json=fallbackHint,proto3,enum=finfocus.v1.FallbackHint" json:"fallback_hint,omitempty"`
 	// pagination token for retrieving additional results for this resource.
 	// If empty, all results for this resource have been returned.
+	//
+	// IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+	// validate, or construct page tokens manually. The token format is an
+	// implementation detail subject to change without notice.
 	//
 	// Pagination continuation workflow:
 	//

--- a/sdk/typescript/packages/client/src/generated/finfocus/v1/costsource_pb.ts
+++ b/sdk/typescript/packages/client/src/generated/finfocus/v1/costsource_pb.ts
@@ -236,6 +236,11 @@ export type GetActualCostRequest = Message<"finfocus.v1.GetActualCostRequest"> &
    * Empty string requests the first page of results.
    * Ignored when dry_run is true.
    *
+   * IMPORTANT: page_token is an OPAQUE value. Clients MUST NOT parse, validate,
+   * or construct page tokens manually. The token format is an implementation
+   * detail subject to change without notice. Always pass tokens back verbatim
+   * as received from next_page_token in the response.
+   *
    * @generated from field: string page_token = 8;
    */
   pageToken: string;
@@ -281,6 +286,11 @@ export type GetActualCostResponse = Message<"finfocus.v1.GetActualCostResponse">
    * next_page_token is the token for retrieving the next page of results.
    * Non-empty when additional pages are available. Empty when this is the
    * last page or when all results fit in a single response.
+   *
+   * IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+   * validate, or construct page tokens manually. The token format is an
+   * implementation detail subject to change without notice. Always pass this
+   * token back verbatim as page_token in the next GetActualCost request.
    *
    * @generated from field: string next_page_token = 4;
    */
@@ -1888,7 +1898,12 @@ export type GetRecommendationsRequest = Message<"finfocus.v1.GetRecommendationsR
   pageSize: number;
 
   /**
-   * page_token is the continuation token from a previous response
+   * page_token is the continuation token from a previous response.
+   *
+   * IMPORTANT: page_token is an OPAQUE value. Clients MUST NOT parse, validate,
+   * or construct page tokens manually. The token format is an implementation
+   * detail subject to change without notice. Always pass tokens back verbatim
+   * as received from next_page_token in the response.
    *
    * @generated from field: string page_token = 4;
    */
@@ -1978,7 +1993,12 @@ export type GetRecommendationsResponse = Message<"finfocus.v1.GetRecommendations
   summary?: RecommendationSummary;
 
   /**
-   * next_page_token is the token for retrieving the next page (empty if last)
+   * next_page_token is the token for retrieving the next page (empty if last).
+   *
+   * IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+   * validate, or construct page tokens manually. The token format is an
+   * implementation detail subject to change without notice. Always pass this
+   * token back verbatim as page_token in the next GetRecommendations request.
    *
    * @generated from field: string next_page_token = 3;
    */
@@ -3367,6 +3387,10 @@ export type ActualCostData = Message<"finfocus.v1.ActualCostData"> & {
   /**
    * pagination token for retrieving additional results for this resource.
    * If empty, all results for this resource have been returned.
+   *
+   * IMPORTANT: next_page_token is an OPAQUE value. Clients MUST NOT parse,
+   * validate, or construct page tokens manually. The token format is an
+   * implementation detail subject to change without notice.
    *
    * Pagination continuation workflow:
    *   BatchCostRequest does not accept page tokens, so when this field is


### PR DESCRIPTION
Add explicit proto documentation warning that page_token and next_page_token are opaque values that clients MUST NOT parse, validate, or construct manually.

Updated all pagination token fields in:
- GetActualCostRequest.page_token
- GetActualCostResponse.next_page_token
- GetRecommendationsRequest.page_token
- GetRecommendationsResponse.next_page_token
- ActualCostData.next_page_token

Token format is an implementation detail subject to change without notice. Clients must always pass tokens verbatim as received from responses.

Fixes #363