### PR TITLE
feat(pluginsdk): add ResourceDescriptor field validation limits

### DIFF
--- a/sdk/go/pluginsdk/batch.go
+++ b/sdk/go/pluginsdk/batch.go
@@ -43,6 +43,11 @@ const (
 	MaxBatchWorkers = 50
 )
 
+// DoS-guard limits for ResourceDescriptor field validation.
+// These are intentionally more generous than the contract validation limits
+// in testing/contract.go (e.g., MaxTagCount=50, MaxResourceIDLength=512),
+// which enforce stricter bounds for well-formed data. These limits only
+// prevent unbounded allocations from malicious or malformed input.
 const (
 	// MaxTagsPerResource is the maximum number of tags allowed per ResourceDescriptor.
 	MaxTagsPerResource = 256
@@ -107,75 +112,88 @@ func NormalizeCostQueryType(queryType pbc.CostQueryType) pbc.CostQueryType {
 }
 
 // ValidateResourceDescriptor validates individual ResourceDescriptor fields against defined limits.
-// It checks string field lengths and tag map constraints to prevent denial-of-service scenarios.
+// It checks string field lengths and tag map constraints to prevent denial-of-service scenarios
+// from unbounded allocations during batch processing.
+//
+// This function validates field sizes for DoS prevention only. Semantic validation of field
+// values (e.g., recognized provider names, valid ARN formats) is the plugin's responsibility.
+// These limits are intentionally more generous than the contract validation limits in the
+// testing package (testing/contract.go), which enforce stricter bounds for well-formed data.
 //
 // Validation rules:
-// - provider must not exceed MaxProviderLength (32 characters)
-// - resource_type must not exceed MaxResourceTypeLength (256 characters)
-// - id must not exceed MaxIDLength (1024 characters)
-// - arn must not exceed MaxARNLength (2048 characters)
-// - sku must not exceed MaxSKULength (128 characters)
-// - region must not exceed MaxRegionLength (64 characters)
-// - tags map must not exceed MaxTagsPerResource (256 entries)
-// - tag keys must not exceed MaxTagKeyLength (128 characters)
-// - tag values must not exceed MaxTagValueLength (256 characters)
+//   - resource must not be nil
+//   - provider must not exceed MaxProviderLength (32 characters)
+//   - resource_type must not exceed MaxResourceTypeLength (256 characters)
+//   - id must not exceed MaxIDLength (1024 characters)
+//   - arn must not exceed MaxARNLength (2048 characters)
+//   - sku must not exceed MaxSKULength (128 characters)
+//   - region must not exceed MaxRegionLength (64 characters)
+//   - tags map must not exceed MaxTagsPerResource (256 entries)
+//   - tag keys must not exceed MaxTagKeyLength (128 characters)
+//   - tag values must not exceed MaxTagValueLength (256 characters)
 //
 // Returns nil if validation passes, or a gRPC InvalidArgument error describing the violation.
 func ValidateResourceDescriptor(resource *pbc.ResourceDescriptor) error {
 	if resource == nil {
-		return nil
+		return status.Error(codes.InvalidArgument, "resource descriptor must not be nil")
 	}
 
-	if len(resource.GetProvider()) > MaxProviderLength {
+	provider := resource.GetProvider()
+	if len(provider) > MaxProviderLength {
 		return status.Errorf(
 			codes.InvalidArgument,
 			"provider length %d exceeds maximum %d",
-			len(resource.GetProvider()),
+			len(provider),
 			MaxProviderLength,
 		)
 	}
 
-	if len(resource.GetResourceType()) > MaxResourceTypeLength {
+	resourceType := resource.GetResourceType()
+	if len(resourceType) > MaxResourceTypeLength {
 		return status.Errorf(
 			codes.InvalidArgument,
 			"resource_type length %d exceeds maximum %d",
-			len(resource.GetResourceType()),
+			len(resourceType),
 			MaxResourceTypeLength,
 		)
 	}
 
-	if len(resource.GetId()) > MaxIDLength {
+	id := resource.GetId()
+	if len(id) > MaxIDLength {
 		return status.Errorf(
 			codes.InvalidArgument,
 			"id length %d exceeds maximum %d",
-			len(resource.GetId()),
+			len(id),
 			MaxIDLength,
 		)
 	}
 
-	if len(resource.GetArn()) > MaxARNLength {
+	arn := resource.GetArn()
+	if len(arn) > MaxARNLength {
 		return status.Errorf(
 			codes.InvalidArgument,
 			"arn length %d exceeds maximum %d",
-			len(resource.GetArn()),
+			len(arn),
 			MaxARNLength,
 		)
 	}
 
-	if len(resource.GetSku()) > MaxSKULength {
+	sku := resource.GetSku()
+	if len(sku) > MaxSKULength {
 		return status.Errorf(
 			codes.InvalidArgument,
 			"sku length %d exceeds maximum %d",
-			len(resource.GetSku()),
+			len(sku),
 			MaxSKULength,
 		)
 	}
 
-	if len(resource.GetRegion()) > MaxRegionLength {
+	region := resource.GetRegion()
+	if len(region) > MaxRegionLength {
 		return status.Errorf(
 			codes.InvalidArgument,
 			"region length %d exceeds maximum %d",
-			len(resource.GetRegion()),
+			len(region),
 			MaxRegionLength,
 		)
 	}
@@ -194,7 +212,8 @@ func ValidateResourceDescriptor(resource *pbc.ResourceDescriptor) error {
 		if len(key) > MaxTagKeyLength {
 			return status.Errorf(
 				codes.InvalidArgument,
-				"tag key length %d exceeds maximum %d",
+				"tag key %q: length %d exceeds maximum %d",
+				key,
 				len(key),
 				MaxTagKeyLength,
 			)
@@ -202,7 +221,8 @@ func ValidateResourceDescriptor(resource *pbc.ResourceDescriptor) error {
 		if len(value) > MaxTagValueLength {
 			return status.Errorf(
 				codes.InvalidArgument,
-				"tag value length %d exceeds maximum %d",
+				"tag value for key %q: length %d exceeds maximum %d",
+				key,
 				len(value),
 				MaxTagValueLength,
 			)
@@ -258,11 +278,14 @@ func ValidateBatchCostRequest(req *pbc.BatchCostRequest, maxBatchSize int32) (*p
 	// Validate each resource descriptor for field length and tag constraints.
 	for i, resource := range req.GetResources() {
 		if err := ValidateResourceDescriptor(resource); err != nil {
+			// ValidateResourceDescriptor always returns gRPC status errors,
+			// so status.FromError is guaranteed to succeed here.
+			s, _ := status.FromError(err)
 			return nil, status.Errorf(
 				codes.InvalidArgument,
-				"resource at index %d: %v",
+				"resource at index %d: %s",
 				i,
-				err,
+				s.Message(),
 			)
 		}
 	}

--- a/sdk/go/pluginsdk/batch_test.go
+++ b/sdk/go/pluginsdk/batch_test.go
@@ -118,6 +118,30 @@ func BenchmarkIsValidCostQueryType_ZeroAllocs(b *testing.B) {
 	}
 }
 
+func BenchmarkValidateResourceDescriptor_ZeroAllocs(b *testing.B) {
+	resource := &pbc.ResourceDescriptor{
+		Provider:     "aws",
+		ResourceType: "ec2",
+		Id:           "i-1234567890abcdef0",
+		Arn:          "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0",
+		Sku:          "t3.micro",
+		Region:       "us-east-1",
+		Tags: map[string]string{
+			"env":     "production",
+			"team":    "platform",
+			"service": "api",
+		},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := ValidateResourceDescriptor(resource); err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
 func TestServerBatchCostEnforcesDefaultMaxBatchSize(t *testing.T) {
 	plugin := &batchServerTestPlugin{}
 	server := NewServer(plugin)
@@ -408,9 +432,10 @@ func TestValidateResourceDescriptor(t *testing.T) {
 		errorText   string
 	}{
 		{
-			name:        "nil resource is valid",
+			name:        "nil resource is rejected",
 			resource:    nil,
-			expectError: false,
+			expectError: true,
+			errorText:   "resource descriptor must not be nil",
 		},
 		{
 			name: "valid resource with all fields",
@@ -503,7 +528,7 @@ func TestValidateResourceDescriptor(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorText:   "tag key length",
+			errorText:   "tag key",
 		},
 		{
 			name: "tag value exceeds max length",
@@ -511,11 +536,11 @@ func TestValidateResourceDescriptor(t *testing.T) {
 				Provider:     "aws",
 				ResourceType: "ec2",
 				Tags: map[string]string{
-					"key": strings.Repeat("v", MaxTagValueLength+1),
+					"mykey": strings.Repeat("v", MaxTagValueLength+1),
 				},
 			},
 			expectError: true,
-			errorText:   "tag value length",
+			errorText:   `tag value for key "mykey": length`,
 		},
 		{
 			name: "max valid provider length",
@@ -539,6 +564,64 @@ func TestValidateResourceDescriptor(t *testing.T) {
 				Provider:     "aws",
 				ResourceType: "ec2",
 				Tags:         generateTags(MaxTagsPerResource),
+			},
+			expectError: false,
+		},
+		{
+			name: "max valid id length",
+			resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Id:           strings.Repeat("a", MaxIDLength),
+			},
+			expectError: false,
+		},
+		{
+			name: "max valid arn length",
+			resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Arn:          strings.Repeat("a", MaxARNLength),
+			},
+			expectError: false,
+		},
+		{
+			name: "max valid sku length",
+			resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Sku:          strings.Repeat("a", MaxSKULength),
+			},
+			expectError: false,
+		},
+		{
+			name: "max valid region length",
+			resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Region:       strings.Repeat("a", MaxRegionLength),
+			},
+			expectError: false,
+		},
+		{
+			name: "max valid tag key length",
+			resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Tags: map[string]string{
+					strings.Repeat("k", MaxTagKeyLength): "value",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "max valid tag value length",
+			resource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "ec2",
+				Tags: map[string]string{
+					"mykey": strings.Repeat("v", MaxTagValueLength),
+				},
 			},
 			expectError: false,
 		},
@@ -618,6 +701,12 @@ func TestValidateBatchCostRequestResourceDescriptorValidation(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errorText)
 				assert.Equal(t, codes.InvalidArgument, status.Code(err))
+				// Verify clean error wrapping: the status message (desc) should not
+				// contain a nested "rpc error: code =" from an inner gRPC status.
+				s, ok := status.FromError(err)
+				require.True(t, ok, "expected gRPC status error")
+				assert.NotContains(t, s.Message(), "rpc error: code =",
+					"nested gRPC error should be unwrapped before wrapping")
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
Add validation for ResourceDescriptor fields in ValidateBatchCostRequest to prevent denial-of-service scenarios from oversized inputs.

Changes:
- Add 10 validation constants for field length limits
- Implement ValidateResourceDescriptor function with comprehensive checks
- Update ValidateBatchCostRequest to validate each resource descriptor
- Add 16 test cases covering all validation scenarios

Validation limits:
- Max tags per resource: 256
- Max string lengths: provider (32), resource_type (256), id (1024), arn (2048), sku (128), region (64)
- Max tag key/value lengths: 128/256 characters

Fixes #401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced maximum size limits for resource identifiers, tags, and metadata; batch requests now validate each resource individually and report the first failing item.

* **Tests**
  * Added extensive tests covering boundary cases, error messages, nil handling, and per-resource validation reporting.
  * Added a micro-benchmark to verify validation allocation behaviour.

* **Documentation**
  * Clarified validation behavior and eager validation impact in docs/comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->