### PR TITLE
feat(pluginsdk): warn when total_count changes mid-iteration

### DIFF
--- a/sdk/go/pluginsdk/actual_cost_iterator.go
+++ b/sdk/go/pluginsdk/actual_cost_iterator.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rs/zerolog"
+
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
 )
 
@@ -26,9 +28,24 @@ import (
 // It is called by ActualCostIterator to retrieve each page of data.
 type ActualCostFetchFunc func(ctx context.Context, pageToken string, pageSize int32) (*pbc.GetActualCostResponse, error)
 
+// ActualCostIteratorOption is a functional option for configuring ActualCostIterator.
+type ActualCostIteratorOption func(*ActualCostIterator)
+
+// WithLogger sets a custom logger for the iterator. When not set, the iterator
+// uses the default pluginsdk logger. Use zerolog.Nop() in tests to suppress output.
+func WithLogger(logger zerolog.Logger) ActualCostIteratorOption {
+	return func(it *ActualCostIterator) {
+		it.logger = &logger
+	}
+}
+
 // ActualCostIterator provides a standard Go iterator pattern (Next/Record/Err)
 // for consuming paginated GetActualCost responses. It lazily fetches pages
 // on demand and yields one ActualCostResult at a time.
+//
+// If total_count changes between pages (indicating a dataset mutation mid-iteration),
+// the iterator logs a warning at Warn level. The warning includes previous_total_count,
+// new_total_count, and page_number fields for diagnostics.
 //
 // # Concurrency Safety
 //
@@ -76,6 +93,8 @@ type ActualCostIterator struct {
 	totalCount int32
 	done       bool
 	err        error
+	logger     *zerolog.Logger
+	pageNumber int
 }
 
 // NewActualCostIterator creates a new iterator for consuming paginated actual cost responses.
@@ -84,17 +103,23 @@ type ActualCostIterator struct {
 //   - ctx: Context for cancellation and deadline propagation
 //   - fetchFn: Callback function that makes the GetActualCost RPC call
 //   - pageSize: Number of records to request per page (0 uses server default)
+//   - opts: Optional configuration (e.g., WithLogger)
 func NewActualCostIterator(
 	ctx context.Context,
 	fetchFn ActualCostFetchFunc,
 	pageSize int32,
+	opts ...ActualCostIteratorOption,
 ) *ActualCostIterator {
-	return &ActualCostIterator{
+	it := &ActualCostIterator{
 		ctx:      ctx,
 		fetchFn:  fetchFn,
 		pageSize: pageSize,
 		index:    -1,
 	}
+	for _, o := range opts {
+		o(it)
+	}
+	return it
 }
 
 // maxEmptyPages is the maximum number of consecutive empty pages the iterator
@@ -164,8 +189,25 @@ func (it *ActualCostIterator) Next() bool {
 
 		it.current = resp.GetResults()
 		it.pageToken = resp.GetNextPageToken()
-		it.totalCount = resp.GetTotalCount()
+		newTotalCount := resp.GetTotalCount()
 		it.index = 0
+		it.pageNumber++
+
+		// Track total_count changes across pages (skip first page)
+		if it.pageNumber > 1 && newTotalCount != it.totalCount {
+			// Subsequent page with different total_count: log warning
+			if it.logger == nil {
+				l := newDefaultLogger()
+				it.logger = &l
+			}
+			it.logger.Warn().
+				Int32("previous_total_count", it.totalCount).
+				Int32("new_total_count", newTotalCount).
+				Int("page_number", it.pageNumber).
+				Msg("total_count changed during pagination, underlying dataset may have changed")
+		}
+
+		it.totalCount = newTotalCount
 
 		if len(it.current) > 0 {
 			return true

--- a/sdk/go/pluginsdk/actual_cost_iterator_test.go
+++ b/sdk/go/pluginsdk/actual_cost_iterator_test.go
@@ -15,11 +15,14 @@
 package pluginsdk_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"math"
 	"testing"
+
+	"github.com/rs/zerolog"
 
 	"github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
@@ -318,7 +321,8 @@ func TestActualCostIterator_InconsistentTotalCount(t *testing.T) {
 		}, nil
 	}
 
-	iter := pluginsdk.NewActualCostIterator(context.Background(), fetchFn, 10)
+	nop := zerolog.Nop()
+	iter := pluginsdk.NewActualCostIterator(context.Background(), fetchFn, 10, pluginsdk.WithLogger(nop))
 
 	var collected []*pbc.ActualCostResult
 	for iter.Next() {
@@ -397,5 +401,235 @@ func BenchmarkActualCostIterator_Next(b *testing.B) {
 		if err := iter.Err(); err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}
+	}
+}
+
+// TestActualCostIterator_ConsistentTotalCount_NoWarning verifies that when
+// total_count is consistent across all pages, no warning is logged.
+func TestActualCostIterator_ConsistentTotalCount_NoWarning(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := zerolog.New(&logBuf).With().Timestamp().Logger()
+
+	// Create fetch function that returns consistent total_count=30 across all pages
+	callCount := 0
+	fetchFn := func(_ context.Context, _ string, _ int32) (*pbc.GetActualCostResponse, error) {
+		callCount++
+		results := make([]*pbc.ActualCostResult, 10)
+		for i := range results {
+			results[i] = &pbc.ActualCostResult{
+				Cost:   float64((callCount-1)*10 + i + 1),
+				Source: "test",
+			}
+		}
+
+		nextToken := ""
+		if callCount < 3 {
+			nextToken = fmt.Sprintf("page-%d", callCount)
+		}
+
+		return &pbc.GetActualCostResponse{
+			Results:       results,
+			NextPageToken: nextToken,
+			TotalCount:    30, // Consistent across all pages
+		}, nil
+	}
+
+	iter := pluginsdk.NewActualCostIterator(context.Background(), fetchFn, 10, pluginsdk.WithLogger(logger))
+
+	var collected []*pbc.ActualCostResult
+	for iter.Next() {
+		collected = append(collected, iter.Record())
+	}
+
+	if iter.Err() != nil {
+		t.Fatalf("unexpected error: %v", iter.Err())
+	}
+	if len(collected) != 30 {
+		t.Errorf("expected 30 records, got %d", len(collected))
+	}
+
+	// Verify no warning was logged
+	logOutput := logBuf.String()
+	if bytes.Contains(logBuf.Bytes(), []byte("total_count changed")) {
+		t.Errorf("expected no warning for consistent total_count, but got: %s", logOutput)
+	}
+	if bytes.Contains(logBuf.Bytes(), []byte(`"level":"warn"`)) {
+		t.Errorf("expected no warning logs, but found warning in output: %s", logOutput)
+	}
+}
+
+// TestActualCostIterator_InconsistentTotalCount_LogsWarning verifies that when
+// total_count changes between pages, a warning is logged with context.
+func TestActualCostIterator_InconsistentTotalCount_LogsWarning(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := zerolog.New(&logBuf).With().Timestamp().Logger()
+
+	callCount := 0
+	fetchFn := func(_ context.Context, _ string, _ int32) (*pbc.GetActualCostResponse, error) {
+		callCount++
+		// Return changing TotalCount on each page: 100, 90, 80
+		totalCounts := []int32{100, 90, 80}
+		tc := totalCounts[0]
+		if callCount <= len(totalCounts) {
+			tc = totalCounts[callCount-1]
+		}
+
+		results := make([]*pbc.ActualCostResult, 10)
+		for i := range results {
+			results[i] = &pbc.ActualCostResult{
+				Cost:   float64((callCount-1)*10 + i + 1),
+				Source: "test",
+			}
+		}
+
+		nextToken := ""
+		if callCount < 3 {
+			nextToken = fmt.Sprintf("page-%d", callCount)
+		}
+
+		return &pbc.GetActualCostResponse{
+			Results:       results,
+			NextPageToken: nextToken,
+			TotalCount:    tc,
+		}, nil
+	}
+
+	iter := pluginsdk.NewActualCostIterator(context.Background(), fetchFn, 10, pluginsdk.WithLogger(logger))
+
+	var collected []*pbc.ActualCostResult
+	for iter.Next() {
+		collected = append(collected, iter.Record())
+	}
+
+	if iter.Err() != nil {
+		t.Fatalf("unexpected error: %v", iter.Err())
+	}
+	if len(collected) != 30 {
+		t.Errorf("expected 30 records, got %d", len(collected))
+	}
+
+	// Verify warning was logged
+	logOutput := logBuf.String()
+	if !bytes.Contains(logBuf.Bytes(), []byte("total_count changed")) {
+		t.Errorf("expected warning about total_count change, but got: %s", logOutput)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"level":"warn"`)) {
+		t.Errorf("expected warning level log, but got: %s", logOutput)
+	}
+
+	// Verify first transition (100→90): page 2 detects change from page 1
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"previous_total_count":100`)) {
+		t.Errorf("expected previous_total_count=100 in first warning, but got: %s", logOutput)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"new_total_count":90`)) {
+		t.Errorf("expected new_total_count=90 in first warning, but got: %s", logOutput)
+	}
+
+	// Verify second transition (90→80): page 3 detects change from page 2
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"previous_total_count":90`)) {
+		t.Errorf("expected previous_total_count=90 in second warning, but got: %s", logOutput)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"new_total_count":80`)) {
+		t.Errorf("expected new_total_count=80 in second warning, but got: %s", logOutput)
+	}
+
+	if !bytes.Contains(logBuf.Bytes(), []byte("underlying dataset may have changed")) {
+		t.Errorf("expected warning message about dataset change, but got: %s", logOutput)
+	}
+
+	// Verify page_number fields in warnings (page 2 detects first change, page 3 detects second)
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"page_number":2`)) {
+		t.Errorf("expected page_number=2 in first warning, but got: %s", logOutput)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"page_number":3`)) {
+		t.Errorf("expected page_number=3 in second warning, but got: %s", logOutput)
+	}
+
+	// Verify TotalCount() still returns the most recent value
+	if iter.TotalCount() != 80 {
+		t.Errorf("expected TotalCount=80 (most recent), got %d", iter.TotalCount())
+	}
+}
+
+// TestActualCostIterator_UnpopulatedThenPopulatedTotalCount documents the behavior when
+// a server returns total_count=0 (proto3 zero value / unset) on page 1 and then returns
+// a real count on subsequent pages. The iterator treats 0 as a valid total_count value,
+// so the transition from 0→N triggers a warning. This is the expected behavior because
+// the iterator cannot distinguish between "server doesn't support total_count" (always 0)
+// and "server forgot to set it on page 1" — both cases warrant a diagnostic warning.
+func TestActualCostIterator_UnpopulatedThenPopulatedTotalCount(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := zerolog.New(&logBuf).With().Timestamp().Logger()
+
+	callCount := 0
+	fetchFn := func(_ context.Context, _ string, _ int32) (*pbc.GetActualCostResponse, error) {
+		callCount++
+		results := make([]*pbc.ActualCostResult, 5)
+		for i := range results {
+			results[i] = &pbc.ActualCostResult{
+				Cost:   float64((callCount-1)*5 + i + 1),
+				Source: "test",
+			}
+		}
+
+		nextToken := ""
+		if callCount < 3 {
+			nextToken = fmt.Sprintf("page-%d", callCount)
+		}
+
+		// Page 1: total_count=0 (unset/zero value)
+		// Page 2: total_count=15 (server starts reporting)
+		// Page 3: total_count=15 (consistent)
+		tc := int32(0)
+		if callCount >= 2 {
+			tc = 15
+		}
+
+		return &pbc.GetActualCostResponse{
+			Results:       results,
+			NextPageToken: nextToken,
+			TotalCount:    tc,
+		}, nil
+	}
+
+	iter := pluginsdk.NewActualCostIterator(context.Background(), fetchFn, 5, pluginsdk.WithLogger(logger))
+
+	var collected []*pbc.ActualCostResult
+	for iter.Next() {
+		collected = append(collected, iter.Record())
+	}
+
+	if iter.Err() != nil {
+		t.Fatalf("unexpected error: %v", iter.Err())
+	}
+	if len(collected) != 15 {
+		t.Errorf("expected 15 records, got %d", len(collected))
+	}
+
+	// The 0→15 transition on page 2 SHOULD trigger a warning.
+	// This documents that the iterator cannot distinguish "unset" from "actually zero".
+	logOutput := logBuf.String()
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"level":"warn"`)) {
+		t.Errorf("expected warning for 0→15 total_count transition, but got: %s", logOutput)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"previous_total_count":0`)) {
+		t.Errorf("expected previous_total_count=0, but got: %s", logOutput)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"new_total_count":15`)) {
+		t.Errorf("expected new_total_count=15, but got: %s", logOutput)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`"page_number":2`)) {
+		t.Errorf("expected page_number=2 for the transition, but got: %s", logOutput)
+	}
+
+	// Page 2→3 should NOT trigger a second warning (15→15 is consistent)
+	warnCount := bytes.Count(logBuf.Bytes(), []byte("total_count changed"))
+	if warnCount != 1 {
+		t.Errorf("expected exactly 1 warning (0→15 only), got %d warnings: %s", warnCount, logOutput)
+	}
+
+	// TotalCount should reflect the most recent value
+	if iter.TotalCount() != 15 {
+		t.Errorf("expected TotalCount=15, got %d", iter.TotalCount())
 	}
 }


### PR DESCRIPTION
Adds zerolog warning when total_count changes between pages during ActualCostIterator pagination, indicating underlying dataset changes.

- Tracks initial total_count from first page
- Compares subsequent pages and logs warning with context
- Includes previous/new count and page number in warning
- Adds SetLoggerForTesting() for test verification
- Adds comprehensive tests for consistent and inconsistent counts

Fixes #365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination now detects when the reported total item count changes between pages and emits warnings to improve visibility into inconsistent results.

* **New Features**
  * Iterator can be configured with a custom logger and now tracks page numbers to support clearer diagnostics.

* **Tests**
  * Added tests covering consistent and inconsistent total-count scenarios and verifying warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->