### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, pricing-2]


### PR DESCRIPTION
Potential fix for [https://github.com/rshade/finfocus-spec/security/code-scanning/1](https://github.com/rshade/finfocus-spec/security/code-scanning/1)

In general, the fix is to explicitly set `permissions` for the `GITHUB_TOKEN` either at the workflow root (applies to all jobs) or per job, granting only the scopes required. Here, none of the jobs need to write to the repository or to issues/PRs; they only read code and report to external services using their own secrets. Therefore we can safely set `permissions: contents: read` at the workflow root, which will apply to all jobs (`generate-and-test`, `lint`, `buf-lint`, `validate-schema`, `validate-commits`) and limit the token to read‑only access to repository contents.

To implement this with minimal change and without altering existing behavior, add a root‑level `permissions:` block right after the `name: CI` line, before the `on:` block. No additional imports, methods, or definitions are needed; this is purely a YAML configuration change inside `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI workflow permissions to reduce default repository access for automated runs, improving pipeline security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->